### PR TITLE
Recalculate cart totals when removing coupon

### DIFF
--- a/includes/mutation/class-cart-remove-coupons.php
+++ b/includes/mutation/class-cart-remove-coupons.php
@@ -85,6 +85,9 @@ class Cart_Remove_Coupons {
 				}
 			}
 
+			// Recalculate totals.
+			\WC()->cart->calculate_totals();
+
 			// Return payload.
 			return array( 'cart' => \WC()->cart );
 		};


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Recalculate cart totals when removing a coupon.


Does this close any currently open issues?
------------------------------------------
Closes #260 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …