### PR TITLE
make order processing methods static

### DIFF
--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -509,7 +509,7 @@ class Checkout_Mutation {
 	 *
 	 * @return array.
 	 */
-	protected function process_order_payment( $order_id, $payment_method ) {
+	protected static function process_order_payment( $order_id, $payment_method ) {
 		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! isset( $available_gateways[ $payment_method ] ) ) {
@@ -538,7 +538,7 @@ class Checkout_Mutation {
 	 *
 	 * @return array
 	 */
-	protected function process_order_without_payment( $order_id, $transaction_id = '' ) {
+	protected static function process_order_without_payment( $order_id, $transaction_id = '' ) {
 		$order = wc_get_order( $order_id );
 		$order->payment_complete( $transaction_id );
 		wc_empty_cart();


### PR DESCRIPTION
This should fix Checkout mutation returns error 
Fixes #539 
From what I can tell these methods are only called statically, so I think it's an easy fix. 

Where has this been tested?
---------------------------

- **WooGraphQL Version: 0.0.1
- **WPGraphQL Version: 1.6.5
- **WordPress Version: 5.8.1
- **WooCommerce Version: 5.7.1
