### PR TITLE
"product_connection_catalog_visibility" hook implemented.

### DIFF
--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -262,14 +262,14 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			 * Filters the default catalog visibility tax query for non-adminstrator requests.
 			 *
 			 * @param array       $default_visibility  Default catalog visibility tax query.
-			 * @param array       $query_args          The args that will be passed to the WP_Query
-			 * @param mixed       $source              The source that's passed down the GraphQL queries
-			 * @param array       $args                The inputArgs on the field
-			 * @param AppContext  $context             The AppContext passed down the GraphQL tree
-			 * @param ResolveInfo $info                The ResolveInfo passed down the GraphQL tree
+			 * @param array       $query_args          The args that will be passed to the WP_Query.
+			 * @param mixed       $source              The source that's passed down the GraphQL queries.
+			 * @param array       $args                The inputArgs on the field.
+			 * @param AppContext  $context             The AppContext passed down the GraphQL tree.
+			 * @param ResolveInfo $info                The ResolveInfo passed down the GraphQL tree.
 			 */
 			$catalog_visibility = apply_filters(
-				'product_connection_catalog_visibility',
+				'graphql_product_connection_catalog_visibility',
 				self::$default_visibility,
 				$query_args,
 				$this->source,
@@ -300,13 +300,13 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 * Filter the $query_args to allow folks to customize queries programmatically
+		 * Filter the $query_args to allow folks to customize queries programmatically.
 		 *
-		 * @param array       $query_args The args that will be passed to the WP_Query
-		 * @param mixed       $source     The source that's passed down the GraphQL queries
-		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param array       $query_args The args that will be passed to the WP_Query.
+		 * @param mixed       $source     The source that's passed down the GraphQL queries.
+		 * @param array       $args       The inputArgs on the field.
+		 * @param AppContext  $context    The AppContext passed down the GraphQL tree.
+		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
 		 */
 		$query_args = apply_filters( 'graphql_product_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -34,6 +34,18 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	protected $post_type;
 
 	/**
+	 * Holds default catalog visibility tax query.
+	 *
+	 * @var array
+	 */
+	public static $default_visibility = array(
+		'taxonomy' => 'product_visibility',
+		'field'    => 'slug',
+		'terms'    => array( 'exclude-from-catalog', 'exclude-from-search' ),
+		'operator' => 'NOT IN',
+	);
+
+	/**
 	 * Refund_Connection_Resolver constructor.
 	 *
 	 * @param mixed       $source    The object passed down from the previous level in the Resolve tree.
@@ -245,12 +257,30 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			if ( empty( $query_args['tax_query'] ) ) {
 				$query_args['tax_query'] = array(); // WPCS: slow query ok.
 			}
-			$query_args['tax_query'][] = array(
-				'taxonomy' => 'product_visibility',
-				'field'    => 'slug',
-				'terms'    => array( 'exclude-from-catalog', 'exclude-from-search' ),
-				'operator' => 'NOT IN',
+
+			/**
+			 * Filters the default catalog visibility tax query for non-adminstrator requests.
+			 *
+			 * @param array       $default_visibility  Default catalog visibility tax query.
+			 * @param array       $query_args          The args that will be passed to the WP_Query
+			 * @param mixed       $source              The source that's passed down the GraphQL queries
+			 * @param array       $args                The inputArgs on the field
+			 * @param AppContext  $context             The AppContext passed down the GraphQL tree
+			 * @param ResolveInfo $info                The ResolveInfo passed down the GraphQL tree
+			 */
+			$catalog_visibility = apply_filters(
+				'product_connection_catalog_visibility',
+				self::$default_visibility,
+				$query_args,
+				$this->source,
+				$this->args,
+				$this->context,
+				$this->info
 			);
+
+			if ( ! empty( $catalog_visibility ) ) {
+				$query_args['tax_query'][] = $catalog_visibility;
+			}
 		}
 
 		/**
@@ -270,7 +300,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 * Filter the $query args to allow folks to customize queries programmatically
+		 * Filter the $query_args to allow folks to customize queries programmatically
 		 *
 		 * @param array       $query_args The args that will be passed to the WP_Query
 		 * @param mixed       $source     The source that's passed down the GraphQL queries


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Add hook for filtering the default catalog visibility tax query used in `Product` connections for non-administrator request.

#### Example usage
```
function show_all_products( $default_visiibility, $query_args, $source, $args, $context, $info ) {
  if( 'allProducts' === $info->fieldName ) {
     $default_visibility = null;
  }
  return $default_visibility;
}
add_filter( 'graphql_product_connection_catalog_visibility', 'show_all_products', 10, 6 );
```

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.2.3