### PR TITLE
"format" arg added to Product description fields

### DIFF
--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -167,11 +167,32 @@ class Product extends Crud_CPT {
 					return ! empty( $this->data->get_catalog_visibility() ) ? $this->data->get_catalog_visibility() : null;
 				},
 				'description'          => function() {
-					return ! empty( $this->data->get_description() ) ? $this->data->get_description() : null;
+					return ! empty( $this->data->get_description() )
+						? apply_filters( 'the_content', $this->data->get_description() )
+						: null;
 				},
+				'descriptionRaw'       => array(
+					'callback'   => function() {
+						return ! empty( $this->data->get_description() ) ? $this->data->get_description() : null;
+					},
+					'capability' => $this->post_type_object->cap->edit_posts,
+				),
 				'shortDescription'     => function() {
-					return ! empty( $this->data->get_short_description() ) ? $this->data->get_short_description() : null;
+					$short_description = ! empty( $this->data->get_short_description() )
+						? apply_filters(
+							'get_the_excerpt',
+							$this->data->get_short_description(),
+							get_post( $this->data->get_id() )
+						)
+						: null;
+					return apply_filters( 'the_excerpt', $short_description );
 				},
+				'shortDescriptionRaw'  => array(
+					'callback'   => function() {
+						return ! empty( $this->data->get_short_description() ) ? $this->data->get_short_description() : null;
+					},
+					'capability' => $this->post_type_object->cap->edit_posts,
+				),
 				'sku'                  => function() {
 					return ! empty( $this->data->get_sku() ) ? $this->data->get_sku() : null;
 				},

--- a/includes/type/object/class-product-type.php
+++ b/includes/type/object/class-product-type.php
@@ -76,10 +76,37 @@ class Product_Type {
 					'description'          => array(
 						'type'        => 'String',
 						'description' => __( 'Product description', 'wp-graphql-woocommerce' ),
+						'args'        => array(
+							'format' => array(
+								'type'        => 'PostObjectFieldFormatEnum',
+								'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
+							),
+						),
+						'resolve'     => function( $source, $args ) {
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								// @codingStandardsIgnoreLine.
+								return $source->descriptionRaw;
+							}
+							return $source->description;
+						},
 					),
 					'shortDescription'     => array(
 						'type'        => 'String',
 						'description' => __( 'Product short description', 'wp-graphql-woocommerce' ),
+						'args'        => array(
+							'format' => array(
+								'type'        => 'PostObjectFieldFormatEnum',
+								'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
+							),
+						),
+						'resolve'     => function( $source, $args ) {
+							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+								// @codingStandardsIgnoreLine.
+								return $source->shortDescriptionRaw;
+							}
+							// @codingStandardsIgnoreLine.
+							return $source->shortDescription;
+						},
 					),
 					'sku'                  => array(
 						'type'        => 'String',

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -32,6 +32,8 @@ class Wpunit extends \Codeception\Module {
 		$helper->create_attribute( 'size', array( 'small', 'medium', 'large' ) );
 		$helper->create_attribute( 'color', array( 'red', 'blue', 'green' ) );
 		codecept_debug( 'ATTRIBUTES_LOADED' );
+		add_action( 'init_graphql_request', array( __CLASS__, 'shortcode_test_init' ) );
+		codecept_debug( 'SHORTCODE_INITIALIZED' );
 	}
 
 	public function cart() {
@@ -86,5 +88,14 @@ class Wpunit extends \Codeception\Module {
 	public function clear_loader_cache( $loader_name ) {
 		$loader = \WPGraphQL::get_app_context()->getLoader( $loader_name );
 		$loader->clearAll();
+	}
+
+	public static function shortcode_test_init() {
+		add_shortcode( 'shortcode_test', array( __CLASS__, 'shortcode_test_handler' ) );
+		codecept_debug( 'shortcode created' );
+	}
+
+	public static function shortcode_test_handler( $atts ) {
+		return '<p>This is the product description.</p>';
 	}
 }

--- a/tests/_support/Helper/crud-helpers/product.php
+++ b/tests/_support/Helper/crud-helpers/product.php
@@ -69,17 +69,19 @@ class ProductHelper extends WCG_Helper {
 
 		$props = array_merge(
 			array(
-				'name'          => $name,
-				'slug'          => $this->next_slug(),
-				'regular_price' => $regular_price,
-				'price'         => $price,
-				'sku'           => uniqid(),
-				'manage_stock'  => false,
-				'tax_status'    => 'taxable',
-				'downloadable'  => false,
-				'virtual'       => false,
-				'stock_status'  => 'instock',
-				'weight'        => '1.1',
+				'name'              => $name,
+				'slug'              => $this->next_slug(),
+				'regular_price'     => $regular_price,
+				'price'             => $price,
+				'sku'               => uniqid(),
+				'manage_stock'      => false,
+				'tax_status'        => 'taxable',
+				'downloadable'      => false,
+				'virtual'           => false,
+				'stock_status'      => 'instock',
+				'weight'            => '1.1',
+				'description'       => '[shortcode_test]',
+				'short_description' => $this->dummy->sentence(),
 			),
 			$args
 		);
@@ -292,7 +294,7 @@ class ProductHelper extends WCG_Helper {
 		return $download;
 	}
 
-	public function print_query( $id ) {
+	public function print_query( $id, $raw = false ) {
 		$data = wc_get_product( $id );
 
 		return array(
@@ -306,11 +308,18 @@ class ProductHelper extends WCG_Helper {
 			'featured'          => $data->get_featured(),
 			'catalogVisibility' => strtoupper( $data->get_catalog_visibility() ),
 			'description'       => ! empty( $data->get_description() )
-				? $data->get_description()
+				? $raw
+					? $data->get_description()
+					: apply_filters( 'the_content', $data->get_description() )
 				: null,
 			'shortDescription'  => ! empty( $data->get_short_description() )
-			? $data->get_short_description()
-			: null,
+				? $raw
+					? $data->get_short_description()
+					: apply_filters(
+						'get_the_excerpt',
+						apply_filters( 'the_excerpt', $data->get_short_description() )
+					)
+				: null,
 			'sku'               => $data->get_sku(),
 			'price'             => ! empty( $data->get_price() )
 				? \wc_graphql_price( $data->get_price() )
@@ -352,7 +361,7 @@ class ProductHelper extends WCG_Helper {
 			'onSale'            => $data->is_on_sale(),
 			'purchasable'       => $data->is_purchasable(),
 			'shippingRequired'  => $data->needs_shipping(),
-			'shippingTaxable'   => $data->is_shipping_taxable()
+			'shippingTaxable'   => $data->is_shipping_taxable(),
 		);
 	}
 


### PR DESCRIPTION
…cription".

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds `format` argument to description fields. It functions identically to **WPGraphQL**'s CPT content fields. Users must have the capability for editing products in order to retrieve the raw descriptions straight from the database, same as CPT-based types.

#### Example Usage
```
query ( $id: ID!, $format: PostObjectFieldFormatEnum ) {
	product(id: $id) {
		description(format: $format)
		shortDescription(format: $format)
	}
}
```

`PostObjectFieldFormatEnum` is an enumeration define in **WPGraphQL** core, possible values are
- RAW
- RENDERED


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.2