### PR TITLE
Fixes duplicate auto generated Connection Type names

### DIFF
--- a/includes/connection/class-coupons.php
+++ b/includes/connection/class-coupons.php
@@ -46,11 +46,11 @@ class Coupons {
 	public static function get_connection_config( $args = array() ): array {
 		$connection_config = array_merge(
 			array(
-				'fromType'           => 'RootQuery',
-				'toType'             => 'Coupon',
-				'fromFieldName'      => 'coupons',
-				'connectionArgs'     => self::get_connection_args(),
-				'resolve'            => function ( $source, $args, $context, $info ) {
+				'fromType'       => 'RootQuery',
+				'toType'         => 'Coupon',
+				'fromFieldName'  => 'coupons',
+				'connectionArgs' => self::get_connection_args(),
+				'resolve'        => function ( $source, $args, $context, $info ) {
 					return Factory::resolve_coupon_connection( $source, $args, $context, $info );
 				},
 			),

--- a/includes/connection/class-coupons.php
+++ b/includes/connection/class-coupons.php
@@ -44,18 +44,22 @@ class Coupons {
 	 * @return array
 	 */
 	public static function get_connection_config( $args = array() ): array {
-		return array_merge(
+		$connection_config = array_merge(
 			array(
-				'fromType'       => 'RootQuery',
-				'toType'         => 'Coupon',
-				'fromFieldName'  => 'coupons',
-				'connectionArgs' => self::get_connection_args(),
-				'resolve'        => function ( $source, $args, $context, $info ) {
+				'fromType'           => 'RootQuery',
+				'toType'             => 'Coupon',
+				'fromFieldName'      => 'coupons',
+				'connectionArgs'     => self::get_connection_args(),
+				'resolve'            => function ( $source, $args, $context, $info ) {
 					return Factory::resolve_coupon_connection( $source, $args, $context, $info );
 				},
 			),
 			$args
 		);
+
+		$connection_config['connectionTypeName'] = $connection_config['fromType'] . $connection_config['fromFieldName'] . 'To' . $connection_config['toType'] . 'Connection';
+
+		return $connection_config;
 	}
 
 	/**

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -312,7 +312,7 @@ class Products {
 	 * @return array
 	 */
 	public static function get_connection_config( $args = array() ): array {
-		return array_merge(
+		$connection_config = array_merge(
 			array(
 				'fromType'       => 'RootQuery',
 				'toType'         => 'Product',
@@ -324,6 +324,10 @@ class Products {
 			),
 			$args
 		);
+
+		$connection_config['connectionTypeName'] = $connection_config['fromType'] . $connection_config['fromFieldName'] . 'To' . $connection_config['toType'] . 'Connection';
+
+		return $connection_config;
 	}
 
 	/**

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -49,11 +49,11 @@ class WC_Terms extends TermObjects {
 										'toType'        => $tax_object->graphql_single_name,
 										'fromFieldName' => $tax_object->graphql_plural_name,
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
-											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );											
-                                            
+											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
+
 											// Get the term ids that are associated with this $source
 											$terms = wp_list_pluck( get_the_terms( $source->ID, $tax_object->name ), 'term_id' );
-											
+
 											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $terms ) ? $terms : array( '0' ) );
 
 											return $resolver->get_connection();
@@ -118,5 +118,23 @@ class WC_Terms extends TermObjects {
 				},
 			)
 		);
+	}
+
+	/**
+	 * Given the Taxonomy Object and an array of args, this returns an array of args for use in
+	 * registering a connection.
+	 *
+	 * @param \WP_Taxonomy $tax_object        The taxonomy object for the taxonomy having a
+	 *                                        connection registered to it
+	 * @param array        $args              The custom args to modify the connection registration
+	 *
+	 * @return array
+	 */
+	public static function get_connection_config( $tax_object, $args = [] ) {
+		$connection_config = parent::get_connection_config( $tax_object, $args );
+
+		$connection_config['connectionTypeName'] = $connection_config['fromType'] . $connection_config['fromFieldName'] . 'To' . $connection_config['toType'] . 'Connection';
+
+		return $connection_config;
 	}
 }


### PR DESCRIPTION
Fixes the duplicate Connection Type Names.

Closes Issue #356 


Where has this been tested?
---------------------------
**Operating System:** CentOS 7

**WordPress Version:** 5.5.3