### PR TITLE
Fix: Access denied state for coupon and order connections.

### DIFF
--- a/includes/connection/class-coupons.php
+++ b/includes/connection/class-coupons.php
@@ -46,10 +46,7 @@ class Coupons {
 					$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'shop_coupon' );
 
 					if ( ! self::should_execute() ) {
-						return array(
-							'nodes' => array(),
-							'edges' => array(),
-						);
+						return array();
 					}
 
 					return $resolver->get_connection();

--- a/includes/connection/class-orders.php
+++ b/includes/connection/class-orders.php
@@ -110,11 +110,7 @@ class Orders {
 	private static function get_customer_order_connection( $resolver, $customer ) {
 		// If not "billing email" or "ID" set bail early by returning an empty connection.
 		if ( empty( $customer->get_billing_email() ) && empty( $customer->get_id() ) ) {
-			return array(
-				'pageInfo' => null,
-				'nodes'    => array(),
-				'edges'    => array(),
-			);
+			return array();
 		}
 
 		// If the querying user has a "billing email" set filter orders by user's billing email, otherwise filter by user's ID.


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Access denied state for `coupon` and `order` connection altered to match standard set in WPGraphQL.


Does this close any currently open issues?
------------------------------------------
Resolves #516


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
