### PR TITLE
fix: allow acf schema filter to accept array of sources

### DIFF
--- a/includes/class-acf-schema-filters.php
+++ b/includes/class-acf-schema-filters.php
@@ -54,21 +54,49 @@ class ACF_Schema_Filters {
 	 * @return mixed|null
 	 */
 	public static function resolve_post_object_source( $source, $value ) {
-		$post = get_post( $value );
-		if ( $post instanceof \WP_Post ) {
-			switch ( $post->post_type ) {
-				case 'shop_coupon':
-					$source = new Coupon( $post->ID );
-					break;
-				case 'shop_order':
-					$source = new Order( $post->ID );
-					break;
-				case 'product':
-					$source = new Product( $post->ID );
-					break;
+		$return = [];
+		if ( ! empty( $value ) ) {
+			if ( is_array( $value )) {
+				foreach ( $value as $idx => $id ) {
+					$post = get_post( $id );
+
+					if ( $post instanceof \WP_Post ) {
+						switch ( $post->post_type ) {
+							case 'shop_coupon':
+								$return[] = new Coupon( $post->ID );
+								break;
+							case 'shop_order':
+								$return[] = new Order( $post->ID );
+								break;
+							case 'product':
+								$return[] = new Product( $post->ID );
+								break;
+							default:
+								$return[] = $source[$idx];
+						}
+					}
+				}
+			} else {
+				$post = get_post ( absint( $value ));
+
+				if ( $post instanceof \WP_Post ) {
+					switch ( $post->post_type ) {
+						case 'shop_coupon':
+							$return = new Coupon( $post->ID );
+							break;
+						case 'shop_order':
+							$return = new Order( $post->ID );
+							break;
+						case 'product':
+							$return = new Product( $post->ID );
+							break;
+						default:
+							$return = $source;
+					}
+				}
 			}
 		}
 
-		return $source;
+		return $return;
 	}
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
There are currently two edge cases involving interactions between products and  `wp-graphql-acf` field types: `relationship` and `post_object`.

1. Relationships can have multiple objects by default. 

2. Post Objects can have multiple objects by turning on the `multiple` flag.

By modifying the `resolve_post_object_source` filter, we can accomodate both arrays of objects or a single post object.


Does this close any currently open issues?
------------------------------------------

Closes #565 

Partially Closes https://github.com/wp-graphql/wp-graphql-acf/issues/155 (requires a fix on `wp-graphql-acf` repo to allow the relationship field to use the acf schema filter)


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A

Any other comments?
-------------------

- **NOTE:** This is only a temporary fix as significant schema changes are expected in `wp-graphql-acf 0.6.0`. 

- **NOTE:** This does NOT resolve another edge case where an error will be thrown when no post type filters are set on the custom field. This is because when no filter is set, the `$acf_field['post_type']` is set to an empty string, causing the type of the `post_object` or `relationship` to be defaulted to `PostObjectUnion`.



Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.10.4
- **WPGraphQL Version:** 1.6.6
- **WordPress Version:** 5.8.1
- **WooCommerce Version:** 5.8.0
