### PR TITLE
Added missing fields

### DIFF
--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -170,6 +170,15 @@ class Product extends Crud_CPT {
 				'name'                => function() {
 					return ! empty( $this->data->get_name() ) ? $this->data->get_name() : null;
 				},
+				'price'                => function() {
+					return ! empty( $this->data->get_price() ) ? $this->data->get_price() : null;
+				},
+				'regularPrice'                => function() {
+					return ! empty( $this->data->get_regularPrice() ) ? $this->data->get_regularPrice() : null;
+				},
+				'salePrice'                => function() {
+					return ! empty( $this->data->get_salePrice() ) ? $this->data->get_salePrice() : null;
+				},
 				'date'                => function() {
 					return ! empty( $this->data ) ? $this->data->get_date_created() : null;
 				},

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -138,6 +138,57 @@ class Product {
 				'type'        => 'String',
 				'description' => __( 'Product name', 'wp-graphql-woocommerce' ),
 			),
+			'price'              => array(
+				'type'        => 'String',
+				'description' => __( 'Product price', 'wp-graphql-woocommerce' ),
+				'args'        => array(
+					'format' => array(
+						'type'        => 'PostObjectFieldFormatEnum',
+						'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
+					),
+				),
+				'resolve'     => function( $source, $args ) {
+					if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+						// @codingStandardsIgnoreLine.
+						return $source->priceRaw;
+					}
+					return $source->price;
+				},
+			),
+			'regularPrice'              => array(
+				'type'        => 'String',
+				'description' => __( 'Product regular price', 'wp-graphql-woocommerce' ),
+				'args'        => array(
+					'format' => array(
+						'type'        => 'PostObjectFieldFormatEnum',
+						'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
+					),
+				),
+				'resolve'     => function( $source, $args ) {
+					if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+						// @codingStandardsIgnoreLine.
+						return $source->regularPriceRaw;
+					}
+					return $source->regularPrice;
+				},
+			),
+			'salePrice'              => array(
+				'type'        => 'String',
+				'description' => __( 'Product sale price', 'wp-graphql-woocommerce' ),
+				'args'        => array(
+					'format' => array(
+						'type'        => 'PostObjectFieldFormatEnum',
+						'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
+					),
+				),
+				'resolve'     => function( $source, $args ) {
+					if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+						// @codingStandardsIgnoreLine.
+						return $source->salePriceRaw;
+					}
+					return $source->salePrice;
+				},
+			),
 			'status'            => array(
 				'type'        => 'String',
 				'description' => __( 'Product status', 'wp-graphql-woocommerce' ),

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -143,7 +143,7 @@ class Product {
 				'description' => __( 'Product price', 'wp-graphql-woocommerce' ),
 				'args'        => array(
 					'format' => array(
-						'type'        => 'PostObjectFieldFormatEnum',
+						'type'        => 'PricingFieldFormatEnum',
 						'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
 					),
 				),
@@ -160,7 +160,7 @@ class Product {
 				'description' => __( 'Product regular price', 'wp-graphql-woocommerce' ),
 				'args'        => array(
 					'format' => array(
-						'type'        => 'PostObjectFieldFormatEnum',
+						'type'        => 'PricingFieldFormatEnum',
 						'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
 					),
 				),
@@ -177,7 +177,7 @@ class Product {
 				'description' => __( 'Product sale price', 'wp-graphql-woocommerce' ),
 				'args'        => array(
 					'format' => array(
-						'type'        => 'PostObjectFieldFormatEnum',
+						'type'        => 'PricingFieldFormatEnum',
 						'description' => __( 'Format of the field output', 'wp-graphql-woocommerce' ),
 					),
 				),


### PR DESCRIPTION
Added few missing fields on Product. [price, regularPrice, salePrice]

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Added few missing fields for product-class


Does this close any currently open issues?
------------------------------------------
No current issues have been opened.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
GrafphiQL registers these fields correctly, however resolvers on field format's need to be added to the product-class interface

Any other comments?
-------------------
TBD: update unit tests
GraphiQL errors trying to resolve salePrice and regularPrice formatted fields, but the data shows a correctly formatted field.


Where has this been tested?
---------------------------
**Operating System:** macOS Sierra 10.12.6

**WordPress Version:** 5.4.1