### PR TITLE
Added refund date field

### DIFF
--- a/includes/model/class-refund.php
+++ b/includes/model/class-refund.php
@@ -63,6 +63,9 @@ class Refund extends Order {
 					},
 					'capability' => 'list_users',
 				),
+				'date'           => function() {
+					return ! empty( $this->wc_data->get_date_modified() ) ? $this->wc_data->get_date_modified() : null;
+				},
 			);
 
 			$this->fields = array_merge( $this->fields, $fields );

--- a/includes/type/object/class-refund-type.php
+++ b/includes/type/object/class-refund-type.php
@@ -58,6 +58,10 @@ class Refund_Type {
 							return DataSource::resolve_user( $source->refunded_by_id, $context );
 						},
 					),
+					'date'      => array(
+						'type'        => 'String',
+						'description' => __( 'The date of the refund', 'wp-graphql-woocommerce' ),
+					),
 				),
 			)
 		);

--- a/includes/type/object/class-refund-type.php
+++ b/includes/type/object/class-refund-type.php
@@ -58,7 +58,7 @@ class Refund_Type {
 							return DataSource::resolve_user( $source->refunded_by_id, $context );
 						},
 					),
-					'date'      => array(
+					'date'       => array(
 						'type'        => 'String',
 						'description' => __( 'The date of the refund', 'wp-graphql-woocommerce' ),
 					),

--- a/tests/_support/Helper/crud-helpers/refund.php
+++ b/tests/_support/Helper/crud-helpers/refund.php
@@ -54,7 +54,8 @@ class RefundHelper extends WCG_Helper {
 			'amount'     => $data->get_amount(),
 			'refundedBy' => array(
 				'id' => Relay::toGlobalId( 'user', $data->get_refunded_by() )
-			)
+			),
+			'date'       => $data->get_date_modified(),
 		);
 	}
 
@@ -71,6 +72,7 @@ class RefundHelper extends WCG_Helper {
 			'reason'     => null,
 			'amount'     => null,
 			'refundedBy' => null,
+			'date'       => null,
 		);
 	}
 }

--- a/tests/wpunit/RefundQueriesTest.php
+++ b/tests/wpunit/RefundQueriesTest.php
@@ -44,6 +44,7 @@ class RefundQueriesTest extends \Codeception\TestCase\WPTestCase {
 					refundedBy {
 						id
 					}
+					date
 				}
 			}
 		';


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds date field to refund object. Is needed if you for example create monthly sales reports and need to see when a particular refund was made. 


Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
No

Any other comments?
-------------------
Thank you for developing this! It's an awesome solution for headless WC.

Where has this been tested?
---------------------------

- WordPress Version: 5.5.3
- Operating system: Manjaro 20.2.1


