### PR TITLE
Fixes downloadableItems accessibility bug.

### DIFF
--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -59,7 +59,7 @@ class Order extends Crud_CPT {
 			'needsPayment',
 			'needsProcessing',
 			'hasDownloadableItem',
-			'downloadableItems',
+			'downloadable_items',
 		);
 
 		parent::__construct( $allowed_restricted_fields, 'shop_order', $id );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
- changes "downloadableItem" to "downloadable_item" is the `allowed_restricted_fields` list in the **Order** model to make the model field name.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04

**WordPress Version:** 5.4.2