### PR TITLE
fix: respect woocommerce tax display settings in cart

### DIFF
--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -137,7 +137,7 @@ class Cart_Type {
 							} else {
 								$cart_subtotal = $source->get_subtotal();
 							}
-							
+
 							$price = ! is_null( $cart_subtotal )
 								? $cart_subtotal
 								: 0;
@@ -334,7 +334,7 @@ class Cart_Type {
 						'resolve'     => function( $source ) {
 							$price_without_tax = isset( $source['line_total'] ) ? floatval( $source['line_total'] ) : null;
 							$tax = isset( $source['line_tax'] ) ? floatval( $source['line_tax'] ) : null;
-							$price = $price_without_tax + $tax;               
+							$price = $price_without_tax + $tax;
 							return \wc_graphql_price( $price );
 						},
 					),


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).
**Nope. Terrible sorry, PHP is not my hometurf. I have no idea** 

What does this implement/fix? Explain your changes.
---------------------------------------------------
The issue: Cart response does always show item and contents total without taxes, regardless of the respective settings in WooCommerce (show prices including tax). This applied to cart item's `total` as well as cart's `contentsTotal`

The fix: I copied the relevant parts from Woocommerce Core

Does this close any currently open issues?
Fixes #405 
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Kudos to @davevanhoorn and @mraf for their work shown in #405 


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
