### PR TITLE
pass WP_User object instead of WPGraphQL\Model\User to viewer field, …

### DIFF
--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -77,8 +77,7 @@ class Customer_Register {
 			'viewer'   => array(
 				'type'    => 'User',
 				'resolve' => function ( $payload ) {
-					$user = get_user_by( 'ID', $payload['id'] );
-					return new User( $user );
+					return get_user_by( 'ID', $payload['id'] );
 				},
 			),
 		);


### PR DESCRIPTION
…fixes #111

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Changes the object passed to the viewer field of the `registerCustomer` mutation from `WPGraphQL\Model\User` to `WP_User`.

Does this close any currently open issues?
------------------------------------------
Fixes issue  #111.
