### PR TITLE
chore: CartItem product connection resolvers updated.

### DIFF
--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -14,7 +14,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Connection\Variation_Attribute_Connection_Resolver;
-use WPGraphQL\WooCommerce\Data\Connection\Product_Connection_Resolver;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\WooCommerce\Data\Connection\Cart_Item_Connection_Resolver;
 use WPGraphQL\WooCommerce\Data\Factory;
 
@@ -422,9 +422,10 @@ class Cart_Type {
 						),
 						'resolve'    => function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 							$id       = $source['product_id'];
-							$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
+							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
 
-							return $resolver->one_to_one()
+							return $resolver
+								->one_to_one()
 								->set_query_arg( 'p', $id )
 								->get_connection();
 						},
@@ -456,14 +457,14 @@ class Cart_Type {
 						),
 						'resolve'    => function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 							$id       = $source['variation_id'];
-							$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
+							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product_variation' );
 
 							if ( ! $id ) {
 								return null;
 							}
 
-							return $resolver->one_to_one()
-								->set_query_arg( 'post_type', 'product_variation' )
+							return $resolver
+								->one_to_one()
 								->set_query_arg( 'p', $id )
 								->get_connection();
 						},


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Update CartItem product and variation connections to use `PostObjectConnectionResolver`


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
