### PR TITLE
"cart" field add to mutation output.

### DIFF
--- a/includes/data/mutation/class-cart-mutation.php
+++ b/includes/data/mutation/class-cart-mutation.php
@@ -15,6 +15,25 @@ use GraphQL\Error\UserError;
  */
 class Cart_Mutation {
 	/**
+	 * Retrieve `cart` output field defintion
+	 *
+	 * @param bool $fallback  Should cart be retrieved, if not provided in payload.
+	 * @return array
+	 */
+	public static function get_cart_field( $fallback = false ) {
+		return array(
+			'type'    => 'Cart',
+			'resolve' => function ( $payload ) use ( $fallback ) {
+				$cart = ! empty( $payload['cart'] ) ? $payload['cart'] : null;
+				if ( is_null( $cart ) && $fallback ) {
+					$cart = \WC()->cart;
+				}
+				return $cart;
+			},
+		);
+	}
+
+	/**
 	 * Returns a cart item.
 	 *
 	 * @param array       $input   Input data describing cart item.

--- a/includes/mutation/class-cart-add-fee.php
+++ b/includes/mutation/class-cart-add-fee.php
@@ -75,6 +75,7 @@ class Cart_Add_Fee {
 					return $fees[ $payload['id'] ];
 				},
 			),
+			'cart'    => Cart_Mutation::get_cart_field( true ),
 		);
 	}
 

--- a/includes/mutation/class-cart-add-item.php
+++ b/includes/mutation/class-cart-add-item.php
@@ -80,6 +80,7 @@ class Cart_Add_Item {
 					return $item;
 				},
 			),
+			'cart'     => Cart_Mutation::get_cart_field( true ),
 		);
 	}
 

--- a/includes/mutation/class-cart-apply-coupon.php
+++ b/includes/mutation/class-cart-apply-coupon.php
@@ -56,12 +56,7 @@ class Cart_Apply_Coupon {
 	 */
 	public static function get_output_fields() {
 		return array(
-			'cart' => array(
-				'type'    => 'Cart',
-				'resolve' => function ( $payload ) {
-					return $payload['cart'];
-				},
-			),
+			'cart' => Cart_Mutation::get_cart_field(),
 		);
 	}
 

--- a/includes/mutation/class-cart-empty.php
+++ b/includes/mutation/class-cart-empty.php
@@ -40,12 +40,7 @@ class Cart_Empty {
 	 */
 	public static function get_output_fields() {
 		return array(
-			'cart' => array(
-				'type'    => 'Cart',
-				'resolve' => function ( $payload ) {
-					return $payload['cart'];
-				},
-			),
+			'cart' => Cart_Mutation::get_cart_field(),
 		);
 	}
 

--- a/includes/mutation/class-cart-remove-coupons.php
+++ b/includes/mutation/class-cart-remove-coupons.php
@@ -56,12 +56,7 @@ class Cart_Remove_Coupons {
 	 */
 	public static function get_output_fields() {
 		return array(
-			'cart' => array(
-				'type'    => 'Cart',
-				'resolve' => function ( $payload ) {
-					return $payload['cart'];
-				},
-			),
+			'cart' => Cart_Mutation::get_cart_field(),
 		);
 	}
 

--- a/includes/mutation/class-cart-remove-items.php
+++ b/includes/mutation/class-cart-remove-items.php
@@ -66,6 +66,7 @@ class Cart_Remove_Items {
 					return $payload['items'];
 				},
 			),
+			'cart'      => Cart_Mutation::get_cart_field( true ),
 		);
 	}
 

--- a/includes/mutation/class-cart-update-item-quantities.php
+++ b/includes/mutation/class-cart-update-item-quantities.php
@@ -82,6 +82,7 @@ class Cart_Update_Item_Quantities {
 					return array_merge( $updated, $payload['removed'] );
 				},
 			),
+			'cart'    => Cart_Mutation::get_cart_field( true ),
 		);
 	}
 

--- a/includes/mutation/class-cart-update-shipping-method.php
+++ b/includes/mutation/class-cart-update-shipping-method.php
@@ -53,12 +53,7 @@ class Cart_Update_Shipping_Method {
 	 */
 	public static function get_output_fields() {
 		return array(
-			'cart' => array(
-				'type'    => 'Cart',
-				'resolve' => function () {
-					return \WC()->cart;
-				},
-			),
+			'cart' => Cart_Mutation::get_cart_field( true ),
 		);
 	}
 


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds `cart` field to all cart mutation output types.

#### Example mutation
```
mutation {
  addToCart(input: { productId: 1, quantity: 2 }) {
    clientMutationId
    cartItem {
      key
    }
    cart {
       subtotal
    }
}
```

Does this close any currently open issues?
------------------------------------------
#192


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.3