### PR TITLE
Guard against empty terms

### DIFF
--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -52,13 +52,8 @@ class WC_Terms extends TermObjects {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
 
 											$term_ids = \wc_get_object_terms( $source->ID, $tax_object->name, 'term_id' );
-											
-											// Guard against empty terms to prevent all terms from returning
-											if ( empty( $term_ids ) ) {
-												return;
-											}
 
-											$resolver->set_query_arg( 'term_taxonomy_id', $term_ids );
+											$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $term_ids ) ? $term_ids : array( '0' ) );
 
 											return $resolver->get_connection();
 										}

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -52,6 +52,11 @@ class WC_Terms extends TermObjects {
 											$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
 
 											$term_ids = \wc_get_object_terms( $source->ID, $tax_object->name, 'term_id' );
+											
+											// Guard against empty terms to prevent all terms from returning
+											if ( empty( $term_ids ) ) {
+												return;
+											}
 
 											$resolver->set_query_arg( 'term_taxonomy_id', $term_ids );
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Prevents returning all data for a given taxonomy when it's not associated with a product. That way if an attribute is not associated with a given product, we return `null` instead of the first `n` terms of the the taxonomy.


Does this close any currently open issues?
------------------------------------------
#372 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
See issue.


Any other comments?
-------------------
@kidunot89 perhaps I should get the term ids and return _before_ instantiating the `TermObjectConnectionResolver` class? That way we truly bail early.


Where has this been tested?
---------------------------
WP: 5.5.3
WooCommerce: 3.6
WPGraphQL: 0.13.3
WooGraphQL: develop branch