### PR TITLE
Connect terms to their source

### DIFF
--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -49,9 +49,12 @@ class WC_Terms extends TermObjects {
 										'toType'        => $tax_object->graphql_single_name,
 										'fromFieldName' => $tax_object->graphql_plural_name,
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
-											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
-                                            $options  = $source->attributes[ $tax_object->name ]['options'];
-											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $options ) ? $options : array( '0' ) );
+											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );											
+                                            
+											// Get the term ids that are associated with this $source
+											$terms = wp_list_pluck( get_the_terms( $source->ID, $tax_object->name ), 'term_id' );
+											
+											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $terms ) ? $terms : array( '0' ) );
 
 											return $resolver->get_connection();
 										}


### PR DESCRIPTION
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Ensures that connections between all products and their terms are properly connected, not just product attributes.

The previous PR (#346) mistakenly assumed that all connections were attributes. What we should be grabbing is the terms instead of the attributes.


Does this close any currently open issues?
------------------------------------------
#348 
#345 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
See issues.



Where has this been tested?
---------------------------
**WooCommerce:** 3.6
**WordPress Version:** 5.2