### PR TITLE
Fix raw pricing returning null

### DIFF
--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -78,7 +78,7 @@ class Product extends WC_Post {
 		sort( $prices, SORT_NUMERIC );
 
 		if ( $raw ) {
-			return implode( ', ', $prices['price'] );
+			return implode( ', ', $prices );
 		}
 
 		return \wc_graphql_price_range( current( $prices ), end( $prices ) );


### PR DESCRIPTION
$prices['price'] doesn't exist as $prices variable has already been overwritten inside the switch case. This causes pricing to return null for all pricing fields (regular, sale, price) which are formatted as RAW.


What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes raw pricing for variable products returning null.


Does this close any currently open issues?
------------------------------------------
Fixes #479 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
None


Any other comments?
-------------------
None
