### PR TITLE
Fix: pass expected checkout validation WP_Error instance

### DIFF
--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -9,6 +9,8 @@
 namespace WPGraphQL\WooCommerce\Data\Mutation;
 
 use GraphQL\Error\UserError;
+use WP_Error;
+
 use function WC;
 
 /**
@@ -496,7 +498,7 @@ class Checkout_Mutation {
 		}
 
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-		do_action( 'woocommerce_after_checkout_validation', $data );
+		do_action( 'woocommerce_after_checkout_validation', $data, new WP_Error() );
 	}
 
 	/**


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Passes an empty instance of `WP_Error` to the `woocommerce_after_checkout_validation` action hook. WooCommerce passes an error object as the second argument to the hook and several 3rd party plugins expect it to be provided. Dokan for example doesn't even check `is_wp_error` before calling `$errors->add()` resulting in runtime errors. 

Normally I'd expect plugin developers to know better, do better but in this case, the wp-graphql-woocommerce breaks from Woocommerce in not passing the second argument. Supplying an empty 


Does this close any currently open issues?
------------------------------------------

https://github.com/wp-graphql/wp-graphql-woocommerce/issues/448


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Example error from my application 

```
errors: [{,…}]
0: {,…}
debugMessage: "Too few arguments to function WeDevs\\DokanPro\\Modules\\Moip\\Module::check_vendor_configure_moip(), 1 passed in /var/www/html/web/wp/wp-includes/class-wp-hook.php on line 292 and exactly 2 expected"
extensions: {category: "internal"}
locations: [{line: 2, column: 3}]
message: "Internal server error"
path: ["checkout"]
trace: [{file: "/var/www/html/web/wp/wp-includes/class-wp-hook.php", line: 292,…},…]
```


Any other comments?
-------------------
I attempted to add a unit test but I the tests for `CheckoutMutationTest` aren't passing locally on a fresh clone. Arguably no test is needed as it would just be testing WordPress internals.

```
Output from a fresh install

Wpunit (docker) Tests (6) ------------------------------------------------------------------------------------------------------------
✖ CheckoutMutationTest: Checkout mutation (15.33s)
✖ CheckoutMutationTest: Checkout mutation with new account (7.11s)
✖ CheckoutMutationTest: Checkout mutation with no account (6.10s)
✖ CheckoutMutationTest: Checkout mutation with prepaid order (4.53s)
S CheckoutMutationTest: Checkout mutation with stripe (2.45s)
✔ CheckoutMutationTest: Checkout mutation cart item validation (2.72s)
--------------------------------------------------------------------------------------------------------------------------------------

Time: 2.73 seconds, Memory: 103.00 MB

There were 4 failures:

---------
1) CheckoutMutationTest: Checkout mutation
 Test  tests/wpunit/CheckoutMutationTest.php:testCheckoutMutation
Failed asserting that two arrays are equal.
- Expected | + Actual
@@ @@
'metaData' => Array (
0 => Array (...)
1 => Array (...)
+                    2 => Array (...)
)
'couponLines' => Array (
'nodes' => Array (
0 => Array (
-                            'databaseId' => 131
-                            'orderId' => 20
+                            'databaseId' => null
+                            'orderId' => null
'code' => '62off'
'discount' => '398.5'
-                            'discountTax' => '79.7'
+                            'discountTax' => null

.......
```

It looks like a database issue with some rows not updating? I'm glad to attempt again with some guidance on how to resolve.


Where has this been tested?
---------------------------
N/A

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
