### PR TITLE
Check for product_variation post type for ACF relationship resolver

### DIFF
--- a/includes/class-acf-schema-filters.php
+++ b/includes/class-acf-schema-filters.php
@@ -11,6 +11,7 @@ namespace WPGraphQL\WooCommerce;
 use WPGraphQL\WooCommerce\Model\Coupon;
 use WPGraphQL\WooCommerce\Model\Order;
 use WPGraphQL\WooCommerce\Model\Product;
+use WPGraphQL\WooCommerce\Model\Product_Variation;
 
 /**
  * Class ACF_Schema_Filters
@@ -65,6 +66,9 @@ class ACF_Schema_Filters {
 					break;
 				case 'product':
 					$source = new Product( $post->ID );
+					break;
+				case 'product_variation':
+					$source = new Product_Variation( $post->ID );
 					break;
 			}
 		}


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds a check for the `product_variation` post type when attempting to resolve the ACF relationship field. ACF allows for `product_variations`, so we need to support this post type should it come through.


Does this close any currently open issues?
------------------------------------------
#470 


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.8.1
- **WPGraphQL Version:** 1.1.8
- **WordPress Version:** 5.7
- **WooCommerce Version:** 4.9.2
