### PR TITLE
Guard against false terms when plucking IDs

### DIFF
--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -61,8 +61,8 @@ class WC_Terms extends TermObjects {
 											if ( ! empty( $terms ) ) {
 												$term_ids = wp_list_pluck( $terms, 'term_id' );
 											}
-											
-											$resolver->set_query_arg( 'term_taxonomy_id', $terms_ids );
+
+											$resolver->set_query_arg( 'term_taxonomy_id', $term_ids );
 
 											return $resolver->get_connection();
 										}

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -51,8 +51,7 @@ class WC_Terms extends TermObjects {
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
 
-
-											$term_ids = \wc_get_object_terms( $object_id, $taxonomy, 'term_id' );
+											$term_ids = \wc_get_object_terms( $source->ID, $tax_object->name, 'term_id' );
 
 											$resolver->set_query_arg( 'term_taxonomy_id', $term_ids );
 

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -51,10 +51,18 @@ class WC_Terms extends TermObjects {
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );											
                                             
-											// Get the term ids that are associated with this $source
-											$terms = wp_list_pluck( get_the_terms( $source->ID, $tax_object->name ), 'term_id' );
+											// Set up the term_ids array for the query arguments.
+											$term_ids = [];
 											
-											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $terms ) ? $terms : array( '0' ) );
+											// Get the terms that are associated with this $source.
+											$terms = get_the_terms( $source->ID, $tax_object->name );
+											
+											// Extract the term ids if there are terms.
+											if ( ! empty( $terms ) ) {
+												$term_ids = wp_list_pluck( $terms, 'term_id' );
+											}
+											
+											$resolver->set_query_arg( 'term_taxonomy_id', $terms_ids );
 
 											return $resolver->get_connection();
 										}

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -51,16 +51,8 @@ class WC_Terms extends TermObjects {
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
 
-											// Set up the term_ids array for the query arguments.
-											$term_ids = [];
 
-											// Get the terms that are associated with this $source.
-											$terms = get_the_terms( $source->ID, $tax_object->name );
-
-											// Extract the term ids if there are terms.
-											if ( ! empty( $terms ) ) {
-												$term_ids = wp_list_pluck( $terms, 'term_id' );
-											}
+											$term_ids = \wc_get_object_terms( $object_id, $taxonomy, 'term_id' );
 
 											$resolver->set_query_arg( 'term_taxonomy_id', $term_ids );
 

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -49,14 +49,14 @@ class WC_Terms extends TermObjects {
 										'toType'        => $tax_object->graphql_single_name,
 										'fromFieldName' => $tax_object->graphql_plural_name,
 										'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
-											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );											
-                                            
+											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
+
 											// Set up the term_ids array for the query arguments.
 											$term_ids = [];
-											
+
 											// Get the terms that are associated with this $source.
 											$terms = get_the_terms( $source->ID, $tax_object->name );
-											
+
 											// Extract the term ids if there are terms.
 											if ( ! empty( $terms ) ) {
 												$term_ids = wp_list_pluck( $terms, 'term_id' );


### PR DESCRIPTION
`get_the_terms` can return `false`, which causes errors when running anything other than an array in `wp_list_pluck`. Related to #363.


What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes an `ErrorException Invalid argument supplied for foreach()` when we pass anything other than an array to `wp_list_pluck()` when connecting a term to a product.


Does this close any currently open issues?
------------------------------------------
#363 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
See the issue.
