### PR TITLE
Fix multiple and allow null on ACF Post Object filter causing error when querying single product 

### DIFF
--- a/includes/class-acf-schema-filters.php
+++ b/includes/class-acf-schema-filters.php
@@ -54,6 +54,10 @@ class ACF_Schema_Filters {
 	 * @return mixed|null
 	 */
 	public static function resolve_post_object_source( $source, $value ) {
+		
+		// If null of array do nothing
+		if (empty($value) || is_array($value)) return $source;
+		
 		$post = get_post( $value );
 		if ( $post instanceof \WP_Post ) {
 			switch ( $post->post_type ) {


### PR DESCRIPTION
When using Post Object relation field and enabling multiply and allowing null the code on in the file `/includes/class-acf-schema-filters.php` line 56 returns error when null value since it runs the `get_post` function with a null value and then it returns the current post.

This is a temporary fix to at least skip control if null or array. 