### PR TITLE
Feature: Checkout mutation stripe payment intent secret (3D secure)

### DIFF
--- a/includes/mutation/class-checkout.php
+++ b/includes/mutation/class-checkout.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Mutation - checkout
  *
@@ -22,12 +23,14 @@ use Exception;
 /**
  * Class Checkout
  */
-class Checkout {
+class Checkout
+{
 
 	/**
 	 * Registers mutation
 	 */
-	public static function register_mutation() {
+	public static function register_mutation()
+	{
 		register_graphql_mutation(
 			'checkout',
 			array(
@@ -43,47 +46,48 @@ class Checkout {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields()
+	{
 		return array(
 			'paymentMethod'          => array(
 				'type'        => 'String',
-				'description' => __( 'Payment method ID.', 'wp-graphql-woocommerce' ),
+				'description' => __('Payment method ID.', 'wp-graphql-woocommerce'),
 			),
 			'shippingMethod'         => array(
-				'type'        => array( 'list_of' => 'String' ),
-				'description' => __( 'Order shipping method', 'wp-graphql-woocommerce' ),
+				'type'        => array('list_of' => 'String'),
+				'description' => __('Order shipping method', 'wp-graphql-woocommerce'),
 			),
 			'shipToDifferentAddress' => array(
 				'type'        => 'Boolean',
-				'description' => __( 'Ship to a separate address', 'wp-graphql-woocommerce' ),
+				'description' => __('Ship to a separate address', 'wp-graphql-woocommerce'),
 			),
 			'billing'                => array(
 				'type'        => 'CustomerAddressInput',
-				'description' => __( 'Order billing address', 'wp-graphql-woocommerce' ),
+				'description' => __('Order billing address', 'wp-graphql-woocommerce'),
 			),
 			'shipping'               => array(
 				'type'        => 'CustomerAddressInput',
-				'description' => __( 'Order shipping address', 'wp-graphql-woocommerce' ),
+				'description' => __('Order shipping address', 'wp-graphql-woocommerce'),
 			),
 			'account'                => array(
 				'type'        => 'CreateAccountInput',
-				'description' => __( 'Create new customer account', 'wp-graphql-woocommerce' ),
+				'description' => __('Create new customer account', 'wp-graphql-woocommerce'),
 			),
 			'transactionId'          => array(
 				'type'        => 'String',
-				'description' => __( 'Order transaction ID', 'wp-graphql-woocommerce' ),
+				'description' => __('Order transaction ID', 'wp-graphql-woocommerce'),
 			),
 			'isPaid'                 => array(
 				'type'        => 'Boolean',
-				'description' => __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'wp-graphql-woocommerce' ),
+				'description' => __('Define if the order is paid. It will set the status to processing and reduce stock items.', 'wp-graphql-woocommerce'),
 			),
 			'metaData'               => array(
-				'type'        => array( 'list_of' => 'MetaDataInput' ),
-				'description' => __( 'Order meta data', 'wp-graphql-woocommerce' ),
+				'type'        => array('list_of' => 'MetaDataInput'),
+				'description' => __('Order meta data', 'wp-graphql-woocommerce'),
 			),
 			'customerNote'           => array(
 				'type'        => 'String',
-				'description' => __( 'Order customer note', 'wp-graphql-woocommerce' ),
+				'description' => __('Order customer note', 'wp-graphql-woocommerce'),
 			),
 		);
 	}
@@ -93,30 +97,37 @@ class Checkout {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields()
+	{
 		return array(
 			'order'    => array(
 				'type'    => 'Order',
-				'resolve' => function( $payload ) {
-					return new Order( $payload['id'] );
+				'resolve' => function ($payload) {
+					return new Order($payload['id']);
 				},
 			),
 			'customer' => array(
 				'type'    => 'Customer',
-				'resolve' => function() {
-					return is_user_logged_in() ? new Customer( get_current_user_id() ) : null;
+				'resolve' => function () {
+					return is_user_logged_in() ? new Customer(get_current_user_id()) : null;
 				},
 			),
 			'result'   => array(
 				'type'    => 'String',
-				'resolve' => function( $payload ) {
+				'resolve' => function ($payload) {
 					return $payload['result'];
 				},
 			),
 			'redirect' => array(
 				'type'    => 'String',
-				'resolve' => function( $payload ) {
+				'resolve' => function ($payload) {
 					return $payload['redirect'];
+				},
+			),
+			'paymentIntentSecret' => array(
+				'type'    => 'String',
+				'resolve' => function ($payload) {
+					return $payload['payment_intent_secret'];
 				},
 			),
 		);
@@ -127,12 +138,13 @@ class Checkout {
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+	public static function mutate_and_get_payload()
+	{
+		return function ($input, AppContext $context, ResolveInfo $info) {
 			// Create order.
 			$order = null;
 			try {
-				$args = Checkout_Mutation::prepare_checkout_args( $input, $context, $info );
+				$args = Checkout_Mutation::prepare_checkout_args($input, $context, $info);
 
 				/**
 				 * Action called before checking out.
@@ -142,12 +154,12 @@ class Checkout {
 				 * @param AppContext  $context Request AppContext instance.
 				 * @param ResolveInfo $info    Request ResolveInfo instance.
 				 */
-				do_action( 'graphql_woocommerce_before_checkout', $args, $input, $context, $info );
+				do_action('graphql_woocommerce_before_checkout', $args, $input, $context, $info);
 
-				$order_id = Checkout_Mutation::process_checkout( $args, $input, $context, $info, $results );
+				$order_id = Checkout_Mutation::process_checkout($args, $input, $context, $info, $results);
 
-				if ( is_wp_error( $order_id ) ) {
-					throw new UserError( $order_id->get_error_message( 'checkout-error' ) );
+				if (is_wp_error($order_id)) {
+					throw new UserError($order_id->get_error_message('checkout-error'));
 				}
 
 				/**
@@ -158,12 +170,12 @@ class Checkout {
 				 * @param AppContext  $context Request AppContext instance.
 				 * @param ResolveInfo $info    Request ResolveInfo instance.
 				 */
-				do_action( 'graphql_woocommerce_after_checkout', $order_id, $input, $context, $info );
+				do_action('graphql_woocommerce_after_checkout', $order_id, $input, $context, $info);
 
-				return array_merge( array( 'id' => $order_id ), $results );
-			} catch ( Exception $e ) {
-				Order_Mutation::purge( $order );
-				throw new UserError( $e->getMessage() );
+				return array_merge(array('id' => $order_id), $results);
+			} catch (Exception $e) {
+				Order_Mutation::purge($order);
+				throw new UserError($e->getMessage());
 			}
 		};
 	}

--- a/includes/mutation/class-checkout.php
+++ b/includes/mutation/class-checkout.php
@@ -23,14 +23,13 @@ use Exception;
 /**
  * Class Checkout
  */
-class Checkout
-{
+class Checkout {
+
 
 	/**
 	 * Registers mutation
 	 */
-	public static function register_mutation()
-	{
+	public static function register_mutation() {
 		register_graphql_mutation(
 			'checkout',
 			array(
@@ -46,50 +45,49 @@ class Checkout
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields()
-	{
-		return array(
-			'paymentMethod'          => array(
-				'type'        => 'String',
-				'description' => __('Payment method ID.', 'wp-graphql-woocommerce'),
-			),
-			'shippingMethod'         => array(
-				'type'        => array('list_of' => 'String'),
-				'description' => __('Order shipping method', 'wp-graphql-woocommerce'),
-			),
-			'shipToDifferentAddress' => array(
-				'type'        => 'Boolean',
-				'description' => __('Ship to a separate address', 'wp-graphql-woocommerce'),
-			),
-			'billing'                => array(
-				'type'        => 'CustomerAddressInput',
-				'description' => __('Order billing address', 'wp-graphql-woocommerce'),
-			),
-			'shipping'               => array(
-				'type'        => 'CustomerAddressInput',
-				'description' => __('Order shipping address', 'wp-graphql-woocommerce'),
-			),
-			'account'                => array(
-				'type'        => 'CreateAccountInput',
-				'description' => __('Create new customer account', 'wp-graphql-woocommerce'),
-			),
-			'transactionId'          => array(
-				'type'        => 'String',
-				'description' => __('Order transaction ID', 'wp-graphql-woocommerce'),
-			),
-			'isPaid'                 => array(
-				'type'        => 'Boolean',
-				'description' => __('Define if the order is paid. It will set the status to processing and reduce stock items.', 'wp-graphql-woocommerce'),
-			),
-			'metaData'               => array(
-				'type'        => array('list_of' => 'MetaDataInput'),
-				'description' => __('Order meta data', 'wp-graphql-woocommerce'),
-			),
-			'customerNote'           => array(
-				'type'        => 'String',
-				'description' => __('Order customer note', 'wp-graphql-woocommerce'),
-			),
-		);
+	public static function get_input_fields() {
+		 return array(
+			 'paymentMethod'          => array(
+				 'type'        => 'String',
+				 'description' => __( 'Payment method ID.', 'wp-graphql-woocommerce' ),
+			 ),
+			 'shippingMethod'         => array(
+				 'type'        => array( 'list_of' => 'String' ),
+				 'description' => __( 'Order shipping method', 'wp-graphql-woocommerce' ),
+			 ),
+			 'shipToDifferentAddress' => array(
+				 'type'        => 'Boolean',
+				 'description' => __( 'Ship to a separate address', 'wp-graphql-woocommerce' ),
+			 ),
+			 'billing'                => array(
+				 'type'        => 'CustomerAddressInput',
+				 'description' => __( 'Order billing address', 'wp-graphql-woocommerce' ),
+			 ),
+			 'shipping'               => array(
+				 'type'        => 'CustomerAddressInput',
+				 'description' => __( 'Order shipping address', 'wp-graphql-woocommerce' ),
+			 ),
+			 'account'                => array(
+				 'type'        => 'CreateAccountInput',
+				 'description' => __( 'Create new customer account', 'wp-graphql-woocommerce' ),
+			 ),
+			 'transactionId'          => array(
+				 'type'        => 'String',
+				 'description' => __( 'Order transaction ID', 'wp-graphql-woocommerce' ),
+			 ),
+			 'isPaid'                 => array(
+				 'type'        => 'Boolean',
+				 'description' => __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'wp-graphql-woocommerce' ),
+			 ),
+			 'metaData'               => array(
+				 'type'        => array( 'list_of' => 'MetaDataInput' ),
+				 'description' => __( 'Order meta data', 'wp-graphql-woocommerce' ),
+			 ),
+			 'customerNote'           => array(
+				 'type'        => 'String',
+				 'description' => __( 'Order customer note', 'wp-graphql-woocommerce' ),
+			 ),
+		 );
 	}
 
 	/**
@@ -97,36 +95,35 @@ class Checkout
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields()
-	{
+	public static function get_output_fields() {
 		return array(
-			'order'    => array(
+			'order'               => array(
 				'type'    => 'Order',
-				'resolve' => function ($payload) {
-					return new Order($payload['id']);
+				'resolve' => function ( $payload ) {
+					return new Order( $payload['id'] );
 				},
 			),
-			'customer' => array(
+			'customer'            => array(
 				'type'    => 'Customer',
 				'resolve' => function () {
-					return is_user_logged_in() ? new Customer(get_current_user_id()) : null;
+					return is_user_logged_in() ? new Customer( get_current_user_id() ) : null;
 				},
 			),
-			'result'   => array(
+			'result'              => array(
 				'type'    => 'String',
-				'resolve' => function ($payload) {
+				'resolve' => function ( $payload ) {
 					return $payload['result'];
 				},
 			),
-			'redirect' => array(
+			'redirect'            => array(
 				'type'    => 'String',
-				'resolve' => function ($payload) {
+				'resolve' => function ( $payload ) {
 					return $payload['redirect'];
 				},
 			),
 			'paymentIntentSecret' => array(
 				'type'    => 'String',
-				'resolve' => function ($payload) {
+				'resolve' => function ( $payload ) {
 					return $payload['payment_intent_secret'];
 				},
 			),
@@ -138,28 +135,27 @@ class Checkout
 	 *
 	 * @return callable
 	 */
-	public static function mutate_and_get_payload()
-	{
-		return function ($input, AppContext $context, ResolveInfo $info) {
+	public static function mutate_and_get_payload() {
+		return function ( $input, AppContext $context, ResolveInfo $info ) {
 			// Create order.
 			$order = null;
 			try {
-				$args = Checkout_Mutation::prepare_checkout_args($input, $context, $info);
+				  $args = Checkout_Mutation::prepare_checkout_args( $input, $context, $info );
 
-				/**
-				 * Action called before checking out.
-				 *
-				 * @param array       $args    Order data.
-				 * @param array       $input   Raw input data .
-				 * @param AppContext  $context Request AppContext instance.
-				 * @param ResolveInfo $info    Request ResolveInfo instance.
-				 */
-				do_action('graphql_woocommerce_before_checkout', $args, $input, $context, $info);
+				  /**
+				   * Action called before checking out.
+				   *
+				   * @param array       $args    Order data.
+				   * @param array       $input   Raw input data .
+				   * @param AppContext  $context Request AppContext instance.
+				   * @param ResolveInfo $info    Request ResolveInfo instance.
+				   */
+				  do_action( 'graphql_woocommerce_before_checkout', $args, $input, $context, $info );
 
-				$order_id = Checkout_Mutation::process_checkout($args, $input, $context, $info, $results);
+				  $order_id = Checkout_Mutation::process_checkout( $args, $input, $context, $info, $results );
 
-				if (is_wp_error($order_id)) {
-					throw new UserError($order_id->get_error_message('checkout-error'));
+				if ( is_wp_error( $order_id ) ) {
+					throw new UserError( $order_id->get_error_message( 'checkout-error' ) );
 				}
 
 				/**
@@ -170,12 +166,12 @@ class Checkout
 				 * @param AppContext  $context Request AppContext instance.
 				 * @param ResolveInfo $info    Request ResolveInfo instance.
 				 */
-				do_action('graphql_woocommerce_after_checkout', $order_id, $input, $context, $info);
+				do_action( 'graphql_woocommerce_after_checkout', $order_id, $input, $context, $info );
 
-				return array_merge(array('id' => $order_id), $results);
-			} catch (Exception $e) {
-				Order_Mutation::purge($order);
-				throw new UserError($e->getMessage());
+				return array_merge( array( 'id' => $order_id ), $results );
+			} catch ( Exception $e ) {
+				 Order_Mutation::purge( $order );
+				 throw new UserError( $e->getMessage() );
 			}
 		};
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In Europe, you need to verify payments with 3D Secure. The problem however is that the check-out mutation returns nothing that one can use to validate the payment. Added a "paymentIntentSecret" field to return fields of the said mutation so that the developers can fetch info about the paymentIntent on the frontend.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
![Screenshot 2021-06-21 at 10 18 34](https://user-images.githubusercontent.com/9382870/122730010-0fed8700-d27a-11eb-8902-eb6877a342ac.png)

Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.10.0
- **WPGraphQL Version:** 1.4.3
- **WordPress Version:** 5.7.2
- **WooCommerce Version:** 5.4.1
