### PR TITLE
Make the username field optional in registerCustomer mutation

### DIFF
--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -43,7 +43,7 @@ class Customer_Register {
 	 * @return array
 	 */
 	public static function get_input_fields() {
-		return array_merge(
+		$result = array_merge(
 			UserRegister::get_input_fields(),
 			array(
 				'billing'               => array(
@@ -59,7 +59,12 @@ class Customer_Register {
 					'description' => __( 'Customer shipping is identical to billing address', 'wp-graphql-woocommerce' ),
 				),
 			)
-		);
+    	);
+
+		// Make the username field optional
+    	$result['username']['type'] = 'String';
+    
+    	return $result;
 	}
 
 	/**
@@ -93,9 +98,6 @@ class Customer_Register {
 	public static function mutate_and_get_payload() {
 		return function( $input, AppContext $context, ResolveInfo $info ) {
 			// Validate input.
-			if ( empty( $input['username'] ) ) {
-				throw new UserError( __( 'Please enter a valid account username.', 'wp-graphql-woocommerce' ) );
-			}
 			if ( empty( $input['email'] ) ) {
 				throw new UserError( __( 'Please provide a valid email address.', 'wp-graphql-woocommerce' ) );
 			}
@@ -116,7 +118,7 @@ class Customer_Register {
 			// Create the user using native WooCommerce function.
 			$user_id = wc_create_new_customer(
 				$user_args['user_email'],
-				$user_args['user_login'],
+				isset($user_args['user_login']) ? $user_args['user_login'] : '',
 				isset($user_args['user_pass']) ? $user_args['user_pass'] : '',
 				$user_args
 			);

--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -61,9 +61,9 @@ class Customer_Register {
 			)
     	);
 
-		// Make the username field optional
+		// Make the username field optional.
     	$result['username']['type'] = 'String';
-    
+
     	return $result;
 	}
 
@@ -116,10 +116,10 @@ class Customer_Register {
 			$user_args = UserMutation::prepare_user_object( $input, 'registerCustomer' );
 
 			// Create the user using native WooCommerce function.
-			$user_id = wc_create_new_customer(
+			$user_id = \wc_create_new_customer(
 				$user_args['user_email'],
-				isset($user_args['user_login']) ? $user_args['user_login'] : '',
-				isset($user_args['user_pass']) ? $user_args['user_pass'] : '',
+				isset( $user_args['user_login'] ) ? $user_args['user_login'] : '',
+				isset( $user_args['user_pass'] ) ? $user_args['user_pass'] : '',
 				$user_args
 			);
 

--- a/tests/wpunit/CustomerMutationsTest.php
+++ b/tests/wpunit/CustomerMutationsTest.php
@@ -201,7 +201,6 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		return $actual;
 	}
 
-	// tests
 	public function testRegisterMutationWithoutCustomerInfo() {
 		/**
 		 * Assertion One
@@ -512,6 +511,52 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 							array_intersect_key( $this->billing, $this->empty_shipping() )
 						),
 					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function testRegisterMutationWithoutAnyInfo() {
+		/**
+		 * Assertion One
+		 *
+		 * Tests mutation without a providing an username and password.
+		 */
+		$actual = $this->registerCustomer(
+			array(
+				'clientMutationId' => 'someId',
+				'email'            => $this->email,
+				'firstName'        => $this->first_name,
+				'lastName'         => $this->last_name,
+			)
+		);
+
+		// use --debug flag to view.
+		codecept_debug( $actual );
+
+		$user = get_user_by( 'email', 'peter.parker@dailybugle.com' );
+		$this->assertTrue( is_a( $user, WP_User::class ) );
+
+		$expected = array(
+			'data' => array(
+				'registerCustomer' => array(
+					'clientMutationId' => 'someId',
+					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+					'customer'         => array(
+						'databaseId' => $user->ID,
+						'email'      => $this->email,
+						'username'   => $user->user_login,
+						'firstName'  => $this->first_name,
+						'lastName'   => $this->last_name,
+						'billing'    => $this->empty_billing(),
+						'shipping'   => $this->empty_shipping(),
+					),
+					'viewer'           => array(
+						'userId' => $user->ID,
+					)
 				),
 			),
 		);


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Extends #340 
- Adds `testRegisterMutationWithoutAnyInfo` test to the `CustomerMutationsTest` test case.

@HiepVu511 :point_up: Good work on this :+1: 


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04

**WordPress Version:** 5.5.3