### PR TITLE
CartItem Product edge field "simpleAttributes" implemented and tested.

### DIFF
--- a/bin/_env.sh
+++ b/bin/_env.sh
@@ -1,3 +1,5 @@
+set +u
+
 if [[ -z "$DB_NAME" ]]; then
 	echo "DB_NAME not found"
 	print_usage_instruction
@@ -10,7 +12,7 @@ fi
 DB_HOST=${DB_HOST-localhost}
 DB_PASS=${DB_PASSWORD-""}
 WP_VERSION=${WP_VERSION-5}
-PHPUNIT_VERSION=${PHPUNIT_VERSION-8.1}
+PHPUNIT_VERSION=${PHPUNIT_VERSION-"<=8.1"}
 PROJECT_ROOT_DIR=$(pwd)
 WP_CORE_DIR=${WP_CORE_DIR:-local/public}
 PLUGINS_DIR=${PLUGINS_DIR:-"$WP_CORE_DIR/wp-content/plugins"}

--- a/bin/_lib.sh
+++ b/bin/_lib.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set +u
+
 install_wordpress() {
 	if [ -f $WP_CORE_DIR/wp-config.php ]; then
 		echo "Wordpress already installed."
@@ -47,7 +49,7 @@ remove_wordpress() {
 install_local_test_library() {
 	# Install testing library dependencies.
 	composer install
-	composer require --dev phpunit/phpunit:<=${PHPUNIT_VERSION}
+	composer require --dev phpunit/phpunit:${PHPUNIT_VERSION} \
 		lucatume/wp-browser \
 		codeception/module-asserts \
 		codeception/module-rest \

--- a/includes/class-type-registry.php
+++ b/includes/class-type-registry.php
@@ -60,6 +60,7 @@ class Type_Registry {
 
 		// Interfaces.
 		\WPGraphQL\WooCommerce\Type\WPInterface\Product::register_interface( $type_registry );
+		\WPGraphQL\WooCommerce\Type\WPInterface\Attribute::register_interface( $type_registry );
 		\WPGraphQL\WooCommerce\Type\WPInterface\Product_Attribute::register_interface( $type_registry );
 		\WPGraphQL\WooCommerce\Type\WPInterface\Cart_Error::register_interface( $type_registry );
 
@@ -78,6 +79,7 @@ class Type_Registry {
 		\WPGraphQL\WooCommerce\Type\WPObject\Tax_Rate_Type::register();
 		\WPGraphQL\WooCommerce\Type\WPObject\Shipping_Method_Type::register();
 		\WPGraphQL\WooCommerce\Type\WPObject\Cart_Type::register();
+		\WPGraphQL\WooCommerce\Type\WPObject\Simple_Attribute_Type::register();
 		\WPGraphQL\WooCommerce\Type\WPObject\Variation_Attribute_Type::register();
 		\WPGraphQL\WooCommerce\Type\WPObject\Payment_Gateway_Type::register();
 		\WPGraphQL\WooCommerce\Type\WPObject\Meta_Data_Type::register();

--- a/includes/type/interface/class-attribute.php
+++ b/includes/type/interface/class-attribute.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * WPInterface Type - Attribute_Type
+ *
+ * @package WPGraphQL\WooCommerce\Type\WPInterface
+ * @since   0.10.1
+ */
+
+namespace WPGraphQL\WooCommerce\Type\WPInterface;
+
+/**
+ * Class Attribute
+ */
+class Attribute {
+
+	/**
+	 * Registers the "Product" interface.
+	 *
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry  Instance of the WPGraphQL TypeRegistry.
+	 */
+	public static function register_interface( &$type_registry ) {
+		register_graphql_interface_type(
+			'Attribute',
+			array(
+				'description' => __( 'Attribute object', 'wp-graphql-woocommerce' ),
+				'fields'      => array(
+					'name'  => array(
+						'type'        => 'String',
+						'description' => __( 'Name of attribute', 'wp-graphql-woocommerce' ),
+						'resolve'     => function ( $source ) {
+							return isset( $source['name'] ) ? $source['name'] : null;
+						},
+					),
+					'value' => array(
+						'type'        => 'String',
+						'description' => __( 'Selected value of attribute', 'wp-graphql-woocommerce' ),
+						'resolve'     => function ( $source ) {
+							return isset( $source['value'] ) ? $source['value'] : null;
+						},
+					),
+				),
+				'resolveType' => function( $value ) use ( &$type_registry ) {
+					if ( $value->is_taxonomy() ) {
+						return $type_registry->get_type( 'SimpleAttribute' );
+					} else {
+						return $type_registry->get_type( 'VariationAttribute' );
+					}
+				},
+			)
+		);
+	}
+}

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -308,6 +308,24 @@ class Cart_Type {
 				'toType'        => 'Product',
 				'fromFieldName' => 'product',
 				'oneToOne'      => true,
+				'edgeFields'    => array(
+					'simpleVariations' => array(
+						'type'        => array( 'list_of' => 'SimpleAttribute' ),
+						'description' => __( 'Simple variation attribute data', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source ) {
+							$attributes = array();
+
+							$variation             = $source['node'];
+							$cart_item_data        = $source['source'];
+							$simple_attribute_data = $cart_item_data['variation'];
+							foreach ( $simple_attribute_data as $name => $value ) {
+								$attributes[] = compact( 'name', 'value' );
+							}
+
+							return $attributes;
+						},
+					)
+				),
 				'resolve'       => function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 					$id       = $source['product_id'];
 					$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );

--- a/includes/type/object/class-simple-attribute-type.php
+++ b/includes/type/object/class-simple-attribute-type.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * WPObject Type - Simple_Attribute_Type
+ *
+ * Registers SimpleAttribute WPObject type
+ *
+ * @package WPGraphQL\WooCommerce\Type\WPObject
+ * @since   0.10.1
+ */
+
+namespace WPGraphQL\WooCommerce\Type\WPObject;
+
+/**
+ * Class Simple_Attribute_Type
+ */
+class Simple_Attribute_Type {
+
+	/**
+	 * Register SimpleAttribute type to the WPGraphQL schema
+	 */
+	public static function register() {
+		register_graphql_object_type(
+			'SimpleAttribute',
+			array(
+				'description' => __( 'A simple attribute object', 'wp-graphql-woocommerce' ),
+				'interfaces'  => array( 'Attribute' ),
+				'fields'      => array(),
+			)
+		);
+	}
+}

--- a/includes/type/object/class-variation-attribute-type.php
+++ b/includes/type/object/class-variation-attribute-type.php
@@ -23,6 +23,7 @@ class Variation_Attribute_Type {
 			'VariationAttribute',
 			array(
 				'description' => __( 'A product variation attribute object', 'wp-graphql-woocommerce' ),
+				'interfaces'  => array( 'Attribute' ),
 				'fields'      => array(
 					'id'          => array(
 						'type'        => array( 'non_null' => 'ID' ),


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Introduces 'simpleAttributes' edge field
```graphql
mutation( $input: AddToCartInput! ) {
	addToCart(input: $input) {
		cartItem {
			product {
				simpleVariations {
					name
					value
				}
				node {
					databaseId
				}
			}
		}
	}
}
```


Does this close any currently open issues?
------------------------------------------
Resolves #517 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.10.0
- **WPGraphQL Version:** 1.5.0
- **WordPress Version:**
- **WooCommerce Version:**
