### PR TITLE
deleteOrder mutation

### DIFF
--- a/includes/class-actions.php
+++ b/includes/class-actions.php
@@ -72,6 +72,7 @@ use WPGraphQL\Extensions\WooCommerce\Mutation\Cart_Remove_Coupons;
 use WPGraphQL\Extensions\WooCommerce\Mutation\Cart_Add_Fee;
 use WPGraphQL\Extensions\WooCommerce\Mutation\Order_Create;
 use WPGraphQL\Extensions\WooCommerce\Mutation\Order_Update;
+use WPGraphQL\Extensions\WooCommerce\Mutation\Order_Delete;
 
 /**
  * Class Actions
@@ -165,5 +166,6 @@ class Actions {
 		Cart_Add_Fee::register_mutation();
 		Order_Create::register_mutation();
 		Order_Update::register_mutation();
+		Order_Delete::register_mutation();
 	}
 }

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -15,6 +15,25 @@ use GraphQL\Error\UserError;
  */
 class Order_Mutation {
 	/**
+	 * Filterable authentication function.
+	 *
+	 * @param string $mutation  Mutation being executed.
+	 *
+	 * @return boolean
+	 */
+	public static function authorized( $mutation = 'create', $input, $context, $info ) {
+		$post_type_object = get_post_type_object( 'shop_order' );
+
+		return apply_filters(
+			"authorized_to_{$mutation}_orders",
+			! current_user_can( $post_type_object->cap->create_posts ),
+			$input,
+			$context,
+			$info
+		);
+	}
+
+	/**
 	 * Create an order.
 	 *
 	 * @param array       $input    Input data describing order.

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -337,12 +337,15 @@ class Order_Mutation {
 	/**
 	 * Purge object when creating.
 	 *
-	 * @param WC_Order $order  Object data.
+	 * @param WC_Order|Order $order    Object data.
+	 * @param AppContext     $context  AppContext instance.
+	 * @param ResolveInfo    $info     ResolveInfo instance.
 	 *
 	 * @return bool
+	 * @throws UserError  Failed to delete order.
 	 */
-	public static function purge( $order ) {
-		if ( $order instanceof WC_Order ) {
+	public static function purge( $order, $context, $info ) {
+		if ( is_callable( array( $order, 'delete' ) ) ) {
 			return $order->delete( true );
 		}
 

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -337,16 +337,15 @@ class Order_Mutation {
 	/**
 	 * Purge object when creating.
 	 *
-	 * @param WC_Order|Order $order    Object data.
-	 * @param AppContext     $context  AppContext instance.
-	 * @param ResolveInfo    $info     ResolveInfo instance.
+	 * @param WC_Order|Order $order         Object data.
+	 * @param boolean        $force_delete  Delete or put in trash.
 	 *
 	 * @return bool
 	 * @throws UserError  Failed to delete order.
 	 */
-	public static function purge( $order, $context, $info ) {
+	public static function purge( $order, $force_delete = true ) {
 		if ( is_callable( array( $order, 'delete' ) ) ) {
-			return $order->delete( true );
+			return $order->delete( $force_delete );
 		}
 
 		return false;

--- a/includes/model/class-crud-cpt.php
+++ b/includes/model/class-crud-cpt.php
@@ -10,6 +10,7 @@
 
 namespace WPGraphQL\Extensions\WooCommerce\Model;
 
+use GraphQL\Error\UserError;
 use WPGraphQL\Model\Model;
 
 /**
@@ -86,6 +87,27 @@ abstract class Crud_CPT extends Model {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Wrapper function for deleting
+	 *
+	 * @param boolean $force_delete  Should the data be deleted permanently.
+	 *
+	 * @return boolean
+	 * @throws UserError  Not authorized.
+	 */
+	public function delete( $force_delete = false ) {
+		if ( ! current_user_can( $this->post_type_object->cap->edit_posts ) ) {
+			throw new UserError(
+				__(
+					'User does not have the capabilities necessary to delete this object.',
+					'wp-graphql-woocommerce'
+				)
+			);
+		}
+
+		return $this->data->delete( $force_delete );
 	}
 
 	/**

--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -224,7 +224,7 @@ class Order extends Crud_CPT {
 					return ! is_null( $this->data->needs_processing() ) ? $this->data->needs_processing() : null;
 				},
 				'downloadableItems'     => function() {
-					return ! is_null( $this->data->get_downloadable_items() ) ? $this->data->get_downloadable_items() : null;
+					return ! empty( $this->data->get_downloadable_items() ) ? $this->data->get_downloadable_items() : null;
 				},
 				/**
 				 * Connection resolvers fields

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -179,6 +179,16 @@ class Order_Create {
 					);
 				}
 
+				/**
+				 * Action called after order is created.
+				 *
+				 * @param WC_Order    $order   WC_Order instance.
+				 * @param array       $input   Input data describing order.
+				 * @param AppContext  $context Request AppContext instance.
+				 * @param ResolveInfo $info    Request ResolveInfo instance.
+				 */
+				do_action( 'woocommerce_graphql_after_order_create', $order, $input, $context, $info );
+
 				return array( 'id' => $order->get_id() );
 			} catch ( \Exception $e ) {
 				Order_Mutation::purge( $order );

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -133,9 +133,7 @@ class Order_Create {
 	 */
 	public static function mutate_and_get_payload() {
 		return function( $input, AppContext $context, ResolveInfo $info ) {
-			$post_type_object = get_post_type_object( 'shop_order' );
-
-			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
+			if ( Order_Mutation::authorized( 'create', $input, $context, $info ) ) {
 				throw new UserError( __( 'User does not have the capabilities necessary to create an order.', 'wp-graphql-woocommerce' ) );
 			}
 

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -136,7 +136,7 @@ class Order_Create {
 			$post_type_object = get_post_type_object( 'shop_order' );
 
 			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create a new order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to create an order.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Create order.

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -43,11 +43,11 @@ class Order_Delete {
 	public static function get_input_fields() {
 		$input_fields = array_merge(
 			array(
-				'id'    => array(
+				'id'      => array(
 					'type'        => 'ID',
 					'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
 				),
-				'order' => array(
+				'orderId' => array(
 					'type'        => 'Int',
 					'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
 				),
@@ -83,7 +83,7 @@ class Order_Delete {
 			$post_type_object = get_post_type_object( 'shop_order' );
 
 			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to update this order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to delete an order.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Retrieve order ID.

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -43,13 +43,17 @@ class Order_Delete {
 	public static function get_input_fields() {
 		$input_fields = array_merge(
 			array(
-				'id'      => array(
+				'id'          => array(
 					'type'        => 'ID',
 					'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
 				),
-				'orderId' => array(
+				'orderId'     => array(
 					'type'        => 'Int',
 					'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
+				),
+				'forceDelete' => array(
+					'type'        => 'Boolean',
+					'description' => __( 'Delete or simply place in trash.', 'wp-graphql-woocommerce' ),
 				),
 			)
 		);
@@ -100,6 +104,11 @@ class Order_Delete {
 				throw new UserError( __( 'No order ID provided.', 'wp-graphql-woocommerce' ) );
 			}
 
+			$force_delete = false;
+			if ( ! empty( $input['forceDelete'] ) ) {
+				$force_delete = $input['forceDelete'];
+			}
+
 			// Get Order model instance for output.
 			$order = new Order( $order_id );
 
@@ -124,11 +133,7 @@ class Order_Delete {
 			do_action( 'woocommerce_graphql_before_order_delete', $order, $context, $info );
 
 			// Delete order.
-			$success = Order_Mutation::purge(
-				\WC_Order_Factory::get_order( $order->ID ),
-				$context,
-				$info
-			);
+			$success = Order_Mutation::purge( \WC_Order_Factory::get_order( $order->ID ), $force_delete );
 
 			if ( ! $success ) {
 				throw new UserError(

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -124,11 +124,11 @@ class Order_Delete {
 			 * Action called before order is deleted.
 			 *
 			 * @param WC_Order    $order   WC_Order instance.
-			 * @param array       $props   Order props array.
+			 * @param array       $input   Input data describing order.
 			 * @param AppContext  $context Request AppContext instance.
 			 * @param ResolveInfo $info    Request ResolveInfo instance.
 			 */
-			do_action( 'woocommerce_graphql_before_order_delete', $order, $context, $info );
+			do_action( 'woocommerce_graphql_before_order_delete', $order, $input, $context, $info );
 
 			// Delete order.
 			$success = Order_Mutation::purge( \WC_Order_Factory::get_order( $order->ID ), $force_delete );
@@ -142,6 +142,16 @@ class Order_Delete {
 					)
 				);
 			}
+
+			/**
+			 * Action called before order is deleted.
+			 *
+			 * @param WC_Order    $order   WC_Order instance.
+			 * @param array       $input   Input data describing order
+			 * @param AppContext  $context Request AppContext instance.
+			 * @param ResolveInfo $info    Request ResolveInfo instance.
+			 */
+			do_action( 'woocommerce_graphql_after_order_delete', $order, $input, $context, $info );
 
 			return array( 'order' => $order );
 		};

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Mutation - updateOrder
+ * Mutation - deleteOrder
  *
- * Registers mutation for updating an existing order.
+ * Registers mutation for delete an order.
  *
  * @package WPGraphQL\Extensions\WooCommerce\Mutation
  * @since 0.2.0
@@ -18,15 +18,15 @@ use WPGraphQL\Extensions\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\Extensions\WooCommerce\Model\Order;
 
 /**
- * Class Order_Update
+ * Class Order_Delete
  */
-class Order_Update {
+class Order_Delete {
 	/**
 	 * Registers mutation
 	 */
 	public static function register_mutation() {
 		register_graphql_mutation(
-			'updateOrder',
+			'deleteOrder',
 			array(
 				'inputFields'         => self::get_input_fields(),
 				'outputFields'        => self::get_output_fields(),
@@ -42,19 +42,14 @@ class Order_Update {
 	 */
 	public static function get_input_fields() {
 		$input_fields = array_merge(
-			Order_Create::get_input_fields(),
 			array(
-				'id'         => array(
+				'id'    => array(
 					'type'        => 'ID',
 					'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
 				),
-				'order'      => array(
+				'order' => array(
 					'type'        => 'Int',
 					'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
-				),
-				'customerId' => array(
-					'type'        => 'Int',
-					'description' => __( 'Order customer ID', 'wp-graphql-woocommerce' ),
 				),
 			)
 		);
@@ -72,7 +67,7 @@ class Order_Update {
 			'order' => array(
 				'type'    => 'Order',
 				'resolve' => function( $payload ) {
-					return new Order( $payload['id'] );
+					return $payload['order'];
 				},
 			),
 		);
@@ -88,7 +83,7 @@ class Order_Update {
 			$post_type_object = get_post_type_object( 'shop_order' );
 
 			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to update an order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you are not allowed to update this order.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Retrieve order ID.
@@ -105,45 +100,47 @@ class Order_Update {
 				throw new UserError( __( 'No order ID provided.', 'wp-graphql-woocommerce' ) );
 			}
 
-			Order_Mutation::add_order_meta( $order_id, $input, $context, $info );
-			Order_Mutation::add_items( $input, $order_id, $context, $info );
+			// Get Order model instance for output.
+			$order = new Order( $order_id );
 
-			// Apply coupons.
-			if ( ! empty( $input['coupons'] ) ) {
-				Order_Mutation::apply_coupons( $order_id, $input['coupons'] );
-			}
+			// Cache items to prevent null value errors.
+			// @codingStandardsIgnoreStart
+			$order->downloadableItems;
+			$order->get_items();
+			$order->get_items( 'fee' );
+			$order->get_items( 'shipping' );
+			$order->get_items( 'tax' );
+			$order->get_items( 'coupon' );
+			// @codingStandardsIgnoreEnd.
 
-			$order = \WC_Order_Factory::get_order( $order_id );
+			/**
+			 * Action called before order is deleted.
+			 *
+			 * @param WC_Order    $order   WC_Order instance.
+			 * @param array       $props   Order props array.
+			 * @param AppContext  $context Request AppContext instance.
+			 * @param ResolveInfo $info    Request ResolveInfo instance.
+			 */
+			do_action( 'woocommerce_graphql_before_order_delete', $order, $context, $info );
 
-			// Make sure gateways are loaded so hooks from gateways fire on save/create.
-			WC()->payment_gateways();
+			// Delete order.
+			$success = Order_Mutation::purge(
+				\WC_Order_Factory::get_order( $order->ID ),
+				$context,
+				$info
+			);
 
-			// Validate customer ID.
-			if ( ! empty( $input['customerId'] ) ) {
-				if ( ! Order_Mutation::validate_customer( $input ) ) {
-					throw new UserError( __( 'New customer ID is invalid.', 'wp-graphql-woocommerce' ) );
-				}
-			}
-
-			$order->set_created_via( 'graphql-api' );
-			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
-			$order->calculate_totals( true );
-
-			// Set status.
-			if ( ! empty( $input['status'] ) ) {
-				$order->set_status( $input['status'] );
-			}
-
-			// Actions for after the order is saved.
-			if ( true === $input['isPaid'] ) {
-				$order->payment_complete(
-					! empty( $input['transactionId'] ) ?
-						$input['transactionId']
-						: ''
+			if ( ! $success ) {
+				throw new UserError(
+					sprintf(
+						/* translators: Deletion failed message */
+						__( 'Removal of Order %d failed', 'wp-graphql-woocommerce' ),
+						$order->get_id()
+					)
 				);
 			}
 
-			return array( 'id' => $order->get_id() );
+			return array( 'order' => $order );
 		};
 	}
 }

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -84,9 +84,7 @@ class Order_Delete {
 	 */
 	public static function mutate_and_get_payload() {
 		return function( $input, AppContext $context, ResolveInfo $info ) {
-			$post_type_object = get_post_type_object( 'shop_order' );
-
-			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
+			if ( Order_Mutation::authorized( 'delete', $input, $context, $info ) ) {
 				throw new UserError( __( 'User does not have the capabilities necessary to delete an order.', 'wp-graphql-woocommerce' ) );
 			}
 

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -103,6 +103,16 @@ class Order_Update {
 				throw new UserError( __( 'No order ID provided.', 'wp-graphql-woocommerce' ) );
 			}
 
+			/**
+			 * Action called before order is updated.
+			 *
+			 * @param int         $order_id  Order ID.
+			 * @param array       $input     Input data describing order
+			 * @param AppContext  $context   Request AppContext instance.
+			 * @param ResolveInfo $info      Request ResolveInfo instance.
+			 */
+			do_action( 'woocommerce_graphql_before_order_update', $order_id, $input, $context, $info );
+
 			Order_Mutation::add_order_meta( $order_id, $input, $context, $info );
 			Order_Mutation::add_items( $input, $order_id, $context, $info );
 
@@ -140,6 +150,16 @@ class Order_Update {
 						: ''
 				);
 			}
+
+			/**
+			 * Action called after order is updated.
+			 *
+			 * @param WC_Order    $order   WC_Order instance.
+			 * @param array       $input   Input data describing order
+			 * @param AppContext  $context Request AppContext instance.
+			 * @param ResolveInfo $info    Request ResolveInfo instance.
+			 */
+			do_action( 'woocommerce_graphql_after_order_update', $order, $input, $context, $info );
 
 			return array( 'id' => $order->get_id() );
 		};

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -85,9 +85,7 @@ class Order_Update {
 	 */
 	public static function mutate_and_get_payload() {
 		return function( $input, AppContext $context, ResolveInfo $info ) {
-			$post_type_object = get_post_type_object( 'shop_order' );
-
-			if ( ! current_user_can( $post_type_object->cap->create_posts ) ) {
+			if ( Order_Mutation::authorized( 'update', $input, $context, $info ) ) {
 				throw new UserError( __( 'User does not have the capabilities necessary to update an order.', 'wp-graphql-woocommerce' ) );
 			}
 

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -48,7 +48,7 @@ class Order_Update {
 					'type'        => 'ID',
 					'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
 				),
-				'order'      => array(
+				'orderId'    => array(
 					'type'        => 'Int',
 					'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
 				),

--- a/tests/_support/Helper/crud-helpers/order.php
+++ b/tests/_support/Helper/crud-helpers/order.php
@@ -295,12 +295,14 @@ class OrderHelper extends WCG_Helper {
 			'isDownloadPermitted'   => $data->is_download_permitted(),
 			'needsShippingAddress'  => $data->needs_shipping_address(),
 			'hasDownloadableItem'   => $data->has_downloadable_item(),
-			'downloadableItems'     => array_map(
-				function( $download ) {
-					return array( 'downloadId' => $download->get_id() );
-				},
-				$data->get_downloadable_items()
-			),
+			'downloadableItems'     => ! empty( $data->get_downloadable_items() )
+				? array_map(
+					function( $download ) {
+						return array( 'downloadId' => $download->get_id() );
+					},
+					$data->get_downloadable_items()
+				)
+				: null,
 			'needsPayment'          => $data->needs_payment(),
 			'needsProcessing'       => $data->needs_processing(),
 		);

--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -882,6 +882,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
         $deleted_input = array(
             'clientMutationId' => 'someId',
             'id'               => $this->order->to_relay_id( $order->get_id() ),
+            'forceDelete'      => true,
         );
 
         /**

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -64,6 +64,7 @@ return array(
     'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Register' => $baseDir . '/includes/mutation/class-customer-register.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Update' => $baseDir . '/includes/mutation/class-customer-update.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Create' => $baseDir . '/includes/mutation/class-order-create.php',
+    'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Delete' => $baseDir . '/includes/mutation/class-order-delete.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Update' => $baseDir . '/includes/mutation/class-order-update.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Backorders' => $baseDir . '/includes/type/enum/class-backorders.php',
     'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Catalog_Visibility' => $baseDir . '/includes/type/enum/class-catalog-visibility.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -79,6 +79,7 @@ class ComposerStaticInitee0d17af17b841ed3a93c4a0e5cc5e5f
         'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Register' => __DIR__ . '/../..' . '/includes/mutation/class-customer-register.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Customer_Update' => __DIR__ . '/../..' . '/includes/mutation/class-customer-update.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Create' => __DIR__ . '/../..' . '/includes/mutation/class-order-create.php',
+        'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Delete' => __DIR__ . '/../..' . '/includes/mutation/class-order-delete.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Mutation\\Order_Update' => __DIR__ . '/../..' . '/includes/mutation/class-order-update.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Backorders' => __DIR__ . '/../..' . '/includes/type/enum/class-backorders.php',
         'WPGraphQL\\Extensions\\WooCommerce\\Type\\WPEnum\\Catalog_Visibility' => __DIR__ . '/../..' . '/includes/type/enum/class-catalog-visibility.php',


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Implements `deleteOrder` mutation. User cap requirements are the same and `createOrder` and `updateOrder`.

#### deleteOrder definition
```
mutation deleteOrder( $input: DeleteOrderInput! ) {
    DeleteOrder( input: $input ) {
        clientMutationId
        order {
            ...OrderType fields
        }
    }
}
```

#### DeleteOrderInput definition
```
'id'      => array(
	'type'        => 'ID',
	'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
),
'orderId' => array(
	'type'        => 'Int',
	'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
),
```


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …