### PR TITLE
Orderby ACF fields on Coupon, Product, and Order connections

### DIFF
--- a/includes/class-acf-schema-filters.php
+++ b/includes/class-acf-schema-filters.php
@@ -8,6 +8,8 @@
 
 namespace WPGraphQL\WooCommerce;
 
+use WPGraphQL\Type\WPEnumType;
+
 /**
  * Class ACF_Schema_Filters
  */
@@ -19,6 +21,15 @@ class ACF_Schema_Filters {
 	public static function add_filters() {
 		// Registers WooCommerce CPTs && taxonomies.
 		add_filter( 'graphql_acf_get_root_id', array( __CLASS__, 'resolve_crud_root_id' ), 10, 2 );
+
+		// Register ACF orderby fields.
+		add_filter( 'graphql_couponsOrderByEnum_values', array( __CLASS__, 'orderby_acf_fields' ), 10 );
+		add_filter( 'graphql_productsOrderByEnum_values', array( __CLASS__, 'orderby_acf_fields' ), 10 );
+		add_filter( 'graphql_ordersOrderByEnum_values', array( __CLASS__, 'orderby_acf_fields' ), 10 );
+
+		add_filter( 'graphql_coupon_connection_ordering_meta', array( __CLASS__, 'acf_ordering_meta' ) );
+		add_filter( 'graphql_product_connection_ordering_meta', array( __CLASS__, 'acf_ordering_meta' ) );
+		add_filter( 'graphql_order_connection_ordering_meta', array( __CLASS__, 'acf_ordering_meta' ) );
 	}
 
 	/**
@@ -37,5 +48,143 @@ class ACF_Schema_Filters {
 		}
 
 		return $id;
+	}
+
+	/**
+	 * Retrieves ACF field groups for the custom post-type related to the current hook
+	 *
+	 * @return false|array
+	 */
+	private static function get_acf_field_groups() {
+		// Check captured filter and get the ACF field groups.
+		switch ( current_filter() ) {
+			case 'graphql_couponsOrderByEnum_values':
+			case 'graphql_coupon_connection_ordering_meta':
+				$field_groups = acf_get_field_groups( array( 'post_type' => 'shop_coupon' ) );
+				break;
+			case 'graphql_productsOrderByEnum_values':
+			case 'graphql_product_connection_ordering_meta':
+				$field_groups = acf_get_field_groups( array( 'post_type' => 'product' ) );
+				break;
+			case 'graphql_ordersOrderByEnum_values':
+			case 'graphql_order_connection_ordering_meta':
+				$field_groups = acf_get_field_groups( array( 'post_type' => 'shop_order' ) );
+				break;
+			default:
+				$field_groups = false;
+		}
+
+		return $field_groups;
+	}
+
+	/**
+	 * Adds ACF fields to the "OrderbyEnum" for the custom post-type related to the current hook.
+	 *
+	 * @param array $values  *OrderbyEnum fields.
+	 *
+	 * @return array.
+	 */
+	public static function orderby_acf_fields( $values ) {
+		$field_groups = self::get_acf_field_groups();
+		// If no field groups, bail.
+		if ( empty( $field_groups ) || ! is_array( $field_groups ) ) {
+			return $values;
+		}
+
+		foreach ( $field_groups as $field_group ) {
+			// Check if should be shown in GraphQL.
+			if ( empty( $field_group['show_in_graphql'] ) || false === $field_group['show_in_graphql'] ) {
+				continue;
+			}
+
+			// Get the fields in the group.
+			$acf_fields = ! empty( $field_group['sub_fields'] ) ? $field_group['sub_fields'] : acf_get_fields( $field_group );
+
+			// If there are no fields, continue.
+			if ( empty( $acf_fields ) || ! is_array( $acf_fields ) ) {
+				continue;
+			}
+
+			// Loop over the fields and register them to the Schema.
+			foreach ( $acf_fields as $acf_field ) {
+				if ( empty( $acf_field['name'] ) ) {
+					continue;
+				}
+
+				switch ( $acf_field['type'] ) {
+					case 'text':
+					case 'email':
+					case 'message':
+					case 'url':
+					case 'number':
+					case 'date_picker':
+					case 'time_picker':
+					case 'date_time_picker':
+						$values[ WPEnumType::get_safe_name( $acf_field['name'] ) ] = array(
+							'value'       => $acf_field['name'],
+							'description' => sprintf(
+								/* translators: %s: ACF field label */
+								__( 'Order by the "%s" ACF field', 'wp-graphql-woocommerce' ),
+								$acf_field['label']
+							),
+						);
+						break;
+				}
+			}
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Adds ACF fields to the "ordering_meta" for the type related to the current hook.
+	 *
+	 * @param array $ordering_meta  Valid ordering meta fields.
+	 *
+	 * @return array.
+	 */
+	public static function acf_ordering_meta( $ordering_meta ) {
+		$field_groups = self::get_acf_field_groups();
+		// If no field groups, bail.
+		if ( empty( $field_groups ) || ! is_array( $field_groups ) ) {
+			return $ordering_meta;
+		}
+
+		foreach ( $field_groups as $field_group ) {
+			// Check if should be shown in GraphQL.
+			if ( empty( $field_group['show_in_graphql'] ) || false === $field_group['show_in_graphql'] ) {
+				continue;
+			}
+
+			// Get the fields in the group.
+			$acf_fields = ! empty( $field_group['sub_fields'] ) ? $field_group['sub_fields'] : acf_get_fields( $field_group );
+
+			// If there are no fields, continue.
+			if ( empty( $acf_fields ) || ! is_array( $acf_fields ) ) {
+				continue;
+			}
+
+			// Loop over the fields and register them to the Schema.
+			foreach ( $acf_fields as $acf_field ) {
+				if ( empty( $acf_field['name'] ) ) {
+					continue;
+				}
+
+				switch ( $acf_field['type'] ) {
+					case 'text':
+					case 'email':
+					case 'message':
+					case 'url':
+					case 'number':
+					case 'date_picker':
+					case 'time_picker':
+					case 'date_time_picker':
+						$ordering_meta[] = $acf_field['name'];
+						break;
+				}
+			}
+		}
+
+		return $ordering_meta;
 	}
 }

--- a/includes/class-type-registry.php
+++ b/includes/class-type-registry.php
@@ -35,6 +35,7 @@ class Type_Registry {
 		\WPGraphQL\WooCommerce\Type\WPEnum\Product_Taxonomy::register();
 		\WPGraphQL\WooCommerce\Type\WPEnum\Taxonomy_Operator::register();
 		\WPGraphQL\WooCommerce\Type\WPEnum\Post_Type_Orderby_Enum::register();
+		\WPGraphQL\WooCommerce\Type\WPEnum\Coupons_Orderby_Enum::register();
 		\WPGraphQL\WooCommerce\Type\WPEnum\Products_Orderby_Enum::register();
 		\WPGraphQL\WooCommerce\Type\WPEnum\Orders_Orderby_Enum::register();
 

--- a/includes/connection/class-coupons.php
+++ b/includes/connection/class-coupons.php
@@ -42,7 +42,7 @@ class Coupons {
 	 *
 	 * @return array
 	 */
-	public static function get_connection_config( $args = [] ) {
+	public static function get_connection_config( $args = array() ) {
 		$defaults = array(
 			'fromType'       => 'RootQuery',
 			'toType'         => 'Coupon',
@@ -67,9 +67,13 @@ class Coupons {
 		return array_merge(
 			get_common_post_type_args(),
 			array(
-				'code' => array(
+				'code'    => array(
 					'type'        => 'String',
 					'description' => __( 'Limit result set to resources with a specific code.', 'wp-graphql-woocommerce' ),
+				),
+				'orderby' => array(
+					'type'        => array( 'list_of' => 'CouponsOrderbyInput' ),
+					'description' => __( 'What paramater to use to order the objects by.', 'wp-graphql-woocommerce' ),
 				),
 			)
 		);

--- a/includes/data/connection/class-coupon-connection-resolver.php
+++ b/includes/data/connection/class-coupon-connection-resolver.php
@@ -105,7 +105,7 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 		/**
 		 * Collect the input_fields and sanitize them to prepare them for sending to the WP_Query
 		 */
-		$input_fields = [];
+		$input_fields = array();
 		if ( ! empty( $this->args['where'] ) ) {
 			$input_fields = $this->sanitize_input_fields( $this->args['where'] );
 		}
@@ -163,7 +163,7 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_items() {
-		return ! empty( $this->query->posts ) ? $this->query->posts : [];
+		return ! empty( $this->query->posts ) ? $this->query->posts : array();
 	}
 
 	/**
@@ -172,7 +172,7 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function ordering_meta() {
-		return array();
+		return apply_filters( 'graphql_coupon_connection_ordering_meta', array() );
 	}
 
 	/**

--- a/includes/data/connection/class-order-connection-resolver.php
+++ b/includes/data/connection/class-order-connection-resolver.php
@@ -168,13 +168,16 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function ordering_meta() {
-		return array(
-			'_order_key',
-			'_cart_discount',
-			'_order_total',
-			'_order_tax',
-			'_date_paid',
-			'_date_completed',
+		return apply_filters(
+			'graphql_order_connection_ordering_meta',
+			array(
+				'_order_key',
+				'_cart_discount',
+				'_order_total',
+				'_order_tax',
+				'_date_paid',
+				'_date_completed',
+			)
 		);
 	}
 

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -335,15 +335,18 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function ordering_meta() {
-		return array(
-			'_price',
-			'_regular_price',
-			'_sale_price',
-			'_wc_rating_count',
-			'_wc_average_rating',
-			'_sale_price_dates_from',
-			'_sale_price_dates_to',
-			'total_sales',
+		return apply_filters(
+			'graphql_product_connection_ordering_meta',
+			array(
+				'_price',
+				'_regular_price',
+				'_sale_price',
+				'_wc_rating_count',
+				'_wc_average_rating',
+				'_sale_price_dates_from',
+				'_sale_price_dates_to',
+				'total_sales',
+			)
 		);
 	}
 

--- a/includes/data/connection/trait-common-cpt-args-processing.php
+++ b/includes/data/connection/trait-common-cpt-args-processing.php
@@ -66,7 +66,7 @@ trait Common_CPT_Input_Sanitize_Functions {
 
 					// Handle meta fields.
 				} elseif ( in_array( $orderby_input['field'], $this->ordering_meta(), true ) ) {
-					$args['orderby']  = array( 'meta_value_num' => $orderby_input['order'] );
+					$args['orderby']  = array( 'meta_value' => $orderby_input['order'] );
 					$args['meta_key'] = esc_sql( $orderby_input['field'] ); // WPCS: slow query ok.
 
 					// Handle post object fields.

--- a/includes/type/enum/class-coupons-orderby-enum.php
+++ b/includes/type/enum/class-coupons-orderby-enum.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * WPEnum Type - CouponsOrderbyEnum
+ *
+ * @package \WPGraphQL\WooCommerce\Type\WPEnum
+ * @since   0.3.2
+ */
+
+namespace WPGraphQL\WooCommerce\Type\WPEnum;
+
+/**
+ * Class Coupons_Orderby_Enum
+ */
+class Coupons_Orderby_Enum extends Post_Type_Orderby_Enum {
+	/**
+	 * Holds ordering enumeration base name.
+	 *
+	 * @var string
+	 */
+	protected static $name = 'Coupons';
+
+	/**
+	 * Define enumeration values related to the "shop_coupon" post-type ordering fields.
+	 *
+	 * @return array
+	 */
+	protected static function values() {
+		return self::post_type_values();
+	}
+}

--- a/includes/type/input/class-orderby-inputs.php
+++ b/includes/type/input/class-orderby-inputs.php
@@ -44,6 +44,7 @@ class Orderby_Inputs {
 	public static function register() {
 		$input_types = array(
 			'PostType',
+			'Coupons',
 			'Products',
 			'Orders',
 		);

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -79,6 +79,7 @@ return array(
     'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Backorders' => $baseDir . '/includes/type/enum/class-backorders.php',
     'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Catalog_Visibility' => $baseDir . '/includes/type/enum/class-catalog-visibility.php',
     'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Countries' => $baseDir . '/includes/type/enum/class-countries.php',
+    'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Coupons_Orderby_Enum' => $baseDir . '/includes/type/enum/class-coupons-orderby-enum.php',
     'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Customer_Connection_Orderby_Enum' => $baseDir . '/includes/type/enum/class-customer-connection-orderby-enum.php',
     'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Discount_Type' => $baseDir . '/includes/type/enum/class-discount-type.php',
     'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Manage_Stock' => $baseDir . '/includes/type/enum/class-manage-stock.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -107,6 +107,7 @@ class ComposerStaticInit8ad1f343d0cd8163c5fbabd591f04ce0
         'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Backorders' => __DIR__ . '/../..' . '/includes/type/enum/class-backorders.php',
         'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Catalog_Visibility' => __DIR__ . '/../..' . '/includes/type/enum/class-catalog-visibility.php',
         'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Countries' => __DIR__ . '/../..' . '/includes/type/enum/class-countries.php',
+        'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Coupons_Orderby_Enum' => __DIR__ . '/../..' . '/includes/type/enum/class-coupons-orderby-enum.php',
         'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Customer_Connection_Orderby_Enum' => __DIR__ . '/../..' . '/includes/type/enum/class-customer-connection-orderby-enum.php',
         'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Discount_Type' => __DIR__ . '/../..' . '/includes/type/enum/class-discount-type.php',
         'WPGraphQL\\WooCommerce\\Type\\WPEnum\\Manage_Stock' => __DIR__ . '/../..' . '/includes/type/enum/class-manage-stock.php',


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Provides the ability to order `product`, `order`, and `coupon` connections by ACF field values of the following types
- `text`
- `email`
- `message`
- `url`
- `number`
- `date picker`
- `time picker`
- `date time picker` 


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.3