### PR TITLE
feature: customer call returns session token for guest users

### DIFF
--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -115,11 +115,7 @@ class Customer_Type {
 						'type'        => 'String',
 						'description' => __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
-							if ( \get_current_user_id() === $source->ID ) {
 								return apply_filters( 'graphql_customer_session_token', \WC()->session->build_token() );
-							}
-
-							return null;
 						},
 					),
 

--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -115,7 +115,10 @@ class Customer_Type {
 						'type'        => 'String',
 						'description' => __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
-								return apply_filters( 'graphql_customer_session_token', \WC()->session->build_token() );
+							if ( \get_current_user_id() === $source->ID || 'guest' === $source->id ) {
+										return apply_filters( 'graphql_customer_session_token', \WC()->session->build_token() );
+							}
+										return null;
 						},
 					),
 


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Since the woocommerce session takes into account that a guest user session can generate a token, this should be exposable thru the customer sessionToken trait. 

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.10.3 
- **WPGraphQL Version:** 1.6.3
- **WordPress Version:** 5.8
- **WooCommerce Version:** 5.5.2
