### PR TITLE
ACF Post Object filter: guard against empty post id

### DIFF
--- a/includes/class-acf-schema-filters.php
+++ b/includes/class-acf-schema-filters.php
@@ -54,7 +54,7 @@ class ACF_Schema_Filters {
 	 * @return mixed|null
 	 */
 	public static function resolve_post_object_source( $source, $value ) {
-		// Bail if $value is empty to prevent an unexpected query result
+		// Bail if $value is empty to prevent an unexpected query result.
 		if ( empty( $value ) ) {
 			return $source;
 		}

--- a/includes/class-acf-schema-filters.php
+++ b/includes/class-acf-schema-filters.php
@@ -54,6 +54,11 @@ class ACF_Schema_Filters {
 	 * @return mixed|null
 	 */
 	public static function resolve_post_object_source( $source, $value ) {
+		// Bail if $value is empty to prevent an unexpected query result
+		if ( empty( $value ) ) {
+			return $source;
+		}
+		
 		$post = get_post( $value );
 		if ( $post instanceof \WP_Post ) {
 			switch ( $post->post_type ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a guard against the post id when attempting to set the correct Type source for an ACF Post Object field. This guard will return the correct value (`null`) instead of an unexpected query result (incorrect/duplicate product/order/coupon). 

There could be instances where the post id is empty because an end-user saved an empty value in the WP admin UI. It is better to get a `null` value instead of the incorrect product/order/coupon result.

For more details, see #406

Does this close any currently open issues?
------------------------------------------
#406 