### PR TITLE
"shippingMethod" field type changed to [String].

### DIFF
--- a/includes/mutation/class-checkout.php
+++ b/includes/mutation/class-checkout.php
@@ -50,7 +50,7 @@ class Checkout {
 				'description' => __( 'Payment method ID.', 'wp-graphql-woocommerce' ),
 			),
 			'shippingMethod'         => array(
-				'type'        => 'String',
+				'type'        => array( 'list_of' => 'String' ),
 				'description' => __( 'Order shipping method', 'wp-graphql-woocommerce' ),
 			),
 			'shipToDifferentAddress' => array(

--- a/tests/acceptance/NewCustomerCheckingOutCept.php
+++ b/tests/acceptance/NewCustomerCheckingOutCept.php
@@ -159,7 +159,7 @@ $I->wantTo('checkout');
 $checkout_input = array(
     'clientMutationId'   => 'someId',
     'paymentMethod'      => 'bacs',
-    'shippingMethod'     => 'flat rate',
+    'shippingMethod'     => array( 'flat rate' ),
     'billing'            => array(
         'firstName' => 'May',
         'lastName'  => 'Parker',

--- a/tests/wpunit/CheckoutMutationsTest.php
+++ b/tests/wpunit/CheckoutMutationsTest.php
@@ -278,7 +278,7 @@ class CheckoutMutationsTest extends \Codeception\TestCase\WPTestCase {
         $input      = array(
             'clientMutationId'   => 'someId',
             'paymentMethod'      => 'bacs',
-            'shippingMethod'     => 'flat rate',
+            'shippingMethod'     => array( 'flat rate' ),
 			'billing'            => array(
                 'firstName' => 'May',
                 'lastName'  => 'Parker',
@@ -484,7 +484,7 @@ class CheckoutMutationsTest extends \Codeception\TestCase\WPTestCase {
         $input      = array(
             'clientMutationId'       => 'someId',
             'paymentMethod'          => 'bacs',
-            'shippingMethod'         => 'flat rate',
+            'shippingMethod'         => array( 'flat rate' ),
 			'billing'                => array(
                 'firstName' => 'May',
                 'lastName'  => 'Parker',
@@ -676,7 +676,7 @@ class CheckoutMutationsTest extends \Codeception\TestCase\WPTestCase {
         $input      = array(
             'clientMutationId'   => 'someId',
             'paymentMethod'      => 'bacs',
-            'shippingMethod'     => 'flat rate',
+            'shippingMethod'     => array( 'flat rate' ),
 			'billing'            => array(
                 'firstName' => 'May',
                 'lastName'  => 'Parker',
@@ -880,7 +880,7 @@ class CheckoutMutationsTest extends \Codeception\TestCase\WPTestCase {
             'paymentMethod'      => 'bacs',
             'isPaid'             => true,
             'transactionId'      => 'transaction_id',
-            'shippingMethod'     => 'flat rate',
+            'shippingMethod'     => array( 'flat rate' ),
 			'billing'            => array(
                 'firstName' => 'May',
                 'lastName'  => 'Parker',


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates the `checkout` mutation's `shippingMethod` field to be a list of strings. So it can be properly set to the [session](https://github.com/wp-graphql/wp-graphql-woocommerce/blob/develop/includes/data/mutation/class-checkout-mutation.php#L194-L198) before [order creation](https://github.com/wp-graphql/wp-graphql-woocommerce/blob/develop/includes/data/mutation/class-checkout-mutation.php#L517).


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Linux Mint 19.2

**WordPress Version:** 5.2.3