### PR TITLE
updateOrder mutation

### DIFF
--- a/includes/class-actions.php
+++ b/includes/class-actions.php
@@ -71,6 +71,7 @@ use WPGraphQL\Extensions\WooCommerce\Mutation\Cart_Apply_Coupon;
 use WPGraphQL\Extensions\WooCommerce\Mutation\Cart_Remove_Coupons;
 use WPGraphQL\Extensions\WooCommerce\Mutation\Cart_Add_Fee;
 use WPGraphQL\Extensions\WooCommerce\Mutation\Order_Create;
+use WPGraphQL\Extensions\WooCommerce\Mutation\Order_Update;
 
 /**
  * Class Actions
@@ -163,5 +164,6 @@ class Actions {
 		Cart_Remove_Coupons::register_mutation();
 		Cart_Add_Fee::register_mutation();
 		Order_Create::register_mutation();
+		Order_Update::register_mutation();
 	}
 }

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -72,7 +72,7 @@ class Order_Mutation {
 				foreach ( $items as $item_data ) {
 					// Create Order item.
 					$item_id = ( ! empty( $item_data['id'] ) && \WC_Order_Factory::get_order_item( $item_data['id'] ) )
-						? $item['id']
+						? $item_data['id']
 						: \wc_add_order_item( $order_id, array( 'order_item_type' => $type ) );
 
 					// Continue if order item creation failed.
@@ -113,7 +113,9 @@ class Order_Mutation {
 
 		// Calculate to subtotal/total for line items.
 		if ( isset( $args['quantity'] ) ) {
-			$product          = wc_get_product( self::get_product_id( $args ) );
+			$product          = ( ! empty( $order_item['product_id'] ) )
+				? wc_get_product( $order_item['product_id'] )
+				: wc_get_product( self::get_product_id( $args ) );
 			$total            = wc_get_price_excluding_tax( $product, array( 'qty' => $args['quantity'] ) );
 			$args['subtotal'] = ! empty( $args['subtotal'] ) ? $args['subtotal'] : $total;
 			$args['total']    = ! empty( $args['total'] ) ? $args['total'] : $total;

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -33,6 +33,7 @@ class Order_Create {
 			)
 		);
 	}
+
 	/**
 	 * Defines the mutation input field configuration
 	 *

--- a/includes/type/input/class-fee-line-input.php
+++ b/includes/type/input/class-fee-line-input.php
@@ -21,20 +21,24 @@ class Fee_Line_Input {
 			array(
 				'description' => __( 'Fee line data.', 'wp-graphql-woocommerce' ),
 				'fields'      => array(
+					'id'        => array(
+						'type'        => 'ID',
+						'description' => __( 'Fee Line ID', 'wp-graphql-woocommerce' ),
+					),
 					'name'      => array(
-						'type'        => array( 'non_null' => 'String' ),
+						'type'        => 'String',
 						'description' => __( 'Fee name.', 'wp-graphql-woocommerce' ),
 					),
 					'taxClass'  => array(
-						'type'        => array( 'non_null' => 'TaxClassEnum' ),
+						'type'        => 'TaxClassEnum',
 						'description' => __( 'Tax class of fee.', 'wp-graphql-woocommerce' ),
 					),
 					'taxStatus' => array(
-						'type'        => array( 'non_null' => 'TaxStatusEnum' ),
+						'type'        => 'TaxStatusEnum',
 						'description' => __( 'Tax status of fee.', 'wp-graphql-woocommerce' ),
 					),
 					'total'     => array(
-						'type'        => array( 'non_null' => 'String' ),
+						'type'        => 'String',
 						'description' => __( 'Line total (after discounts).', 'wp-graphql-woocommerce' ),
 					),
 				),

--- a/includes/type/input/class-line-item-input.php
+++ b/includes/type/input/class-line-item-input.php
@@ -21,12 +21,16 @@ class Line_Item_Input {
 			array(
 				'description' => __( 'Meta data.', 'wp-graphql-woocommerce' ),
 				'fields'      => array(
+					'id'          => array(
+						'type'        => 'ID',
+						'description' => __( 'Line Item ID', 'wp-graphql-woocommerce' ),
+					),
 					'name'        => array(
 						'type'        => 'String',
 						'description' => __( 'Line name', 'wp-graphql-woocommerce' ),
 					),
 					'productId'   => array(
-						'type'        => array( 'non_null' => 'Int' ),
+						'type'        => 'Int',
 						'description' => __( 'Product ID.', 'wp-graphql-woocommerce' ),
 					),
 					'variationId' => array(

--- a/includes/type/input/class-shipping-line-input.php
+++ b/includes/type/input/class-shipping-line-input.php
@@ -21,6 +21,10 @@ class Shipping_Line_Input {
 			array(
 				'description' => __( 'Shipping lines data.', 'wp-graphql-woocommerce' ),
 				'fields'      => array(
+					'id'          => array(
+						'type'        => 'ID',
+						'description' => __( 'Shipping Line ID', 'wp-graphql-woocommerce' ),
+					),
 					'methodTitle' => array(
 						'type'        => array( 'non_null' => 'String' ),
 						'description' => __( 'Shipping method name.', 'wp-graphql-woocommerce' ),

--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -49,10 +49,10 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
         parent::tearDown();
     }
 
-    private function createOrder( $input ) {
-        $mutation = '
-            mutation createOrder( $input: CreateOrderInput! ) {
-                createOrder( input: $input ) {
+    private function orderMutation( $input, $operation_name = 'createOrder', $input_type = 'CreateOrderInput' ) {
+        $mutation = "
+            mutation {$operation_name}( \$input: {$input_type}! ) {
+                {$operation_name}( input: \$input ) {
                     clientMutationId
                     order {
                         id
@@ -195,12 +195,12 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
                     }
                 }
             }
-        ';
+        ";
 
         $actual = graphql(
             array(
                 'query'          => $mutation,
-                'operation_name' => 'createOrder',
+                'operation_name' => $operation_name,
                 'variables'      => array( 'input' => $input  ),
             )
         );
@@ -209,7 +209,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
     }
 
     // tests
-    public function testCreateOrderMutationAndArgs() {
+    public function testCreateOrderMutation() {
         $variable  = $this->variation->create( $this->product->create_variable() );
         $product_ids = array(
             $this->product->create_simple(),
@@ -229,7 +229,6 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
             ),
 			'paymentMethod'      => 'bacs',
             'paymentMethodTitle' => 'Direct Bank Transfer',
-            'isPaid'             => true,
 			'billing'            => array(
                 'firstName' => 'May',
                 'lastName'  => 'Parker',
@@ -301,7 +300,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 * User without necessary capabilities cannot create order an order.
 		 */
 		wp_set_current_user( $this->customer );
-        $actual = $this->createOrder( $input );
+        $actual = $this->orderMutation( $input );
 
         // use --debug flag to view.
         codecept_debug( $actual );
@@ -311,10 +310,10 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
         /**
 		 * Assertion Two
 		 * 
-		 * User without necessary capabilities cannot create order an order.
+		 * Test mutation and input.
 		 */
 		wp_set_current_user( $this->shop_manager );
-        $actual = $this->createOrder( $input );
+        $actual = $this->orderMutation( $input );
 
         // use --debug flag to view.
         codecept_debug( $actual );
@@ -323,7 +322,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
         $this->assertArrayHasKey('createOrder', $actual['data'] );
         $this->assertArrayHasKey('order', $actual['data']['createOrder'] );
         $this->assertArrayHasKey('id', $actual['data']['createOrder']['order'] );
-        $order = new \WC_Order( $actual['data']['createOrder']['order']['orderId'] );
+        $order = \WC_Order_Factory::get_order( $actual['data']['createOrder']['order']['orderId'] );
 
         $expected = array(
             'data' => array(
@@ -453,4 +452,327 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
         $this->assertEqualSets( $expected, $actual );
     }
 
+    public function testUpdateOrderMutation() {
+        // Create products and coupons to be used in order creation.
+        $variable    = $this->variation->create( $this->product->create_variable() );
+        $product_ids = array(
+            $this->product->create_simple(),
+            $this->product->create_simple(),
+            $variable['product'],
+        );
+        $coupon      = new WC_Coupon(
+            $this->coupon->create( array( 'product_ids' => $product_ids ) )
+        );
+
+        // Create initial order input.
+        $initial_input = array(
+            'clientMutationId'   => 'someId',
+			'customerId'         => $this->customer,
+			'customerNote'       => 'Customer test note',
+			'coupons'            => array(
+                $coupon->get_code(),
+            ),
+			'paymentMethod'      => 'bacs',
+            'paymentMethodTitle' => 'Direct Bank Transfer',
+			'billing'            => array(
+                'firstName' => 'May',
+                'lastName'  => 'Parker',
+                'address1'  => '20 Ingram St',
+                'city'      => 'New York City',
+                'state'     => 'NY',
+                'postcode'  => '12345',
+                'country'   => 'US',
+                'email'     => 'superfreak500@gmail.com',
+                'phone'     => '555-555-1234',
+            ),
+			'shipping'           => array(
+                'firstName' => 'May',
+                'lastName'  => 'Parker',
+                'address1'  => '20 Ingram St',
+                'city'      => 'New York City',
+                'state'     => 'NY',
+                'postcode'  => '12345',
+                'country'   => 'US',
+            ),
+			'lineItems'          => array(
+                array(
+                    'productId' => $product_ids[0],
+                    'quantity'  => 5,
+                    'metaData'  => array( 
+                        array( 
+                            'key'   => 'test_product_key',
+                            'value' => 'test product value',
+                        ), 
+                    ),
+                ),
+                array(
+                    'productId' => $product_ids[1],
+                    'quantity'  => 2,
+                ),
+                array(
+                    'productId'   => $product_ids[2],
+                    'quantity'    => 6,
+                    'variationId' => $variable['variations'][0]
+                ),
+            ),
+            'shippingLines'      => array(
+                array(
+                    'methodId'    => 'flat_rate_shipping',
+                    'methodTitle' => 'Flat Rate shipping',
+                    'total'       => '10',
+                ),
+            ),
+			'feeLines'           => array(
+                array(
+                    'name'       => 'Some Fee',
+                    'taxStatus' => 'TAXABLE',
+                    'total'      => '100',
+                    'taxClass'  => 'STANDARD',
+                ),
+            ),
+			'metaData'           => array( 
+                array( 
+                    'key'   => 'test_key',
+                    'value' => 'test value',
+                ), 
+            ),
+			'isPaid'             => false,
+        );
+
+        // Create order to update.
+		wp_set_current_user( $this->shop_manager );
+        $initial_response = $this->orderMutation( $initial_input );
+
+        // use --debug flag to view.
+        codecept_debug( $initial_response );
+
+        // Retrieve order and items
+        $order          = \WC_Order_Factory::get_order( $initial_response['data']['createOrder']['order']['orderId'] );
+        $line_items     = $order->get_items();
+        $shipping_lines = $order->get_items( 'shipping' );
+        $fee_lines      = $order->get_items( 'fee' );
+
+        // Create update order input.
+        $updated_input = array(
+            'id'                 => $this->order->to_relay_id( $order->get_id() ),
+            'clientMutationId'   => 'someId',
+			'customerNote'       => 'Customer test note',
+			'coupons'            => array(
+                $coupon->get_code(),
+            ),
+			'billing'            => array(
+                'firstName' => 'Ben',
+            ),
+			'shipping'           => array(
+                'firstName' => 'Ben',
+            ),
+			'lineItems'          => array(
+                array(
+
+                    'id'       => array_keys( $line_items )[0],
+                    'quantity' => 6,
+                    'metaData' => array( 
+                        array( 
+                            'key'   => 'test_product_key',
+                            'value' => 'updated test product value',
+                        ), 
+                    ),
+                ),
+                array(
+                    'id'       => array_keys( $line_items )[1],
+                    'quantity' => 1,
+                ),
+                array(
+                    'id'       => array_keys( $line_items )[2],
+                    'quantity' => 10,
+                ),
+            ),
+            'shippingLines'      => array(
+                array(
+                    'id'          => array_keys( $shipping_lines )[0],
+                    'methodId'    => 'reduced_rate_shipping',
+                    'methodTitle' => 'reduced Rate shipping',
+                    'total'       => '7',
+                ),
+            ),
+			'feeLines'           => array(
+                array(
+                    'id'        => array_keys( $fee_lines )[0],
+                    'name'      => 'Some Updated Fee',
+                    'taxStatus' => 'TAXABLE',
+                    'total'     => '125',
+                    'taxClass'  => 'STANDARD',
+                ),
+            ),
+			'metaData'           => array( 
+                array( 
+                    'key'   => 'test_key',
+                    'value' => 'new test value',
+                ), 
+            ),
+			'isPaid'             => true,
+        );
+
+        /**
+		 * Assertion One
+		 * 
+		 * User without necessary capabilities cannot update order an order.
+		 */
+        wp_set_current_user( $this->customer );
+        $actual = $this->orderMutation(
+            $updated_input,
+            'updateOrder',
+            'UpdateOrderInput'
+        );
+
+        // use --debug flag to view.
+        codecept_debug( $actual );
+
+        $this->assertArrayHasKey('errors', $actual );
+
+        /**
+		 * Assertion Two
+		 * 
+		 * Test mutation and input.
+		 */
+		wp_set_current_user( $this->shop_manager );
+        $actual = $this->orderMutation(
+            $updated_input,
+            'updateOrder',
+            'UpdateOrderInput'
+        );
+
+        // use --debug flag to view.
+        codecept_debug( $actual );
+
+        // Apply new changes to order instances.
+        $order = \WC_Order_Factory::get_order( $order->get_id() );
+
+        $expected = array(
+            'data' => array(
+                'updateOrder' => array(
+                    'clientMutationId' => 'someId',
+                    'order'            => array_merge(
+                        $this->order->print_query( $order->get_id() ),
+                        array(
+                            'couponLines'   => array(
+                                'nodes' => array_reverse(
+                                    array_map(
+                                        function( $item ) {
+                                            return array(
+                                                'itemId'      => $item->get_id(),
+                                                'orderId'     => $item->get_order_id(),
+                                                'code'        => $item->get_code(),
+                                                'discount'    => ! empty( $item->get_discount() ) ? $item->get_discount() : null,
+                                                'discountTax' => ! empty( $item->get_discount_tax() ) ? $item->get_discount_tax() : null,
+                                                'coupon'      => array(
+                                                    'id' => $this->coupon->to_relay_id( \wc_get_coupon_id_by_code( $item->get_code() ) ),
+                                                ),
+                                            );
+                                        },
+                                        $order->get_items( 'coupon' )
+                                    ) 
+                                ),
+                            ),
+                            'feeLines'      => array(
+                                'nodes' => array_reverse(
+                                    array_map(
+                                        function( $item ) {
+                                            return array(
+                                                'itemId'    => $item->get_id(),
+                                                'orderId'   => $item->get_order_id(),
+                                                'amount'    => ! empty( $item->get_amount() ) ? $item->get_amount() : null,
+                                                'name'      => $item->get_name(),
+                                                'taxStatus' => strtoupper( $item->get_tax_status() ),
+                                                'total'     => $item->get_total(),
+                                                'totalTax'  => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
+                                                'taxClass'  => ! empty( $item->get_tax_class() ) 
+                                                    ? WPEnumType::get_safe_name( $item->get_tax_class() )
+                                                    : 'STANDARD',
+                                            );
+                                        },
+                                        $order->get_items( 'fee' )
+                                    )
+                                ),
+                            ),
+                            'shippingLines' => array(
+                                'nodes' => array_reverse(
+                                    array_map(
+                                        function( $item ) {
+        
+                                            return array(
+                                                'itemId'         => $item->get_id(),
+                                                'orderId'        => $item->get_order_id(),
+                                                'methodTitle'    => $item->get_method_title(),
+                                                'total'          => $item->get_total(),
+                                                'totalTax'       => !empty( $item->get_total_tax() )
+                                                    ? $item->get_total_tax()
+                                                    : null,
+                                                'taxClass'       => ! empty( $item->get_tax_class() )
+                                                    ? $item->get_tax_class() === 'inherit'
+                                                        ? WPEnumType::get_safe_name( 'inherit cart' )
+                                                        : WPEnumType::get_safe_name( $item->get_tax_class() )
+                                                    : 'STANDARD'
+                                            );
+                                        },
+                                        $order->get_items( 'shipping' )
+                                    )
+                                ),
+                            ),
+                            'taxLines'      => array(
+                                'nodes' => array_reverse(
+                                    array_map(
+                                        function( $item ) {
+                                            return array(
+                                                'rateCode'         => $item->get_rate_code(),
+                                                'label'            => $item->get_label(),
+                                                'taxTotal'         => $item->get_tax_total(),
+                                                'shippingTaxTotal' => $item->get_shipping_tax_total(),
+                                                'isCompound'       => $item->is_compound(),
+                                                'taxRate'          => array( 'rateId' => $item->get_rate_id() ),
+                                            );
+                                        },
+                                        $order->get_items( 'tax' )
+                                    )
+                                ),
+                            ),
+                            'lineItems'     => array(
+                                'nodes' => array_values(
+                                    array_map(
+                                        function( $item ) {
+                                            return array(
+                                                'productId'     => $item->get_product_id(),
+                                                'variationId'   => ! empty( $item->get_variation_id() )
+                                                    ? $item->get_variation_id()
+                                                    : null,
+                                                'quantity'      => $item->get_quantity(),
+                                                'taxClass'      => ! empty( $item->get_tax_class() )
+                                                    ? strtoupper( $item->get_tax_class() )
+                                                    : 'STANDARD',
+                                                'subtotal'      => ! empty( $item->get_subtotal() ) ? $item->get_subtotal() : null,
+                                                'subtotalTax'   => ! empty( $item->get_subtotal_tax() ) ? $item->get_subtotal_tax() : null,
+                                                'total'         => ! empty( $item->get_total() ) ? $item->get_total() : null,
+                                                'totalTax'      => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
+                                                'itemDownloads' => null,
+                                                'taxStatus'     => strtoupper( $item->get_tax_status() ),
+                                                'product'       => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
+                                                'variation'     => ! empty( $item->get_variation_id() )
+                                                    ? array(
+                                                        'id' => $this->variation->to_relay_id( $item->get_variation_id() )
+                                                    )
+                                                    : null,
+                                            );
+                                        },
+                                        $order->get_items()
+                                    )
+                                ),
+                            ),
+                        )
+                    )
+                ),
+            )
+        );
+
+        $this->assertEqualSets( $expected, $actual );
+    }
 }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -64,6 +64,7 @@ return array(
     'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Register' => $baseDir . '/includes/mutation/class-customer-register.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Update' => $baseDir . '/includes/mutation/class-customer-update.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Create' => $baseDir . '/includes/mutation/class-order-create.php',
+    'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Update' => $baseDir . '/includes/mutation/class-order-update.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Backorders' => $baseDir . '/includes/type/enum/class-backorders.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Catalog_Visibility' => $baseDir . '/includes/type/enum/class-catalog-visibility.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Countries' => $baseDir . '/includes/type/enum/class-countries.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -79,6 +79,7 @@ class ComposerStaticInitee0d17af17b841ed3a93c4a0e5cc5e5f
         'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Register' => __DIR__ . '/../..' . '/includes/mutation/class-customer-register.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Update' => __DIR__ . '/../..' . '/includes/mutation/class-customer-update.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Create' => __DIR__ . '/../..' . '/includes/mutation/class-order-create.php',
+        'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Update' => __DIR__ . '/../..' . '/includes/mutation/class-order-update.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Backorders' => __DIR__ . '/../..' . '/includes/type/enum/class-backorders.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Catalog_Visibility' => __DIR__ . '/../..' . '/includes/type/enum/class-catalog-visibility.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Countries' => __DIR__ . '/../..' . '/includes/type/enum/class-countries.php',


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Implements `updateOrder` mutation, `shop_coupon` post-type `edit-post` cap required for use.

#### updateOrder definition
```
mutation updateOrder( $input: UpdateOrderInput! ) {
    updateOrder( input: $input ) {
        clientMutationId
        order {
            OrderType fields
        }
    }
}
```

#### UpdateOrderInput definition
`...`[`CreateOrderInput`](https://github.com/wp-graphql/wp-graphql-woocommerce/pull/97)` fields,`
```
'id'           => array(
	'type'        => 'ID',
	'description' => __( 'Order global ID.', 'wp-graphql-woocommerce' ),
),
'orderId'           => array(
	'type'        => 'Integer',
	'description' => __( 'order ID.', 'wp-graphql-woocommerce' ),
),
'customerId'           => array(
	'type'        => 'Integer',
	'description' => __( 'customer ID.', 'wp-graphql-woocommerce' ),
),
```

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.2