### PR TITLE
Allow multiple "orderby" fields

### DIFF
--- a/includes/data/connection/trait-wc-cpt-loader-common.php
+++ b/includes/data/connection/trait-wc-cpt-loader-common.php
@@ -87,14 +87,12 @@ trait WC_CPT_Loader_Common {
 
 					// Handle meta fields.
 				} elseif ( in_array( $orderby_input['field'], $this->ordering_meta(), true ) ) {
-					$args['orderby']  = array( 'meta_value_num' => $orderby_input['order'] );
+					$args['orderby']['meta_value_num'] = $orderby_input['order'];
 					$args['meta_key'] = esc_sql( $orderby_input['field'] ); // WPCS: slow query ok.
 
 					// Handle post object fields.
 				} elseif ( ! empty( $orderby_input['field'] ) ) {
-					$args['orderby'] = array(
-						esc_sql( $orderby_input['field'] ) => esc_sql( $orderby_input['order'] ),
-					);
+					$args['orderby'][esc_sql( $orderby_input['field'] )] = esc_sql( $orderby_input['order'] );
 				}
 			}
 		}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR allows multiple `orderby` arguments to be passed to the `WP_Query`. 


Does this close any currently open issues?
------------------------------------------
This PR addresses issue [#262](https://github.com/wp-graphql/wp-graphql-woocommerce/issues/262)


Where has this been tested?
---------------------------
**Operating System:** `OSX` + `Docker`

**WordPress Version:** `5.5.3`