### PR TITLE
Pagination implemented on cart connection

### DIFF
--- a/includes/connection/class-cart-items.php
+++ b/includes/connection/class-cart-items.php
@@ -42,7 +42,7 @@ class Cart_Items {
 			'connectionFields' => array(
 				'itemCount'    => array(
 					'type'        => 'Int',
-					'description' => __( 'Review rating', 'wp-graphql-woocommerce' ),
+					'description' => __( 'Total number of items in the cart.', 'wp-graphql-woocommerce' ),
 					'resolve'     => function( $source ) {
 						if ( empty( $source['edges'] ) ) {
 							return 0;
@@ -59,7 +59,7 @@ class Cart_Items {
 				),
 				'productCount' => array(
 					'type'        => 'Int',
-					'description' => __( 'Review rating', 'wp-graphql-woocommerce' ),
+					'description' => __( 'Total number of different products in the cart', 'wp-graphql-woocommerce' ),
 					'resolve'     => function( $source ) {
 						if ( empty( $source['edges'] ) ) {
 							return 0;

--- a/includes/connection/class-cart-items.php
+++ b/includes/connection/class-cart-items.php
@@ -35,11 +35,42 @@ class Cart_Items {
 	 */
 	public static function get_connection_config( $args = array() ) {
 		$defaults = array(
-			'fromType'       => 'Cart',
-			'toType'         => 'CartItem',
-			'fromFieldName'  => 'contents',
-			'connectionArgs' => self::get_connection_args(),
-			'resolve'        => function ( $source, $args, $context, $info ) {
+			'fromType'         => 'Cart',
+			'toType'           => 'CartItem',
+			'fromFieldName'    => 'contents',
+			'connectionArgs'   => self::get_connection_args(),
+			'connectionFields' => array(
+				'itemCount'    => array(
+					'type'        => 'Int',
+					'description' => __( 'Review rating', 'wp-graphql-woocommerce' ),
+					'resolve'     => function( $source ) {
+						if ( empty( $source['edges'] ) ) {
+							return 0;
+						}
+
+						$items = array_values( $source['edges'][0]['source']->get_cart() );
+						$count = 0;
+						foreach ( $items as $item ) {
+							$count += $item['quantity'];
+						}
+
+						return $count;
+					},
+				),
+				'productCount' => array(
+					'type'        => 'Int',
+					'description' => __( 'Review rating', 'wp-graphql-woocommerce' ),
+					'resolve'     => function( $source ) {
+						if ( empty( $source['edges'] ) ) {
+							return 0;
+						}
+
+						$items = array_values( $source['edges'][0]['source']->get_cart() );
+						return count( $items );
+					},
+				),
+			),
+			'resolve'          => function ( $source, $args, $context, $info ) {
 				return Factory::resolve_cart_item_connection( $source, $args, $context, $info );
 			},
 		);
@@ -55,7 +86,7 @@ class Cart_Items {
 		return array(
 			'needShipping' => array(
 				'type'        => 'Boolean',
-				'description' => __( 'Limit results to cart item that require shipping', 'wp-graphql-woocommerce' ),
+				'description' => __( 'Limit results to cart items that require shipping', 'wp-graphql-woocommerce' ),
 			),
 		);
 	}

--- a/includes/data/class-factory.php
+++ b/includes/data/class-factory.php
@@ -487,8 +487,8 @@ class Factory {
 	 * @access public
 	 */
 	public static function resolve_cart_item_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
-		$resolver = new Cart_Item_Connection_Resolver();
-		return $resolver->resolve( $source, $args, $context, $info );
+		$resolver = new Cart_Item_Connection_Resolver( $source, $args, $context, $info );
+		return $resolver->get_connection();
 	}
 
 	/**

--- a/includes/data/connection/class-cart-item-connection-resolver.php
+++ b/includes/data/connection/class-cart-item-connection-resolver.php
@@ -12,52 +12,114 @@ namespace WPGraphQL\WooCommerce\Data\Connection;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use GraphQLRelay\Connection\ArrayConnection;
 use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 
 /**
  * Class Cart_Item_Connection_Resolver
  */
-class Cart_Item_Connection_Resolver {
+class Cart_Item_Connection_Resolver extends AbstractConnectionResolver {
 	/**
-	 * Returns an array of cart items filtered based upon query arguments
+	 * Confirms if cart items should be retrieved.
 	 *
-	 * @param array $items - Cart items.
-	 * @param array $args  - Query arguments.
-	 *
-	 * @return array
+	 * @return bool
 	 */
-	public function filter( $items, $args = array() ) {
-		$filter_items = array_values( $items );
-
-		usort(
-			$filter_items,
-			function( $item_a, $item_b ) {
-				return strcmp( $item_a['key'], $item_b['key'] );
-			}
-		);
-
-		return $filter_items;
+	public function should_execute() {
+		return true;
 	}
 
 	/**
-	 * Creates connection
-	 *
-	 * @param mixed       $source     - Connection source Model instance.
-	 * @param array       $args       - Connection arguments.
-	 * @param AppContext  $context    - AppContext object.
-	 * @param ResolveInfo $info       - ResolveInfo object.
+	 * Creates query arguments array
 	 */
-	public function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
-		$items = $this->filter( $source->get_cart(), $args );
-
-		$connection = Relay::connectionFromArray( $items, $args );
-		$nodes      = array();
-		if ( ! empty( $connection['edges'] ) && is_array( $connection['edges'] ) ) {
-			foreach ( $connection['edges'] as $edge ) {
-				$nodes[] = ! empty( $edge['node'] ) ? $edge['node'] : null;
+	public function get_query_args() {
+		$query_args = array();
+		if ( ! empty( $this->args['where'] ) ) {
+			$where_args = $this->args['where'];
+			if ( ! empty( $where_args['needShipping'] ) ) {
+				$query_args['filters']   = array();
+				$query_args['filters'][] = function( $cart_item ) {
+					$product = \WC()->product_factory->get_product( $cart_item['product_id'] );
+					if ( $product ) {
+						return $product->needs_shipping();
+					}
+				};
 			}
 		}
-		$connection['nodes'] = ! empty( $nodes ) ? $nodes : array();
-		return $connection;
+
+		return $query_args;
+	}
+
+	/**
+	 * Executes query
+	 *
+	 * @return \WP_Query
+	 */
+	public function get_query() {
+		$cart_items = array_values( $this->source->get_cart() );
+
+		if ( ! empty( $this->query_args['filters'] ) ) {
+			if ( is_array( $this->query_args['filters'] ) ) {
+				foreach ( $this->query_args['filters'] as $filter ) {
+					$cart_items = array_filter( $cart_items, $filter );
+				}
+			} else {
+				$cart_items = array_filter( $cart_items, $this->query_args['filters'] );
+			}
+		}
+
+		$cursor_key    = $this->get_offset();
+		$cursor_offset = array_search( $cursor_key, \array_column( $cart_items, 'key' ), true );
+
+		if ( ! empty( $this->args['after'] ) ) {
+			$cart_items = array_splice( $cart_items, $cursor_offset + 1 );
+		} elseif ( $cursor_offset ) {
+			$cart_items = array_splice( $cart_items, 0, $cursor_offset );
+		}
+
+		return array_values( $cart_items );
+	}
+
+	/**
+	 * This returns the offset to be used in the $query_args based on the $args passed to the
+	 * GraphQL query.
+	 *
+	 * @return int|mixed
+	 */
+	public function get_offset() {
+		$offset = null;
+
+		// Get the offset.
+		if ( ! empty( $this->args['after'] ) ) {
+			$offset = $this->args['after'];
+		} elseif ( ! empty( $this->args['before'] ) ) {
+			$offset = $this->args['before'];
+		}
+
+		/**
+		 * Return the higher of the two values
+		 */
+		return $offset;
+	}
+
+	/**
+	 * Create cursor for cart item node.
+	 *
+	 * @param array  $node  Cart item.
+	 * @param string $key   Cart item key.
+	 *
+	 * @return string
+	 */
+	protected function get_cursor_for_node( $node, $key = null ) {
+		return $node['key'];
+	}
+
+	/**
+	 * Return an array of items from the query
+	 *
+	 * @return array
+	 */
+	public function get_items() {
+		return ! empty( $this->query ) ? $this->query : array();
 	}
 }

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -100,7 +100,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Confirms the uses has the privileges to query Products
+	 * Confirms the user has the privileges to query the products
 	 *
 	 * @return bool
 	 */

--- a/tests/_support/Helper/crud-helpers/cart.php
+++ b/tests/_support/Helper/crud-helpers/cart.php
@@ -68,13 +68,10 @@ class CartHelper extends WCG_Helper {
 
 	public function print_nodes( $processors = array(), $_ = null ) {
 		$cart = WC()->cart;
-		$ids = array_keys( $cart->get_cart_contents() );
+		$ids = array_keys( $cart->get_cart() );
 		$default_processors = array(
 			'mapper' => function( $key ) {
 				return array( 'key' => $key ); 
-			},
-			'sorter' => function( $key_a, $key_b ) {
-				return strcmp( $key_a, $key_b );
 			},
 			'filter' => function( $key ) {
 				return true;
@@ -84,9 +81,6 @@ class CartHelper extends WCG_Helper {
 		$processors = array_merge( $default_processors, $processors );
 
 		$results = array_filter( $ids, $processors['filter'] );
-		if( ! empty( $results ) ) {
-			usort( $results, $processors['sorter'] );
-		}
 
 		return array_values( array_map( $processors['mapper'], $results ) );
 	}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Enhances the `Cart` to `CartItem` connection.
- adds `itemCount` field. Number of items in the cart. See example below.
- adds `productCount` field. Number of different products in the cart. See example below.
- `needShipping` whereArg implemented. See example below.
- Pagination implemented. See example below.
#### Usage Example
```
query ($first: Int, $last: Int, $before: String, $after: String, $needShipping: Boolean) {
	cart {
		contents(first: $first, last: $last, before: $before, after: $after where: { needShipping: $needShipping }) {
			itemCount
			productCount
			edges {
				cursor
				node {
					key
				}
			}
		}
	}
}
```

Does this close any currently open issues?
------------------------------------------
#205 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.3.2