### PR TITLE
feat: applied coupon description field added

### DIFF
--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -618,6 +618,14 @@ class Cart_Type {
 							return \wc_graphql_price( $tax );
 						},
 					),
+					'description'    => array(
+						'type'        => 'String',
+						'description' => __( 'Description of applied coupon', 'wp-graphql-woocommerce' ),
+						'resolve'     => function( $source, array $args ) {
+							$coupon = new \WC_Coupon( $source );
+							return $coupon->get_description();
+						},
+					),
 				),
 			)
 		);

--- a/tests/wpunit/CartMutationsTest.php
+++ b/tests/wpunit/CartMutationsTest.php
@@ -427,7 +427,8 @@ class CartMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 			$this->factory->coupon->create(
                 array(
                     'amount'      => 0.5,
-                    'product_ids' => array( $product_id )
+                    'product_ids' => array( $product_id ),
+					'description' => 'lorem ipsum dolor',
                 )
             )
         );
@@ -445,6 +446,7 @@ class CartMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
                     cart {
                         appliedCoupons {
 							code
+							description
                         }
                         contents {
                             nodes {
@@ -484,7 +486,8 @@ class CartMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 				$this->expectedNode(
 					'applyCoupon.cart.appliedCoupons',
 					array(
-						'code' => $coupon_code,
+						'code'        => $coupon_code,
+						'description' => 'lorem ipsum dolor',
 					)
 				),
 				$this->expectedNode(


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds `description` field to **AppliedCoupon** type.
- Update **CartMutationsTest** to test new field.


Does this close any currently open issues?
------------------------------------------
Resolves #548 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
