### PR TITLE
Variation image: guard against null image_id

### DIFF
--- a/includes/type/object/class-product-variation-type.php
+++ b/includes/type/object/class-product-variation-type.php
@@ -232,8 +232,7 @@ class Product_Variation_Type {
 						'type'        => 'MediaItem',
 						'description' => __( 'Product variation main image', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source, array $args, AppContext $context ) {
-							// @codingStandardsIgnoreLine
-							return DataSource::resolve_post_object( $source->image_id, $context );
+							return ! empty( $source->image_id ) ? DataSource::resolve_post_object( $source->image_id, $context ) : null;
 						},
 					),
 				),


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes an error when a variation product does not have an image. The resolver is too eager in that it doesn't check for the existence of the image_id before attempting to resolve. As a result, when a variation product does not have an image and is queried, the corresponding resolve_post_object will throw an error because it expects an int type as the first argument, not null.


Does this close any currently open issues?
------------------------------------------
#423 
