### PR TITLE
Fix Syntax Error in php7.2 and 7.4

### DIFF
--- a/includes/type/object/class-product-types.php
+++ b/includes/type/object/class-product-types.php
@@ -259,7 +259,7 @@ class Product_Types {
 					self::get_pricing_and_tax_fields(),
 					self::get_inventory_fields(),
 					self::get_shipping_fields(),
-					self::get_virtual_data_fields(),
+					self::get_virtual_data_fields()
 				),
 			)
 		);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Syntax error on line 262.
I remove last coma inside array_merge().


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![Screenshot 2020-10-28 225133](https://user-images.githubusercontent.com/1408634/97502188-f017f480-1972-11eb-90ed-f3c67aa6e790.png)



Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Windows 10

**WordPress Version:** 5.5.1