### PR TITLE
Add filter for DiscountTypeEnum

### DIFF
--- a/includes/type/enum/class-discount-type.php
+++ b/includes/type/enum/class-discount-type.php
@@ -16,11 +16,14 @@ class Discount_Type {
 	 * Registers type
 	 */
 	public static function register() {
-		$values = [
-			'PERCENT'       => array( 'value' => 'percent' ),
-			'FIXED_CART'    => array( 'value' => 'fixed_cart' ),
-			'FIXED_PRODUCT' => array( 'value' => 'fixed_product' ),
-		];
+		$values = apply_filters(
+			'graphql_discount_type_enum_values',
+			[
+				'PERCENT'       => array( 'value' => 'percent' ),
+				'FIXED_CART'    => array( 'value' => 'fixed_cart' ),
+				'FIXED_PRODUCT' => array( 'value' => 'fixed_product' ),
+			]
+		);
 
 		register_graphql_enum_type(
 			'DiscountTypeEnum',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This filter allows developers to extend the DiscountTypeEnum Type to prevent errors when a coupon plugin is present. 


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Example error message (when adding a coupon from Smart Coupons plugin) after running `cart.appliedCoupons.nodes` query:

```json
{
      "debugMessage": "Expected a value of type \"DiscountTypeEnum\" but received: smart_coupon",
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      }
}
```