### PR TITLE
Return connected TermObjects from the PostObjectType

### DIFF
--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -50,8 +50,7 @@ class WC_Terms extends TermObjects {
 										'fromFieldName' => $tax_object->graphql_plural_name,
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
-											$taxonomy = str_replace( ' ', '_', strtolower( $tax_object->labels->singular_name ) );
-                                            $options = $source->attributes[ $tax_object->name ]['options'];
+                                            $options  = $source->attributes[ $tax_object->name ]['options'];
 											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $options ) ? $options : array( '0' ) );
 
 											return $resolver->get_connection();

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -51,7 +51,8 @@ class WC_Terms extends TermObjects {
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
 											$taxonomy = str_replace( ' ', '_', strtolower( $tax_object->labels->singular_name ) );
-											$resolver->set_query_arg( 'term_taxonomy_id', $source->attributes[$tax_object->name]['options'] );
+                                            $options = $source->attributes[ $tax_object->name ]['options'];
+											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $options ) ? $options : array( '0' ) );
 
 											return $resolver->get_connection();
 										}

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -51,7 +51,7 @@ class WC_Terms extends TermObjects {
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
 											$taxonomy = str_replace( ' ', '_', strtolower( $tax_object->labels->singular_name ) );
-											$resolver->set_query_arg( 'term_taxonomy_id', $source->{"{$taxonomy}_ids"} );
+											$resolver->set_query_arg( 'term_taxonomy_id', $source->attributes[$tax_object->name]['options'] );
 
 											return $resolver->get_connection();
 										}


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
The current implementation `$source->{"$taxonomy}_ids"}` returns null, which results in all TermObjects getting returned, not just the connected ones.

`$tax_object` is an instance of `WP_Term`. We can use the `attributes` array of the `$source` - which returns an array of `WC_Product_Attribute` - to collect the connected ids to properly set the query args.


Does this close any currently open issues?
------------------------------------------
#345 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
See the related issue.


Any other comments?
-------------------
@kidunot89 I tried to use `$taxonomy` instead of `tax_object->name` as you suggested, but `$taxonomy` is simply a lowercase string of the `WP_Term` singular label, and not the referenced attribute name of `$source`.

$taxonomy = 'size'
tax_object->name = 'pa_size'


![image](https://user-images.githubusercontent.com/1371573/96311989-876a6880-0fbf-11eb-80ad-a1463fab0ad1.png)




Where has this been tested?
---------------------------
**WooCommerce**
3.6

**WordPress Version:**
5.2