### PR TITLE
"Coupon_Connection_Resolver" deprecated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,10 @@
         "stripe/stripe-php": "^7.75",
         "wp-coding-standards/wpcs": "^2.3",
         "wp-graphql/wp-graphql-jwt-authentication": "^0.4.1",
-        "wp-graphql/wp-graphql-testcase": "^1.0.1",
+        "wp-graphql/wp-graphql-testcase": "^1.1.1",
         "wpackagist-plugin/woocommerce": "^5.1.0",
         "wpackagist-plugin/woocommerce-gateway-stripe": "^4.5",
-        "wpackagist-plugin/wp-graphql": "^1.2.6",
+        "wpackagist-plugin/wp-graphql": "^1.3.8",
         "wpackagist-theme/twentytwentyone": "^1.0"
     },
     "config": {

--- a/includes/connection/wc-cpt-connection-args.php
+++ b/includes/connection/wc-cpt-connection-args.php
@@ -50,3 +50,75 @@ function get_wc_cpt_connection_args(): array {
 	);
 }
 
+	/**
+	 * Sanitizes common post-type connection query input.
+	 *
+	 * @param array $input  Input to be sanitize.
+	 *
+	 * @return array
+	 */
+	function map_shared_input_fields_to_wp_query( array $input, $ordering_meta = array() ) {
+		$args = array();
+		if ( ! empty( $input['include'] ) ) {
+			$args['post__in'] = $input['include'];
+		}
+
+		if ( ! empty( $input['exclude'] ) ) {
+			$args['post__not_in'] = $input['exclude'];
+		}
+
+		if ( ! empty( $input['parent'] ) ) {
+			$args['post_parent'] = $input['parent'];
+		}
+
+		if ( ! empty( $input['parentIn'] ) ) {
+			if ( ! isset( $args['post_parent__in'] ) ) {
+				$args['post_parent__in'] = array();
+			}
+			$args['post_parent__in'] = array_merge( $args['post_parent__in'], $input['parentIn'] );
+		}
+
+		if ( ! empty( $input['parentNotIn'] ) ) {
+			$args['post_parent__not_in'] = $input['parentNotIn'];
+		}
+
+		if ( ! empty( $input['search'] ) ) {
+			$args['s'] = $input['search'];
+		}
+
+		/**
+		 * Map the orderby inputArgs to the WP_Query
+		 */
+		if ( ! empty( $input['orderby'] ) && is_array( $input['orderby'] ) ) {
+			$args['orderby'] = array();
+			foreach ( $input['orderby'] as $orderby_input ) {
+				/**
+				 * These orderby options should not include the order parameter.
+				 */
+				if ( in_array(
+					$orderby_input['field'],
+					array( 'post__in', 'post_name__in', 'post_parent__in' ),
+					true
+				) ) {
+					$args['orderby'] = esc_sql( $orderby_input['field'] );
+
+					// Handle meta fields.
+				} elseif ( in_array( $orderby_input['field'], $ordering_meta, true ) ) {
+					$args['orderby']['meta_value_num'] = $orderby_input['order'];
+					$args['meta_key']                  = esc_sql( $orderby_input['field'] ); // WPCS: slow query ok.
+
+					// Handle post object fields.
+				} elseif ( ! empty( $orderby_input['field'] ) ) {
+					$args['orderby'][ esc_sql( $orderby_input['field'] ) ] = esc_sql( $orderby_input['order'] );
+				}
+			}
+		}
+
+		if ( ! empty( $input['dateQuery'] ) ) {
+			$args['date_query'] = $input['dateQuery'];
+		}
+
+		return $args;
+	}
+
+

--- a/includes/data/connection/class-coupon-connection-resolver.php
+++ b/includes/data/connection/class-coupon-connection-resolver.php
@@ -18,6 +18,8 @@ use WPGraphQL\Extension\WooCommerce\Model\Coupon;
 
 /**
  * Class Coupon_Connection_Resolver
+ *
+ * @deprecated v0.10.0
  */
 class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 	/**

--- a/tests/_support/TestCase/WooGraphQLTestCase.php
+++ b/tests/_support/TestCase/WooGraphQLTestCase.php
@@ -78,4 +78,21 @@ class WooGraphQLTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		wp_set_current_user( 0 );
 	}
 
+	/**
+	 * The death of `! empty( $v ) ? apply_filters( $v ) : null;`
+	 *
+	 * @param array|mixed $possible   Variable whose existence has to be verified, or
+	 * an array containing the variable followed by a decorated value to be returned.
+	 * @param mixed       $default    Default value to be returned if $possible doesn't exist.
+	 *
+	 * @return mixed
+	 */
+	protected function maybe( $possible, $default = null ) {
+		if ( is_array( $possible ) && 2 === count( $possible ) ) {
+			list( $possible, $decorated ) = $possible;
+		} else {
+			$decorated = $possible;
+		}
+		return ! empty( $possible ) ? $decorated : $default;
+	}
 }

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -1,24 +1,6 @@
 <?php
 class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
 
-	/**
-	 * The death of `! empty( $v ) ? apply_filters( $v ) : null;`
-	 *
-	 * @param array|mixed $possible   Variable whose existence has to be verified, or
-	 * an array containing the variable followed by a decorated value to be returned.
-	 * @param mixed       $default    Default value to be returned if $possible doesn't exist.
-	 *
-	 * @return mixed
-	 */
-	private function maybe( $possible, $default = null ) {
-		if ( is_array( $possible ) && 2 === count( $possible ) ) {
-			list( $possible, $decorated ) = $possible;
-		} else {
-			$decorated = $possible;
-		}
-		return ! empty( $possible ) ? $decorated : $default;
-	}
-
 	public function getExpectedProductData( $product_id ) {
 		$product         = \wc_get_product( $product_id );
 		$is_shop_manager = false;

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -42,6 +42,8 @@ namespace Composer\Autoload;
  */
 class ClassLoader
 {
+    private $vendorDir;
+
     // PSR-4
     private $prefixLengthsPsr4 = array();
     private $prefixDirsPsr4 = array();
@@ -56,6 +58,13 @@ class ClassLoader
     private $classMapAuthoritative = false;
     private $missingClasses = array();
     private $apcuPrefix;
+
+    private static $registeredLoaders = array();
+
+    public function __construct($vendorDir = null)
+    {
+        $this->vendorDir = $vendorDir;
+    }
 
     public function getPrefixes()
     {
@@ -300,6 +309,17 @@ class ClassLoader
     public function register($prepend = false)
     {
         spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+
+        if (null === $this->vendorDir) {
+            return;
+        }
+
+        if ($prepend) {
+            self::$registeredLoaders = array($this->vendorDir => $this) + self::$registeredLoaders;
+        } else {
+            unset(self::$registeredLoaders[$this->vendorDir]);
+            self::$registeredLoaders[$this->vendorDir] = $this;
+        }
     }
 
     /**
@@ -308,6 +328,10 @@ class ClassLoader
     public function unregister()
     {
         spl_autoload_unregister(array($this, 'loadClass'));
+
+        if (null !== $this->vendorDir) {
+            unset(self::$registeredLoaders[$this->vendorDir]);
+        }
     }
 
     /**
@@ -365,6 +389,16 @@ class ClassLoader
         }
 
         return $file;
+    }
+
+    /**
+     * Returns the currently registered loaders indexed by their corresponding vendor directories.
+     *
+     * @return self[]
+     */
+    public static function getRegisteredLoaders()
+    {
+        return self::$registeredLoaders;
     }
 
     private function findFileWithExtension($class, $ext)

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -12,6 +12,7 @@
 
 namespace Composer;
 
+use Composer\Autoload\ClassLoader;
 use Composer\Semver\VersionParser;
 
 
@@ -24,12 +25,12 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => '6ac01352b699d0922262da887bb9048c5340ff08',
+    'reference' => '312e9ce978f8a61ff546016962b2d093b3cf4d00',
     'name' => 'wp-graphql/wp-graphql-woocommerce',
   ),
   'versions' => 
@@ -45,15 +46,17 @@ private static $installed = array (
     ),
     'wp-graphql/wp-graphql-woocommerce' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => '6ac01352b699d0922262da887bb9048c5340ff08',
+      'reference' => '312e9ce978f8a61ff546016962b2d093b3cf4d00',
     ),
   ),
 );
+private static $canGetVendors;
+private static $installedByVendor = array();
 
 
 
@@ -63,7 +66,17 @@ private static $installed = array (
 
 public static function getInstalledPackages()
 {
-return array_keys(self::$installed['versions']);
+$packages = array();
+foreach (self::getInstalled() as $installed) {
+$packages[] = array_keys($installed['versions']);
+}
+
+
+if (1 === \count($packages)) {
+return $packages[0];
+}
+
+return array_keys(array_flip(\call_user_func_array('array_merge', $packages)));
 }
 
 
@@ -76,7 +89,13 @@ return array_keys(self::$installed['versions']);
 
 public static function isInstalled($packageName)
 {
-return isset(self::$installed['versions'][$packageName]);
+foreach (self::getInstalled() as $installed) {
+if (isset($installed['versions'][$packageName])) {
+return true;
+}
+}
+
+return false;
 }
 
 
@@ -111,25 +130,29 @@ return $provided->matches($constraint);
 
 public static function getVersionRanges($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
 $ranges = array();
-if (isset(self::$installed['versions'][$packageName]['pretty_version'])) {
-$ranges[] = self::$installed['versions'][$packageName]['pretty_version'];
+if (isset($installed['versions'][$packageName]['pretty_version'])) {
+$ranges[] = $installed['versions'][$packageName]['pretty_version'];
 }
-if (array_key_exists('aliases', self::$installed['versions'][$packageName])) {
-$ranges = array_merge($ranges, self::$installed['versions'][$packageName]['aliases']);
+if (array_key_exists('aliases', $installed['versions'][$packageName])) {
+$ranges = array_merge($ranges, $installed['versions'][$packageName]['aliases']);
 }
-if (array_key_exists('replaced', self::$installed['versions'][$packageName])) {
-$ranges = array_merge($ranges, self::$installed['versions'][$packageName]['replaced']);
+if (array_key_exists('replaced', $installed['versions'][$packageName])) {
+$ranges = array_merge($ranges, $installed['versions'][$packageName]['replaced']);
 }
-if (array_key_exists('provided', self::$installed['versions'][$packageName])) {
-$ranges = array_merge($ranges, self::$installed['versions'][$packageName]['provided']);
+if (array_key_exists('provided', $installed['versions'][$packageName])) {
+$ranges = array_merge($ranges, $installed['versions'][$packageName]['provided']);
 }
 
 return implode(' || ', $ranges);
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -138,15 +161,19 @@ return implode(' || ', $ranges);
 
 public static function getVersion($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
-if (!isset(self::$installed['versions'][$packageName]['version'])) {
+if (!isset($installed['versions'][$packageName]['version'])) {
 return null;
 }
 
-return self::$installed['versions'][$packageName]['version'];
+return $installed['versions'][$packageName]['version'];
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -155,15 +182,19 @@ return self::$installed['versions'][$packageName]['version'];
 
 public static function getPrettyVersion($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
-if (!isset(self::$installed['versions'][$packageName]['pretty_version'])) {
+if (!isset($installed['versions'][$packageName]['pretty_version'])) {
 return null;
 }
 
-return self::$installed['versions'][$packageName]['pretty_version'];
+return $installed['versions'][$packageName]['pretty_version'];
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -172,15 +203,19 @@ return self::$installed['versions'][$packageName]['pretty_version'];
 
 public static function getReference($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
-if (!isset(self::$installed['versions'][$packageName]['reference'])) {
+if (!isset($installed['versions'][$packageName]['reference'])) {
 return null;
 }
 
-return self::$installed['versions'][$packageName]['reference'];
+return $installed['versions'][$packageName]['reference'];
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -189,7 +224,9 @@ return self::$installed['versions'][$packageName]['reference'];
 
 public static function getRootPackage()
 {
-return self::$installed['root'];
+$installed = self::getInstalled();
+
+return $installed[0]['root'];
 }
 
 
@@ -224,5 +261,32 @@ return self::$installed;
 public static function reload($data)
 {
 self::$installed = $data;
+self::$installedByVendor = array();
+}
+
+
+
+
+private static function getInstalled()
+{
+if (null === self::$canGetVendors) {
+self::$canGetVendors = method_exists('Composer\Autoload\ClassLoader', 'getRegisteredLoaders');
+}
+
+$installed = array();
+
+if (self::$canGetVendors) {
+foreach (ClassLoader::getRegisteredLoaders() as $vendorDir => $loader) {
+if (isset(self::$installedByVendor[$vendorDir])) {
+$installed[] = self::$installedByVendor[$vendorDir];
+} elseif (is_file($vendorDir.'/composer/installed.php')) {
+$installed[] = self::$installedByVendor[$vendorDir] = require $vendorDir.'/composer/installed.php';
+}
+}
+}
+
+$installed[] = self::$installed;
+
+return $installed;
 }
 }

--- a/vendor/composer/autoload_real.php
+++ b/vendor/composer/autoload_real.php
@@ -25,7 +25,7 @@ class ComposerAutoloaderInit6c77413f58088c2fdac4123439a6431a
         require __DIR__ . '/platform_check.php';
 
         spl_autoload_register(array('ComposerAutoloaderInit6c77413f58088c2fdac4123439a6431a', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(\dirname(__FILE__)));
         spl_autoload_unregister(array('ComposerAutoloaderInit6c77413f58088c2fdac4123439a6431a', 'loadClassLoader'));
 
         $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,12 +1,12 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => '6ac01352b699d0922262da887bb9048c5340ff08',
+    'reference' => '312e9ce978f8a61ff546016962b2d093b3cf4d00',
     'name' => 'wp-graphql/wp-graphql-woocommerce',
   ),
   'versions' => 
@@ -22,12 +22,12 @@
     ),
     'wp-graphql/wp-graphql-woocommerce' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => '6ac01352b699d0922262da887bb9048c5340ff08',
+      'reference' => '312e9ce978f8a61ff546016962b2d093b3cf4d00',
     ),
   ),
 );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- **Coupon_Connection_Resolver** class deprecated and will be removed in release **v0.11.x**. The "PostObjectConnectionResolver" class and the hooks contained within are used in it's place. Any remaining unique code in-use has be relocated to the `class-coupons.php`. 
- **CouponQueriesTest.php` has be refactored to use the WPGraphQLTestcase library.  


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.8.1
- **WPGraphQL Version:** 1.3.8
- **WordPress Version:** 5.7.2
- **WooCommerce Version:** 5.3
