### PR TITLE
allow optional password creation for registerCustomer

### DIFF
--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -99,8 +99,9 @@ class Customer_Register {
 			if ( empty( $input['email'] ) ) {
 				throw new UserError( __( 'Please provide a valid email address.', 'wp-graphql-woocommerce' ) );
 			}
-			if ( empty( $input['password'] ) ) {
-				throw new UserError( __( 'Please enter an account password.', 'wp-graphql-woocommerce' ) );
+			// make sure they pass in password if password generation is off
+			if ('no' === get_option('woocommerce_registration_generate_password') && empty($input['password'])) {
+				throw new UserError(__('A password was not provided and WooCommerce does not automatically generate one for you.', 'wp-graphql-woocommerce'));
 			}
 
 			// Map all of the args from GQL to WP friendly.
@@ -110,7 +111,7 @@ class Customer_Register {
 			$user_id = wc_create_new_customer(
 				$user_args['user_email'],
 				$user_args['user_login'],
-				$user_args['user_pass'],
+				isset($user_args['user_pass']) ? $user_args['user_pass'] : '',
 				$user_args
 			);
 

--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -99,9 +99,15 @@ class Customer_Register {
 			if ( empty( $input['email'] ) ) {
 				throw new UserError( __( 'Please provide a valid email address.', 'wp-graphql-woocommerce' ) );
 			}
-			// make sure they pass in password if password generation is off
-			if ('no' === get_option('woocommerce_registration_generate_password') && empty($input['password'])) {
-				throw new UserError(__('A password was not provided and WooCommerce does not automatically generate one for you.', 'wp-graphql-woocommerce'));
+
+			// Validate password input.
+			if ( 'no' === get_option( 'woocommerce_registration_generate_password' ) && empty( $input['password'] ) ) {
+				throw new UserError(
+					__(
+						'A password was not provided and WooCommerce does not automatically generate one for you.',
+						'wp-graphql-woocommerce'
+					)
+				);
 			}
 
 			// Map all of the args from GQL to WP friendly.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This just makes sure that if someone wants to enable automatic password generation, they can do so via WooCommerce settings and still be able to register customers through this endpoint.


Does this close any currently open issues?
------------------------------------------
Nope


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![Throws error if password is not provided and setting is not enabled in WooCommerce settings for accounts](https://user-images.githubusercontent.com/34875122/72210703-6a7f9280-348d-11ea-888c-bc66bb20f291.jpg)

Any other comments?
-------------------
…


Where has this been tested?
---------------------------
MacOS

**WordPress Version:** …