### PR TITLE
JSON stringify string to match expectation of "extraData" on cartItem

### DIFF
--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -107,7 +107,7 @@ class Meta_Data_Type {
 						$data[] = (object) array(
 							'id'    => "{$id_prefix}_{$key}",
 							'key'   => $key,
-							'value' => is_array( $source[ $key ] ) ? JSON_ENCODE($source[ $key ]) : $source[ $key ],
+							'value' => is_array( $source[ $key ] ) ? JSON_ENCODE( $source[ $key ] ) : $source[ $key ],
 						);
 					}
 

--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -107,7 +107,7 @@ class Meta_Data_Type {
 						$data[] = (object) array(
 							'id'    => "{$id_prefix}_{$key}",
 							'key'   => $key,
-							'value' => $source[ $key ],
+							'value' => is_array( $source[ $key ] ) ? JSON_ENCODE($source[ $key ]) : $source[ $key ],
 						);
 					}
 

--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -107,7 +107,7 @@ class Meta_Data_Type {
 						$data[] = (object) array(
 							'id'    => "{$id_prefix}_{$key}",
 							'key'   => $key,
-							'value' => is_array( $source[ $key ] ) ? JSON_ENCODE( $source[ $key ] ) : $source[ $key ],
+							'value' => is_array( $source[ $key ] ) ? wp_json_encode( $source[ $key ] ) : $source[ $key ],
 						);
 					}
 


### PR DESCRIPTION
- [✅ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [✅ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [❌ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
"extraData" expects a string but receives an array or object. This bugfix JSON encodes an array so a string is returned.

Does this close any currently open issues?
------------------------------------------
This might also fix issue [437](https://github.com/wp-graphql/wp-graphql-woocommerce/issues/437). I had the same error locally and it's solved.

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
[Screenshot of GraphiQL response in wp-admin before fix](https://ibb.co/ssYgBd4)
[Screenshot of GraphiQL response in wp-admin after fix](https://ibb.co/b33rPn4)

Any other comments?
-------------------
No. Thanks for the great work :)

Where has this been tested?
---------------------------
Locally.

- **WooGraphQL Version:** 0.6.2
- **WPGraphQL Version:** 1.2.5
- **WordPress Version:** 5.6.2
- **WooCommerce Version:** 5.0.0
