### PR TITLE
fix: order item connection cursor fixed.

### DIFF
--- a/includes/data/connection/class-order-item-connection-resolver.php
+++ b/includes/data/connection/class-order-item-connection-resolver.php
@@ -91,6 +91,7 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 		$items = array();
 		foreach ( $this->source->get_items( $type ) as $id => $item ) {
 			$item->cached_order = $this->source;
+			$item->cached_id    = $id;
 			$items[]            = $item;
 		}
 
@@ -104,7 +105,7 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 			}
 		}
 
-		$cursor = $this->get_offset();
+		$cursor = absint( $this->get_offset() );
 		$first  = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
 		$last   = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes order item connection pagination cursor evaluation.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
