### PR TITLE
Feature/itemized cart tax

### DIFF
--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -49,9 +49,12 @@ class WC_Terms extends TermObjects {
 										'toType'        => $tax_object->graphql_single_name,
 										'fromFieldName' => $tax_object->graphql_plural_name,
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
-											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
-                                            $options  = $source->attributes[ $tax_object->name ]['options'];
-											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $options ) ? $options : array( '0' ) );
+											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );											
+                                            
+											// Get the term ids that are associated with this $source
+											$terms = wp_list_pluck( get_the_terms( $source->ID, $tax_object->name ), 'term_id' );
+											
+											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $terms ) ? $terms : array( '0' ) );
 
 											return $resolver->get_connection();
 										}

--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -123,7 +123,7 @@ class Order extends WC_Post {
 	 *
 	 * @return bool
 	 */
-	protected function is_private() {
+	public function is_private() {
 		/**
 		 * Published content is public, not private
 		 */

--- a/includes/model/class-product-variation.php
+++ b/includes/model/class-product-variation.php
@@ -24,7 +24,7 @@ class Product_Variation extends WC_Post {
 	 * @param int $id - product_variation post-type ID.
 	 */
 	public function __construct( $id ) {
-		$data = new WC_Product_Variation( $id );
+		$data = \wc_get_product( $id );
 		parent::__construct( $data );
 	}
 

--- a/includes/model/class-wc-post.php
+++ b/includes/model/class-wc-post.php
@@ -117,4 +117,22 @@ abstract class WC_Post extends Post {
 
 		return $this->wc_data->delete( $force_delete );
 	}
+
+	/**
+	 * Returns the source WP_Post instance.
+	 *
+	 * @return \WP_Post
+	 */
+	public function as_WP_Post() {
+		return $this->data;
+	}
+
+	/**
+	 * Returns the source WC_Data instance
+	 *
+	 * @return \WC_Data
+	 */
+	public function as_WC_Data() {
+		return $this->wc_data;
+	}
 }

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -383,10 +383,10 @@ class Cart_Type {
 						},
 					),
 					'amount'   => array(
-						'type'        => 'Float',
-						'description' => __( 'Fee amount', 'wp-graphql-woocommerce' ),
+						'type'        => 'String',
+						'description' => __( 'Tax amount', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
-							return ! empty( $source->amount ) ? $source->amount : null;
+							return ! empty( $source->amount ) ? \wc_graphql_price( $source->amount ) : null;
 						},
 					),
 				),

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -25,6 +25,7 @@ class Cart_Type {
 	 */
 	public static function register() {
 		self::register_cart_fee();
+		self::register_cart_tax();
 		self::register_cart_item();
 		self::register_cart();
 	}
@@ -170,6 +171,14 @@ class Cart_Type {
 						'resolve'     => function( $source ) {
 							$price = ! is_null( $source->get_total_tax() ) ? $source->get_total_tax() : 0;
 							return \wc_graphql_price( $price );
+						},
+					),
+					'totalTaxes'								=> array(
+						'type'				=> array( 'list_of' => 'CartTax' ),
+						'description'	=> __( 'Cart total taxes itemized', 'wp-graphql-woocommerce' ),
+						'resolve'	 		=> function( $source ) {
+							$taxes = $source->get_tax_totals();
+							return ! empty( $taxes ) ? array_values( $taxes ) : null;
 						},
 					),
 					'isEmpty'                  => array(
@@ -337,6 +346,47 @@ class Cart_Type {
 						'description' => __( 'Fee total', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
 							return ! empty( $source->total ) ? $source->total : null;
+						},
+					),
+				),
+			)
+		);
+	}
+	/**
+	 * Registers CartTax type
+	 */
+	public static function register_cart_tax() {
+		register_graphql_object_type(
+			'CartTax',
+			array(
+				'description' => __( 'An itemized cart tax item', 'wp-graphql-woocommerce' ),
+				'fields'      => array(
+					'id'       => array(
+						'type'        => array( 'non_null' => 'ID' ),
+						'description' => __( 'Tax Rate ID', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->tax_rate_id ) ? $source->tax_rate_id : null;
+						},
+					),
+					'label'     => array(
+						'type'        => array( 'non_null' => 'String' ),
+						'description' => __( 'Tax label', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->label ) ? $source->label : null;
+						},
+					),
+					'isCompound'  => array(
+						'type'        => 'Boolean',
+						'description' => __( 'Is tax compound?', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->is_compound ) ? $source->is_compound : null;
+						},
+					),
+					'amount'   => array(
+						'type'        => 'Float',
+						'description' => __( 'Fee amount', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->amount ) ? $source->amount : null;
 						},
 					),
 				),

--- a/includes/type/object/class-product-types.php
+++ b/includes/type/object/class-product-types.php
@@ -52,142 +52,196 @@ class Product_Types {
 	/**
 	 * Defines fields related to product inventory.
 	 *
+	 * @param array $fields  Fields array for overwriting any of the inventory fields.
+	 *
 	 * @return array
 	 */
-	public static function get_inventory_fields() {
-		return array(
-			'manageStock'       => array(
-				'type'        => 'Boolean',
-				'description' => __( 'If product manage stock', 'wp-graphql-woocommerce' ),
+	public static function get_inventory_fields( $fields = array() ) {
+		return array_merge(
+			array(
+				'manageStock'       => array(
+					'type'        => 'Boolean',
+					'description' => __( 'If product manage stock', 'wp-graphql-woocommerce' ),
+				),
+				'stockQuantity'     => array(
+					'type'        => 'Int',
+					'description' => __( 'Number of items available for sale', 'wp-graphql-woocommerce' ),
+				),
+				'backorders'        => array(
+					'type'        => 'BackordersEnum',
+					'description' => __( 'Product backorders status', 'wp-graphql-woocommerce' ),
+				),
+				'soldIndividually'  => array(
+					'type'        => 'Boolean',
+					'description' => __( 'If should be sold individually', 'wp-graphql-woocommerce' ),
+				),
+				'backordersAllowed' => array(
+					'type'        => 'Boolean',
+					'description' => __( 'Can product be backordered?', 'wp-graphql-woocommerce' ),
+				),
+				'stockStatus'    => array(
+					'type'        => 'StockStatusEnum',
+					'description' => __( 'Product stock status', 'wp-graphql-woocommerce' ),
+				),
 			),
-			'stockQuantity'     => array(
-				'type'        => 'Int',
-				'description' => __( 'Number of items available for sale', 'wp-graphql-woocommerce' ),
-			),
-			'backorders'        => array(
-				'type'        => 'BackordersEnum',
-				'description' => __( 'Product backorders status', 'wp-graphql-woocommerce' ),
-			),
-			'soldIndividually'  => array(
-				'type'        => 'Boolean',
-				'description' => __( 'If should be sold individually', 'wp-graphql-woocommerce' ),
-			),
-			'backordersAllowed' => array(
-				'type'        => 'Boolean',
-				'description' => __( 'Can product be backordered?', 'wp-graphql-woocommerce' ),
-			),
+			$fields
 		);
 	}
 
 	/**
 	 * Defines fields related to product shipping.
 	 *
+	 * @param array $fields  Fields array for overwriting any of shipping fields.
+	 *
 	 * @return array
 	 */
-	public static function get_shipping_fields() {
-		return array(
-			'weight'           => array(
-				'type'        => 'String',
-				'description' => __( 'Product\'s weight', 'wp-graphql-woocommerce' ),
+	public static function get_shipping_fields( $fields = array() ) {
+		return array_merge(
+			array(
+				'weight'           => array(
+					'type'        => 'String',
+					'description' => __( 'Product\'s weight', 'wp-graphql-woocommerce' ),
+				),
+				'length'           => array(
+					'type'        => 'String',
+					'description' => __( 'Product\'s length', 'wp-graphql-woocommerce' ),
+				),
+				'width'            => array(
+					'type'        => 'String',
+					'description' => __( 'Product\'s width', 'wp-graphql-woocommerce' ),
+				),
+				'height'           => array(
+					'type'        => 'String',
+					'description' => __( 'Product\'s height', 'wp-graphql-woocommerce' ),
+				),
+				'shippingClassId'  => array(
+					'type'        => 'Int',
+					'description' => __( 'shipping class ID', 'wp-graphql-woocommerce' ),
+				),
+				'shippingRequired' => array(
+					'type'        => 'Boolean',
+					'description' => __( 'Does product need to be shipped?', 'wp-graphql-woocommerce' ),
+				),
+				'shippingTaxable'  => array(
+					'type'        => 'Boolean',
+					'description' => __( 'Is product shipping taxable?', 'wp-graphql-woocommerce' ),
+				),
 			),
-			'length'           => array(
-				'type'        => 'String',
-				'description' => __( 'Product\'s length', 'wp-graphql-woocommerce' ),
-			),
-			'width'            => array(
-				'type'        => 'String',
-				'description' => __( 'Product\'s width', 'wp-graphql-woocommerce' ),
-			),
-			'height'           => array(
-				'type'        => 'String',
-				'description' => __( 'Product\'s height', 'wp-graphql-woocommerce' ),
-			),
-			'shippingClassId'  => array(
-				'type'        => 'Int',
-				'description' => __( 'shipping class ID', 'wp-graphql-woocommerce' ),
-			),
-			'shippingRequired' => array(
-				'type'        => 'Boolean',
-				'description' => __( 'Does product need to be shipped?', 'wp-graphql-woocommerce' ),
-			),
-			'shippingTaxable'  => array(
-				'type'        => 'Boolean',
-				'description' => __( 'Is product shipping taxable?', 'wp-graphql-woocommerce' ),
-			),
+			$fields
 		);
 	}
 
 	/**
-	 * Defines fields not found in grouped-type products.
+	 * Defines fields related to pricing and taxes.
+	 *
+	 * @param array $fields  Fields array for overwriting any of the pricing and tax fields.
 	 *
 	 * @return array
 	 */
-	public static function get_non_grouped_fields() {
-		return array(
-			'price'        => array(
-				'type'        => 'String',
-				'description' => __( 'Product\'s active price', 'wp-graphql-woocommerce' ),
-				'args'        => array(
-					'format' => array(
-						'type'        => 'PricingFieldFormatEnum',
-						'description' => __( 'Format of the price', 'wp-graphql-woocommerce' ),
+	public static function get_pricing_and_tax_fields( $fields = array() ) {
+		return array_merge(
+			array(
+				'price'        => array(
+					'type'        => 'String',
+					'description' => __( 'Product\'s active price', 'wp-graphql-woocommerce' ),
+					'args'        => array(
+						'format' => array(
+							'type'        => 'PricingFieldFormatEnum',
+							'description' => __( 'Format of the price', 'wp-graphql-woocommerce' ),
+						),
 					),
+					'resolve'     => function( $source, $args ) {
+						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+							// @codingStandardsIgnoreLine.
+							return $source->priceRaw;
+						} else {
+							return $source->price;
+						}
+					},
 				),
-				'resolve'     => function( $source, $args ) {
-					if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-						// @codingStandardsIgnoreLine.
-						return $source->priceRaw;
-					} else {
-						return $source->price;
-					}
-				},
-			),
-			'regularPrice' => array(
-				'type'        => 'String',
-				'description' => __( 'Product\'s regular price', 'wp-graphql-woocommerce' ),
-				'args'        => array(
-					'format' => array(
-						'type'        => 'PricingFieldFormatEnum',
-						'description' => __( 'Format of the price', 'wp-graphql-woocommerce' ),
+				'regularPrice' => array(
+					'type'        => 'String',
+					'description' => __( 'Product\'s regular price', 'wp-graphql-woocommerce' ),
+					'args'        => array(
+						'format' => array(
+							'type'        => 'PricingFieldFormatEnum',
+							'description' => __( 'Format of the price', 'wp-graphql-woocommerce' ),
+						),
 					),
+					'resolve'     => function( $source, $args ) {
+						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+							// @codingStandardsIgnoreLine.
+							return $source->regularPriceRaw;
+						} else {
+							// @codingStandardsIgnoreLine.
+							return $source->regularPrice;
+						}
+					},
 				),
-				'resolve'     => function( $source, $args ) {
-					if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-						// @codingStandardsIgnoreLine.
-						return $source->regularPriceRaw;
-					} else {
-						// @codingStandardsIgnoreLine.
-						return $source->regularPrice;
-					}
-				},
-			),
-			'salePrice'    => array(
-				'type'        => 'String',
-				'description' => __( 'Product\'s sale price', 'wp-graphql-woocommerce' ),
-				'args'        => array(
-					'format' => array(
-						'type'        => 'PricingFieldFormatEnum',
-						'description' => __( 'Format of the price', 'wp-graphql-woocommerce' ),
+				'salePrice'    => array(
+					'type'        => 'String',
+					'description' => __( 'Product\'s sale price', 'wp-graphql-woocommerce' ),
+					'args'        => array(
+						'format' => array(
+							'type'        => 'PricingFieldFormatEnum',
+							'description' => __( 'Format of the price', 'wp-graphql-woocommerce' ),
+						),
 					),
+					'resolve'     => function( $source, $args ) {
+						if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
+							// @codingStandardsIgnoreLine.
+							return $source->salePriceRaw;
+						} else {
+							// @codingStandardsIgnoreLine.
+							return $source->salePrice;
+						}
+					},
 				),
-				'resolve'     => function( $source, $args ) {
-					if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-						// @codingStandardsIgnoreLine.
-						return $source->salePriceRaw;
-					} else {
-						// @codingStandardsIgnoreLine.
-						return $source->salePrice;
-					}
-				},
+				'taxStatus'    => array(
+					'type'        => 'TaxStatusEnum',
+					'description' => __( 'Tax status', 'wp-graphql-woocommerce' ),
+				),
+				'taxClass'     => array(
+					'type'        => 'TaxClassEnum',
+					'description' => __( 'Tax class', 'wp-graphql-woocommerce' ),
+				),
 			),
-			'taxStatus'    => array(
-				'type'        => 'TaxStatusEnum',
-				'description' => __( 'Tax status', 'wp-graphql-woocommerce' ),
+			$fields
+		);
+	}
+
+	/**
+	 * Defines fields related to virtual product info.
+	 *
+	 * @param array $fields  Fields array for overwriting any of the virtual data fields.
+	 *
+	 * @return array
+	 */
+	public static function get_virtual_data_fields( $fields = array() ) {
+		return array_merge(
+			array(
+				'virtual'        => array(
+					'type'        => 'Boolean',
+					'description' => __( 'Is product virtual?', 'wp-graphql-woocommerce' ),
+				),
+				'downloadExpiry' => array(
+					'type'        => 'Int',
+					'description' => __( 'Download expiry', 'wp-graphql-woocommerce' ),
+				),
+				'downloadable'   => array(
+					'type'        => 'Boolean',
+					'description' => __( 'Is downloadable?', 'wp-graphql-woocommerce' ),
+				),
+				'downloadLimit'  => array(
+					'type'        => 'Int',
+					'description' => __( 'Download limit', 'wp-graphql-woocommerce' ),
+				),
+				'downloads'      => array(
+					'type'        => array( 'list_of' => 'ProductDownload' ),
+					'description' => __( 'Product downloads', 'wp-graphql-woocommerce' ),
+				),
 			),
-			'taxClass'     => array(
-				'type'        => 'TaxClassEnum',
-				'description' => __( 'Tax class', 'wp-graphql-woocommerce' ),
-			),
+			$fields
 		);
 	}
 
@@ -202,35 +256,10 @@ class Product_Types {
 				'interfaces'  => self::get_product_interfaces(),
 				'fields'      => array_merge(
 					Product::get_fields(),
-					self::get_non_grouped_fields(),
+					self::get_pricing_and_tax_fields(),
 					self::get_inventory_fields(),
 					self::get_shipping_fields(),
-					array(
-						'virtual'        => array(
-							'type'        => 'Boolean',
-							'description' => __( 'Is product virtual?', 'wp-graphql-woocommerce' ),
-						),
-						'downloadExpiry' => array(
-							'type'        => 'Int',
-							'description' => __( 'Download expiry', 'wp-graphql-woocommerce' ),
-						),
-						'downloadable'   => array(
-							'type'        => 'Boolean',
-							'description' => __( 'Is downloadable?', 'wp-graphql-woocommerce' ),
-						),
-						'downloadLimit'  => array(
-							'type'        => 'Int',
-							'description' => __( 'Download limit', 'wp-graphql-woocommerce' ),
-						),
-						'downloads'      => array(
-							'type'        => array( 'list_of' => 'ProductDownload' ),
-							'description' => __( 'Product downloads', 'wp-graphql-woocommerce' ),
-						),
-						'stockStatus'    => array(
-							'type'        => 'StockStatusEnum',
-							'description' => __( 'Product stock status', 'wp-graphql-woocommerce' ),
-						),
-					)
+					self::get_virtual_data_fields(),
 				),
 			)
 		);
@@ -247,7 +276,7 @@ class Product_Types {
 				'interfaces'  => self::get_product_interfaces(),
 				'fields'      => array_merge(
 					Product::get_fields(),
-					self::get_non_grouped_fields(),
+					self::get_pricing_and_tax_fields(),
 					self::get_inventory_fields(),
 					self::get_shipping_fields()
 				),
@@ -266,7 +295,7 @@ class Product_Types {
 				'interfaces'  => self::get_product_interfaces(),
 				'fields'      => array_merge(
 					Product::get_fields(),
-					self::get_non_grouped_fields(),
+					self::get_pricing_and_tax_fields(),
 					array(
 						'externalUrl' => array(
 							'type'        => 'String',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

In WooCommerce Tax settings, we have the ability to [control how we display taxes](https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-11): either a single tax total, or an array of itemized tax line items.

Currently, the woographql implementation only supports the single tax total option. This PR adds support for the itemized tax display option with the following changes:

- Registers a new GraphQL object type called `CartTax` to support itemized taxes.
- Modifies the existing GraphQL object type `Cart` by adding a `totalTaxes` field.


Does this close any currently open issues?
------------------------------------------

N/A


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A


Any other comments?
-------------------

- Is this the right approach? I thought about modifying the `totalTax` field instead of creating a new `totalTaxes` field but thought that didn't provide the right flexibility. In this implementation, users who opt to display itemized taxes can still display a single `totalTax` field.
- Naming convention up for discussion. `totalTax` (existing) for singular and `totalTaxes` for itemized made sense to me.


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** v5.5.1 / WooCommerce v4.4.1