### PR TITLE
Fixed : missing static keyword for static variable

### DIFF
--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -27,7 +27,7 @@ class Checkout_Mutation {
 	 *
 	 * @var WC_Customer
 	 */
-	private $logged_in_customer = null;
+	private static $logged_in_customer = null;
 
 	/**
 	 * Is registration required to checkout?

--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -666,9 +666,9 @@ class Checkout_Mutation {
 		if ( is_user_logged_in() ) {
 			// Load customer object, but keep it cached to avoid reloading it multiple times.
 			if ( is_null( self::$logged_in_customer ) ) {
-				self::$logged_in_customer = new WC_Customer( get_current_user_id(), true );
+				self::$logged_in_customer = new \WC_Customer( get_current_user_id(), true );
 			}
-			$customer_object = new WC_Customer( get_current_user_id(), true );
+			$customer_object = new \WC_Customer( get_current_user_id(), true );
 		}
 
 		if ( ! $customer_object ) {


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
1. Checkout_Mutation::$logged_in_customer should be a static variable as shown 
https://github.com/wp-graphql/wp-graphql-woocommerce/blob/01df7b879b765f8cdbe90429309e0032fcb5f6aa/includes/data/mutation/class-checkout-mutation.php#L668

2. Namespace of WC_Customer is incorrect.
https://github.com/wp-graphql/wp-graphql-woocommerce/blob/01df7b879b765f8cdbe90429309e0032fcb5f6aa/includes/data/mutation/class-checkout-mutation.php#L669

Does this close any currently open issues?
------------------------------------------
#295 #296 

Where has this been tested?
---------------------------
**Operating System:** Nginx

**WordPress Version:** 5.4.1