### PR TITLE
Update class-checkout-mutation.php

### DIFF
--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -174,7 +174,7 @@ class Checkout_Mutation {
 	 *
 	 * @param array $data Order data.
 	 */
-	protected function update_session( $data ) {
+	protected static function update_session( $data ) {
 		// Update both shipping and billing to the passed billing address first if set.
 		$address_fields = array(
 			'first_name',


### PR DESCRIPTION
Static Keyword missing

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Got this Error on Checkout Mutation:
debugMessage: "Non-static method WPGraphQL\\WooCommerce\\Data\\Mutation\\Checkout_Mutation::update_session() cannot be called statically"

PHP Version 8


Does this close any currently open issues?
------------------------------------------
#472


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
