### PR TITLE
Feature/itemized cart tax

### DIFF
--- a/includes/mutation/class-cart-empty.php
+++ b/includes/mutation/class-cart-empty.php
@@ -10,6 +10,7 @@
 
 namespace WPGraphQL\WooCommerce\Mutation;
 
+use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Cart_Mutation;
@@ -26,7 +27,9 @@ class Cart_Empty {
 		register_graphql_mutation(
 			'emptyCart',
 			array(
-				'inputFields'         => array(),
+				'inputFields'         => array(
+					'clearPersistentCart' => array( 'type' => 'Boolean' )
+				),
 				'outputFields'        => self::get_output_fields(),
 				'mutateAndGetPayload' => self::mutate_and_get_payload(),
 			)
@@ -44,7 +47,7 @@ class Cart_Empty {
 			'cart'        => array(
 				'type'    => 'Cart',
 				'resolve' => function () {
-					return Factory::resolve_cart();
+					return \WC()->cart;
 				},
 			)
 		);
@@ -62,6 +65,10 @@ class Cart_Empty {
 			// Get/Clone WC_Cart instance.
 			$cloned_cart = clone \WC()->cart;
 
+			if ( $cloned_cart->is_empty() ) {
+				throw new UserError( __( 'Cart is empty', 'wp-graphql-woocommerce' ) );
+			}
+
 			/**
 			 * Action fired before cart was cleared/emptied.
 			 *
@@ -73,7 +80,8 @@ class Cart_Empty {
 			do_action( 'graphql_woocommerce_before_empty_cart', $cloned_cart, $input, $context, $info );
 
 			// Empty cart.
-			\WC()->cart->empty_cart();
+			$clear_persistent_cart = ! empty( $input['clearPersistentCart'] ) ? $input['clearPersistentCart'] : true;
+			\WC()->cart->empty_cart( $clear_persistent_cart );
 
 			/**
 			 * Action fired after cart was cleared/emptied.

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -177,13 +177,8 @@ class Cart_Type {
 						'type'				=> array( 'list_of' => 'CartTax' ),
 						'description'	=> __( 'Cart total taxes itemized', 'wp-graphql-woocommerce' ),
 						'resolve'	 		=> function( $source ) {
-							try {
-								$taxes = $source->get_tax_totals();
-								return ! empty( $taxes ) ? array_values( $taxes ) : null;
-							} catch( \Exception $e ) {
-								wp_send_json( $e->getMessage() );
-							}
-
+							$taxes = $source->get_tax_totals();
+							return ! empty( $taxes ) ? array_values( $taxes ) : null;
 						},
 					),
 					'isEmpty'                  => array(

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -383,10 +383,10 @@ class Cart_Type {
 						},
 					),
 					'amount'   => array(
-						'type'        => 'Float',
-						'description' => __( 'Fee amount', 'wp-graphql-woocommerce' ),
+						'type'        => 'String',
+						'description' => __( 'Tax amount', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
-							return ! empty( $source->amount ) ? $source->amount : null;
+							return ! empty( $source->amount ) ? \wc_graphql_price( $source->amount ) : null;
 						},
 					),
 				),

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -51,7 +51,7 @@ class Cart_Type {
 						'type'        => 'String',
 						'description' => __( 'Cart subtotal tax', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
-							$price = is_null( $source->get_subtotal_tax() ) ? $source->get_subtotal_tax() : 0;
+							$price = ! is_null( $source->get_subtotal_tax() ) ? $source->get_subtotal_tax() : 0;
 							return \wc_graphql_price( $price );
 						},
 					),
@@ -177,8 +177,13 @@ class Cart_Type {
 						'type'				=> array( 'list_of' => 'CartTax' ),
 						'description'	=> __( 'Cart total taxes itemized', 'wp-graphql-woocommerce' ),
 						'resolve'	 		=> function( $source ) {
-							$taxes = $source->get_tax_totals();
-							return ! empty( $taxes ) ? array_values( $taxes ) : null;
+							try {
+								$taxes = $source->get_tax_totals();
+								return ! empty( $taxes ) ? array_values( $taxes ) : null;
+							} catch( \Exception $e ) {
+								wp_send_json( $e->getMessage() );
+							}
+
 						},
 					),
 					'isEmpty'                  => array(

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -25,6 +25,7 @@ class Cart_Type {
 	 */
 	public static function register() {
 		self::register_cart_fee();
+		self::register_cart_tax();
 		self::register_cart_item();
 		self::register_cart();
 	}
@@ -170,6 +171,14 @@ class Cart_Type {
 						'resolve'     => function( $source ) {
 							$price = ! is_null( $source->get_total_tax() ) ? $source->get_total_tax() : 0;
 							return \wc_graphql_price( $price );
+						},
+					),
+					'totalTaxes'								=> array(
+						'type'				=> array( 'list_of' => 'CartTax' ),
+						'description'	=> __( 'Cart total taxes itemized', 'wp-graphql-woocommerce' ),
+						'resolve'	 		=> function( $source ) {
+							$taxes = $source->get_tax_totals();
+							return ! empty( $taxes ) ? array_values( $taxes ) : null;
 						},
 					),
 					'isEmpty'                  => array(
@@ -337,6 +346,47 @@ class Cart_Type {
 						'description' => __( 'Fee total', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
 							return ! empty( $source->total ) ? $source->total : null;
+						},
+					),
+				),
+			)
+		);
+	}
+	/**
+	 * Registers CartTax type
+	 */
+	public static function register_cart_tax() {
+		register_graphql_object_type(
+			'CartTax',
+			array(
+				'description' => __( 'An itemized cart tax item', 'wp-graphql-woocommerce' ),
+				'fields'      => array(
+					'id'       => array(
+						'type'        => array( 'non_null' => 'ID' ),
+						'description' => __( 'Tax Rate ID', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->tax_rate_id ) ? $source->tax_rate_id : null;
+						},
+					),
+					'label'     => array(
+						'type'        => array( 'non_null' => 'String' ),
+						'description' => __( 'Tax label', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->label ) ? $source->label : null;
+						},
+					),
+					'isCompound'  => array(
+						'type'        => 'Boolean',
+						'description' => __( 'Is tax compound?', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->is_compound ) ? $source->is_compound : null;
+						},
+					),
+					'amount'   => array(
+						'type'        => 'Float',
+						'description' => __( 'Fee amount', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							return ! empty( $source->amount ) ? $source->amount : null;
 						},
 					),
 				),

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -27,14 +27,25 @@ class Root_Query {
 			array(
 				'cart'             => array(
 					'type'        => 'Cart',
+					'args'        => array(
+						'recalculateTotals' => array(
+							'type'        => 'Boolean',
+							'description' => __( 'Should cart totals be recalculated.', 'wp-graphql-woocommerce' ),
+						),
+					),
 					'description' => __( 'The cart object', 'wp-graphql-woocommerce' ),
-					'resolve'     => function() {
+					'resolve'     => function( $_, $args ) {
 						$token_invalid = apply_filters( 'graphql_woocommerce_session_token_errors', null );
 						if ( $token_invalid ) {
 							throw new UserError( $token_invalid );
 						}
 
-						return Factory::resolve_cart();
+						$cart = Factory::resolve_cart();
+						if ( ! empty( $args['recalculateTotals'] ) && $args['recalculateTotals'] ) {
+							$cart->calculate_totals();
+						}
+
+						return $cart;
 					},
 				),
 				'cartItem'         => array(

--- a/tests/_support/Helper/crud-helpers/cart.php
+++ b/tests/_support/Helper/crud-helpers/cart.php
@@ -51,6 +51,19 @@ class CartHelper extends WCG_Helper {
 			'isEmpty'                 => $cart->is_empty(),
 			'displayPricesIncludeTax' => $cart->display_prices_including_tax(),
 			'needsShippingAddress'    => $cart->needs_shipping_address(),
+			'totalTaxes'			  => ! empty( $cart->get_tax_totals() )
+				? array_map(
+					function( $tax_data ) {
+						return array(
+							'id'         => $tax_data->tax_rate_id,
+							'label'      => $tax_data->label,
+							'isCompound' => $tax_data->is_compound,
+							'amount'     => \wc_graphql_price( $tax_data->amount ),
+						);
+					},
+					array_values( $cart->get_tax_totals() )
+				)
+				: null,
 		);
 	}
 

--- a/tests/wpunit/CartQueriesTest.php
+++ b/tests/wpunit/CartQueriesTest.php
@@ -18,6 +18,26 @@ class CartQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->variation_helper = $this->getModule('\Helper\Wpunit')->product_variation();
 		$this->coupon_helper    = $this->getModule('\Helper\Wpunit')->coupon();
 		$this->helper           = $this->getModule('\Helper\Wpunit')->cart();
+		$this->tax              = $this->getModule('\Helper\Wpunit')->tax_rate();
+
+        // Turn on tax calculations. Important!
+        update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
+
+        // Create a tax rate.
+        $this->tax->create(
+            array(
+                'country'  => '',
+                'state'    => '',
+                'rate'     => 20.000,
+                'name'     => 'VAT',
+                'priority' => '1',
+                'compound' => '0',
+                'shipping' => '1',
+                'class'    => ''
+            )
+        );
 	}
 
 	public function tearDown() {
@@ -55,6 +75,12 @@ class CartQueriesTest extends \Codeception\TestCase\WPTestCase {
 					isEmpty
 					displayPricesIncludeTax
 					needsShippingAddress
+					totalTaxes {
+						id
+						isCompound
+						amount
+						label
+					}
 				}
 			}
 		';


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Extends #350 
- Added `totalTaxes` to the `CartQueriesTest::testCartQuery` test.
- Patched bug related to `cart` field in `emptyCart()` mutation
- Patched bug related to `subtotalTax` in the `Cart` object type.
- Added `clearPersistentCart` field to `emptyCartInput` type.
```
mutation {
  emptyCart( input: { clearPersistentCart: false } ) {
    ...
  }
}
```
This flag is set to `true` by default.

- Added `recalculateTotals` argument to the `cart` query.
```
query {
  cart( recalculateTotals: true ) {
    ...
  }
}
```
As the name implies it will recalculate the totals, instead of using any cached totals stored in the session data.

@ardiewen :point_up: I also rebased the branch. Great work on this :+1: 


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04

**WordPress Version:** 5.5.3