### PR TITLE
Session Transaction Manager bugfixes and enhancements

### DIFF
--- a/includes/utils/class-session-transaction-manager.php
+++ b/includes/utils/class-session-transaction-manager.php
@@ -169,7 +169,7 @@ class Session_Transaction_Manager {
 	 */
 	public function get_transaction_queue() {
 		// Get transaction queue.
-		$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->_customer_id}" );
+		$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 		if ( ! $transaction_queue ) {
 			$transaction_queue = array();
 		}
@@ -199,7 +199,7 @@ class Session_Transaction_Manager {
 		}
 
 		// Get transaction queue.
-		$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->_customer_id}" );
+		$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 
 		// Throw if transaction ID not on top.
 		if ( $this->transaction_id !== $transaction_queue[0]['transaction_id'] ) {
@@ -221,11 +221,11 @@ class Session_Transaction_Manager {
 	public function save_transaction_queue( $queue = array() ) {
 		// If queue empty delete transient and bail.
 		if ( empty( $queue ) ) {
-			delete_transient( "woo_session_transactions_queue_{$this->_customer_id}" );
+			delete_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 			return;
 		}
 
 		// Save transaction queue.
-		set_transient( "woo_session_transactions_queue_{$this->_customer_id}", $queue );
+		set_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}", $queue );
 	}
 }

--- a/includes/utils/class-session-transaction-manager.php
+++ b/includes/utils/class-session-transaction-manager.php
@@ -177,7 +177,7 @@ class Session_Transaction_Manager {
 		// If transaction ID not in queue, add it, and start transaction.
 		if ( false === array_search( $this->transaction_id, array_column( $transaction_queue, 'transaction_id' ), true ) ) {
 			$transaction_id      = $this->transaction_id;
-			$snapshot            = $this->_data;
+			$snapshot            = $this->session_handler->get_session_data();
 			$transaction_queue[] = compact( 'transaction_id', 'snapshot' );
 
 			// Update queue.


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR intends to add enhancements and bug fixes to the Session Transaction Manager. Specifically:

1. fix `null` value for `_customer_id` when setting/getting the transients. As is **all** transients are getting set to the same id. As a result, if one error occurs, that makes it an error for all subsequent requests.
2. fix `null` value when setting `$snapshot` in the transaction. `$snapshot` isn't used at the moment, but it's incorrectly getting set.
3. add a timing mechanism to prevent infinite loops after a mutation error. As is, if there's an error, the transaction hangs around and becomes stale. Subsequent request will keep looping over and over until the server crashes because there is no mechanism to invalidate the stale transaction. A filterable timestamp provides a mechanism to invalidate the stale transaction.


Does this close any currently open issues?
------------------------------------------
#494 


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.8.1
- **WPGraphQL Version:** 1.1.3
- **WordPress Version:** 5.7.1
- **WooCommerce Version:** 4.9.2
