### PR TITLE
Escape hatch added on non-GraphQL requests.

### DIFF
--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -95,8 +95,9 @@ class WooCommerce_Filters {
 	 * @return bool
 	 */
 	private static function is_graphql_post_request() {
+		global $wp;
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			$haystack = wp_unslash( $_SERVER['REQUEST_URI'] );
+			$haystack = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 			$needle   = apply_filters( 'graphql_endpoint', 'graphql' );
 			$length   = strlen( $needle );
 			if ( 0 === $length ) {

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -26,14 +26,13 @@ class WooCommerce_Filters {
 	 */
 	public static function add_filters() {
 		// Setup QL session handler.
-		$graphql_endpoint = '/' . apply_filters( 'graphql_endpoint', 'graphql' );
-		if ( isset( $_SERVER['REQUEST_URI'] ) && $graphql_endpoint !== $_SERVER['REQUEST_URI'] ) {
-			return;
-		}
 		if ( ! defined( 'NO_QL_SESSION_HANDLER' ) ) {
+			// Check if request is a GraphQL POST request.
 			self::$session_header = apply_filters( 'woocommerce_graphql_session_header_name', 'woocommerce-session' );
-			add_filter( 'woocommerce_cookie', array( __CLASS__, 'woocommerce_cookie' ) );
-			add_filter( 'woocommerce_session_handler', array( __CLASS__, 'init_ql_session_handler' ) );
+			if ( self::is_graphql_post_request() ) {
+				add_filter( 'woocommerce_cookie', array( __CLASS__, 'woocommerce_cookie' ) );
+				add_filter( 'woocommerce_session_handler', array( __CLASS__, 'init_ql_session_handler' ) );
+			}
 			add_filter( 'graphql_response_headers_to_send', array( __CLASS__, 'add_session_header_to_expose_headers' ) );
 			add_filter( 'graphql_access_control_allow_headers', array( __CLASS__, 'add_session_header_to_allow_headers' ) );
 		}
@@ -88,5 +87,25 @@ class WooCommerce_Filters {
 	public static function add_session_header_to_allow_headers( array $allowed_headers ) {
 		$allowed_headers[] = self::$session_header;
 		return $allowed_headers;
+	}
+
+	/**
+	 * Confirm that the current uri is the GraphQL endpoint.
+	 *
+	 * @return bool
+	 */
+	private static function is_graphql_post_request() {
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$haystack = wp_unslash( $_SERVER['REQUEST_URI'] );
+			$needle   = apply_filters( 'graphql_endpoint', 'graphql' );
+			$length   = strlen( $needle );
+			if ( 0 === $length ) {
+				return true;
+			}
+
+			return ( substr( $haystack, -$length ) === $needle );
+		}
+
+		return false;
 	}
 }

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -26,6 +26,10 @@ class WooCommerce_Filters {
 	 */
 	public static function add_filters() {
 		// Setup QL session handler.
+		$graphql_endpoint = '/' . apply_filters( 'graphql_endpoint', 'graphql' );
+		if ( isset( $_SERVER['REQUEST_URI'] ) && $graphql_endpoint !== $_SERVER['REQUEST_URI'] ) {
+			return;
+		}
 		if ( ! defined( 'NO_QL_SESSION_HANDLER' ) ) {
 			self::$session_header = apply_filters( 'woocommerce_graphql_session_header_name', 'woocommerce-session' );
 			add_filter( 'woocommerce_cookie', array( __CLASS__, 'woocommerce_cookie' ) );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds escape hatch that prevents `QL_Session_Handler` from being used on any request not made to the GraphQL endpoint, (by default its `/graphql`). 

This includes query made uses the **GET** method *i.e. /graphql?query={...}*.

The `QL_Session_Handler` is designed to only update and send a response header after specific mutations that make changes to the session data like `addToCart`.

#### TODO
- [ ] Configure codeception to properly merge code coverage results between suites.

Does this close any currently open issues?
------------------------------------------
#143 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04

**WordPress Version:** 5.2.3