### PR TITLE
Adds NO_QL_SESSION_HANDLER flag

### DIFF
--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -67,11 +67,13 @@ class Filters {
 		);
 
 		// Setup QL session handler.
-		self::$session_header = apply_filters( 'woocommerce_session_header_name', 'woocommerce-session' );
-		add_filter( 'woocommerce_cookie', array( __CLASS__, 'woocommerce_cookie' ) );
-		add_filter( 'woocommerce_session_handler', array( __CLASS__, 'init_ql_session_handler' ) );
-		add_filter( 'graphql_response_headers_to_send', array( __CLASS__, 'add_session_header_to_expose_headers' ) );
-		add_filter( 'graphql_access_control_allow_headers', array( __CLASS__, 'add_session_header_to_allow_headers' ) );
+		if ( ! defined( 'NO_QL_SESSION_HANDLER' ) ) {
+			self::$session_header = apply_filters( 'woocommerce_session_header_name', 'woocommerce-session' );
+			add_filter( 'woocommerce_cookie', array( __CLASS__, 'woocommerce_cookie' ) );
+			add_filter( 'woocommerce_session_handler', array( __CLASS__, 'init_ql_session_handler' ) );
+			add_filter( 'graphql_response_headers_to_send', array( __CLASS__, 'add_session_header_to_expose_headers' ) );
+			add_filter( 'graphql_access_control_allow_headers', array( __CLASS__, 'add_session_header_to_allow_headers' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
When `define( 'NO_QL_SESSION_HANDLER', true);` is set. WooCommerce falls back to the default session handler for GraphQL requests. This is meant to allow for use of cookie sessions managed by `WC_Session_Handler` instead of the custom session header managed by the `QL_Session_Handler` class (the default) on GraphQL requests.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.2