### PR TITLE
Fixed : #303

### DIFF
--- a/includes/type/object/class-order-type.php
+++ b/includes/type/object/class-order-type.php
@@ -276,7 +276,7 @@ class Order_Type {
 						'type'        => 'Order',
 						'description' => __( 'Parent order', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $order, array $args, AppContext $context ) {
-							return Factory::resolve_crud_object( $order->parent, $context );
+							return Factory::resolve_crud_object( $order->parent_id, $context );
 						},
 					),
 					'customer'              => array(


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
`WPGraphQL\WooCommerce\Mode\Order` doesn't have `parent` field, instead `parent_id` should be used to access order's parent id in `Order` type.
https://github.com/wp-graphql/wp-graphql-woocommerce/blob/14f5316a976fd8ad38cf0e80a76a9e5d0836653c/includes/model/class-order.php#L256-L258


Does this close any currently open issues?
-----------------------------------------
#303 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
no


Any other comments?
-------------------
no


Where has this been tested?
---------------------------
**Server:** nginx php7.4.1

**WordPress Version:** 5.4.2