### PR TITLE
Fix "set_query_arg()" overwrite logic

### DIFF
--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -584,9 +584,9 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 */
 	public function set_query_arg( $key, $value, $overwrite = false ) {
 		if ( ! empty( $this->query_args[ $key ] )
-			&& is_array( $this->query_args[ $key ] ) && $overwrite
+			&& is_array( $this->query_args[ $key ] ) && !$overwrite
 		) {
-			$this->query_args[ $key ] = array_intersect( $value, $this->query_args[ $key ] );
+			$this->query_args[ $key ][] = $value;
 		} else {
 			$this->query_args[ $key ] = $value;
 		}

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -584,7 +584,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 */
 	public function set_query_arg( $key, $value, $overwrite = false ) {
 		if ( ! empty( $this->query_args[ $key ] )
-			&& is_array( $this->query_args[ $key ] ) && !$overwrite
+			&& is_array( $this->query_args[ $key ] ) && ! $overwrite
 		) {
 			$this->query_args[ $key ][] = $value;
 		} else {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request is a proposed fix for issue #370 
The logic for the `$overwrite` is slightly modified to append query arguments instead of overwriting them. 
_(Please refer to the [issue](https://github.com/wp-graphql/wp-graphql-woocommerce/issues/370) for more details)_


Does this close any currently open issues?
------------------------------------------
#370 


Where has this been tested?
---------------------------
**Operating System:** `OSX` + `Docker`

**WordPress Version:** `5.5.3`