### PR TITLE
implements metadata for customer register and update

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -67,7 +67,7 @@ jobs:
         run: vendor/bin/php-coveralls -v
 
       - name: Test & publish code coverage
-        if: ${{ matrix.coverage == '--coverage --coverage-xml' && env.STRIPE_API_PUBLISHABLE_KEY == null }}
+        if: ${{ matrix.coverage == '--coverage --coverage-xml' }}
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: 739347fbfc0caa4e7f25069899203df2d4a411b3cbc9c3b1ef28257520c99d31

--- a/includes/data/mutation/class-customer-mutation.php
+++ b/includes/data/mutation/class-customer-mutation.php
@@ -119,6 +119,12 @@ class Customer_Mutation {
 		);
 	}
 
+	/**
+	 * Processes Customer meta data input.
+	 *
+	 * @param \WC_Customer $customer  Customer object.
+	 * @param array        $inputs    Incoming meta data.
+	 */
 	public static function input_meta_data_mapping( $customer, $inputs ) {
 		if ( is_array( $inputs ) ) {
 			foreach ( $inputs as $meta ) {

--- a/includes/data/mutation/class-customer-mutation.php
+++ b/includes/data/mutation/class-customer-mutation.php
@@ -118,4 +118,12 @@ class Customer_Mutation {
 			)
 		);
 	}
+
+	public static function input_meta_data_mapping( $customer, $inputs ) {
+		if ( is_array( $inputs ) ) {
+			foreach ( $inputs as $meta ) {
+				$customer->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+			}
+		}
+	}
 }

--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -46,12 +46,6 @@ class Customer_Register {
 		$result = array_merge(
 			UserRegister::get_input_fields(),
 			array(
-				'metaData'          => array(
-					'description' => __( 'Meta data.', 'wp-graphql-woocommerce' ),
-					'type'        => array( 'list_of' => 'MetaDataInput' ),
-				)
-			),
-			array(
 				'billing'               => array(
 					'type'        => 'CustomerAddressInput',
 					'description' => __( 'Customer billing information', 'wp-graphql-woocommerce' ),
@@ -63,6 +57,10 @@ class Customer_Register {
 				'shippingSameAsBilling' => array(
 					'type'        => 'Boolean',
 					'description' => __( 'Customer shipping is identical to billing address', 'wp-graphql-woocommerce' ),
+				),
+				'metaData'              => array(
+					'description' => __( 'Meta data.', 'wp-graphql-woocommerce' ),
+					'type'        => array( 'list_of' => 'MetaDataInput' ),
 				),
 			)
 		);
@@ -178,9 +176,9 @@ class Customer_Register {
 				}
 			}
 
-			// Set meta data
+			// Set meta data.
 			if ( ! empty( $input['metaData'] ) ) {
-				Customer_Mutation::input_meta_data_mapping($customer, $input['metaData']);
+				Customer_Mutation::input_meta_data_mapping( $customer, $input['metaData'] );
 			}
 
 			// Save customer and get customer ID.

--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -46,6 +46,12 @@ class Customer_Register {
 		$result = array_merge(
 			UserRegister::get_input_fields(),
 			array(
+				'metaData'          => array(
+					'description' => __( 'Meta data.', 'wp-graphql-woocommerce' ),
+					'type'        => array( 'list_of' => 'MetaDataInput' ),
+				)
+			),
+			array(
 				'billing'               => array(
 					'type'        => 'CustomerAddressInput',
 					'description' => __( 'Customer billing information', 'wp-graphql-woocommerce' ),
@@ -170,6 +176,11 @@ class Customer_Register {
 					$setter = 'set_shipping_' . $prop;
 					$customer->{$setter}( $value );
 				}
+			}
+
+			// Set meta data
+			if ( ! empty( $input['metaData'] ) ) {
+				Customer_Mutation::input_meta_data_mapping($customer, $input['metaData']);
 			}
 
 			// Save customer and get customer ID.

--- a/includes/mutation/class-customer-update.php
+++ b/includes/mutation/class-customer-update.php
@@ -45,12 +45,6 @@ class Customer_Update {
 		return array_merge(
 			UserCreate::get_input_fields(),
 			array(
-				'metaData'          => array(
-					'description' => __( 'Meta data.', 'wp-graphql-woocommerce' ),
-					'type'        => array( 'list_of' => 'MetaDataInput' ),
-				)
-			),
-			array(
 				'id'                    => array(
 					'type'        => 'ID',
 					'description' => __( 'The ID of the user', 'wp-graphql-woocommerce' ),
@@ -66,6 +60,10 @@ class Customer_Update {
 				'shippingSameAsBilling' => array(
 					'type'        => 'Boolean',
 					'description' => __( 'Customer shipping is identical to billing address', 'wp-graphql-woocommerce' ),
+				),
+				'metaData'              => array(
+					'description' => __( 'Meta data.', 'wp-graphql-woocommerce' ),
+					'type'        => array( 'list_of' => 'MetaDataInput' ),
 				),
 			)
 		);
@@ -142,9 +140,9 @@ class Customer_Update {
 				}
 			}
 
-			// Set meta data
+			// Set meta data.
 			if ( ! empty( $input['metaData'] ) ) {
-				Customer_Mutation::input_meta_data_mapping($customer, $input['metaData']);
+				Customer_Mutation::input_meta_data_mapping( $customer, $input['metaData'] );
 			}
 
 			// Save customer and get customer ID.

--- a/includes/mutation/class-customer-update.php
+++ b/includes/mutation/class-customer-update.php
@@ -45,6 +45,12 @@ class Customer_Update {
 		return array_merge(
 			UserCreate::get_input_fields(),
 			array(
+				'metaData'          => array(
+					'description' => __( 'Meta data.', 'wp-graphql-woocommerce' ),
+					'type'        => array( 'list_of' => 'MetaDataInput' ),
+				)
+			),
+			array(
 				'id'                    => array(
 					'type'        => 'ID',
 					'description' => __( 'The ID of the user', 'wp-graphql-woocommerce' ),
@@ -134,6 +140,11 @@ class Customer_Update {
 				} elseif ( is_callable( array( $customer, "set_{$prop}" ) ) ) {
 					$customer->{"set_{$prop}"}( $value );
 				}
+			}
+
+			// Set meta data
+			if ( ! empty( $input['metaData'] ) ) {
+				Customer_Mutation::input_meta_data_mapping($customer, $input['metaData']);
 			}
 
 			// Save customer and get customer ID.

--- a/tests/wpunit/CustomerMutationsTest.php
+++ b/tests/wpunit/CustomerMutationsTest.php
@@ -63,7 +63,13 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function tearDown(): void {
-		// your tear down methods here
+		wp_set_current_user( 0 );
+		\WC()->customer = null;
+		\WC()->session  = null;
+		\WC()->cart     = null;
+
+		\WC()->initialize_session();
+		\WC()->initialize_cart();
 
 		// then
 		parent::tearDown();

--- a/tests/wpunit/CustomerMutationsTest.php
+++ b/tests/wpunit/CustomerMutationsTest.php
@@ -563,4 +563,168 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	public function testCustomerMutationsWithMeta() {
+		/**
+		 * Assertion One
+		 *
+		 * Test "metaData" input field with "registerCustomer" mutation.
+		 */
+		$query      = '
+			mutation( $input: RegisterCustomerInput! ) {
+				registerCustomer( input: $input ) {
+					customer {
+						databaseId
+						email
+						metaData {
+							key
+							value
+						}
+					}
+				}
+			}
+		';
+		$variables = array(
+			'input' => array(
+				'clientMutationId' => 'some_id',
+				'email'            => 'user@woographql.test',
+				'metaData'         => array(
+					array(
+						'key'   => 'test_meta_key',
+						'value' => 'test_meta_value',
+					),
+				),
+			)
+		);
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		codecept_debug( $actual );
+
+		$user = get_user_by( 'email', 'user@woographql.test' );
+		$this->assertTrue( is_a( $user, WP_User::class ) );
+
+		$expected = array(
+			'data' => array(
+				'registerCustomer' => array(
+					'customer' => array(
+						'databaseId' => $user->ID,
+						'email'      => 'user@woographql.test',
+						'metaData'   => array(
+							array(
+								'key'   => 'test_meta_key',
+								'value' => 'test_meta_value',
+							)
+						)
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $actual );
+
+		/**
+		 * Assertion Two
+		 *
+		 * Test "metaData" input field with "updateCustomer" mutation.
+		 */
+		$query      = '
+			mutation( $input: UpdateCustomerInput! ) {
+				updateCustomer( input: $input ) {
+					customer {
+						databaseId
+						email
+						metaData {
+							key
+							value
+						}
+					}
+				}
+			}
+		';
+		$variables = array(
+			'input' => array(
+				'clientMutationId' => 'some_id',
+				'id'               => \GraphQLRelay\Relay::toGlobalId( 'customer', $user->ID ),
+				'metaData'         => array(
+					array(
+						'key'   => 'test_meta_key',
+						'value' => 'new_meta_value',
+					),
+				),
+			)
+		);
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		codecept_debug( $actual );
+
+		$expected = array(
+			'data' => array(
+				'updateCustomer' => array(
+					'customer' => array(
+						'databaseId' => $user->ID,
+						'email'      => 'user@woographql.test',
+						'metaData'   => array(
+							array(
+								'key'   => 'test_meta_key',
+								'value' => 'new_meta_value',
+							)
+						)
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $actual );
+
+		/**
+		 * Assertion Three
+		 *
+		 * Test "metaData" input field with "updateCustomer" mutation on the session user.
+		 */
+		$query      = '
+			mutation( $input: UpdateCustomerInput! ) {
+				updateCustomer( input: $input ) {
+					customer {
+						id
+						metaData {
+							key
+							value
+						}
+					}
+				}
+			}
+		';
+		$variables = array(
+			'input' => array(
+				'clientMutationId' => 'some_id',
+				'metaData'         => array(
+					array(
+						'key'   => 'test_meta_key',
+						'value' => 'test_meta_value',
+					),
+				),
+			)
+		);
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		codecept_debug( $actual );
+
+		$expected = array(
+			'data' => array(
+				'updateCustomer' => array(
+					'customer' => array(
+						'id'       => 'guest',
+						'metaData' => array(
+							array(
+								'key'   => 'test_meta_key',
+								'value' => 'test_meta_value',
+							)
+						)
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $actual );
+	}
 }

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -29,7 +29,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
+    'reference' => '6adfc199f4aefb3e92b0729d1312b874d452bc1e',
     'name' => 'wp-graphql/wp-graphql-woocommerce',
   ),
   'versions' => 
@@ -50,7 +50,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
+      'reference' => '6adfc199f4aefb3e92b0729d1312b874d452bc1e',
     ),
   ),
 );

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -29,7 +29,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => 'ed8338fc6abadb0140657e0fabe984596d7977dd',
+    'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
     'name' => 'wp-graphql/wp-graphql-woocommerce',
   ),
   'versions' => 
@@ -50,7 +50,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => 'ed8338fc6abadb0140657e0fabe984596d7977dd',
+      'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => 'ed8338fc6abadb0140657e0fabe984596d7977dd',
+    'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
     'name' => 'wp-graphql/wp-graphql-woocommerce',
   ),
   'versions' => 
@@ -27,7 +27,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => 'ed8338fc6abadb0140657e0fabe984596d7977dd',
+      'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
+    'reference' => '6adfc199f4aefb3e92b0729d1312b874d452bc1e',
     'name' => 'wp-graphql/wp-graphql-woocommerce',
   ),
   'versions' => 
@@ -27,7 +27,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => '81f1f9d7d8de9146489f69eb1b833d21d39b444e',
+      'reference' => '6adfc199f4aefb3e92b0729d1312b874d452bc1e',
     ),
   ),
 );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Allow Customer to include metadata in registerCustomer mutation and updateCustomer mutation


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Metadata in registerCustomer mutation
![image](https://user-images.githubusercontent.com/16539960/101964585-2d2e0280-3c12-11eb-8926-0e6ace1ee45a.png)

Metadata in customers query
![image](https://user-images.githubusercontent.com/16539960/101964674-6ebead80-3c12-11eb-9647-113998c15574.png)

Metadata in updateCustomer mutation
![image](https://user-images.githubusercontent.com/16539960/101964849-02907980-3c13-11eb-8a8d-ebf5f5972c5d.png)


Any other comments?
-------------------
Tell me if this enough and meet your requirements. Inspired by woocommerce-rest-api customer register feature


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 18.04.5

**WordPress Version:** 5.5.3