### PR TITLE
Return null if variation ID is falsy

### DIFF
--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -334,6 +334,10 @@ class Cart_Type {
 				'resolve'          => function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 					$id       = $source['variation_id'];
 					$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
+					
+					if ( ! $id ) {
+						return null;
+					}
 
 					return $resolver->one_to_one()
 						->set_query_arg( 'post_type', 'product_variation' )


### PR DESCRIPTION
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes an issue where the cart contents resolver returns a variation when no variation is selected (e.g. because the product is a simple product). This happens because the query generated by `Product_Connection_Resolver`'s `get_query()` method ignores the `p` argument (since it's a falsy value), which results in the query failing to filter by the post ID at all. The problem is solved by returning early in the `variation` resolver if `$variation_id` is falsy.

Does this close any currently open issues?
------------------------------------------
#399 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Operating System:** Windows 10 (WSL Ubuntu 18.04)

**WordPress Version:** 5.5.3