### PR TITLE
Implement the Node Interface on Types that have connections

### DIFF
--- a/includes/type/input/class-fee-line-input.php
+++ b/includes/type/input/class-fee-line-input.php
@@ -21,7 +21,6 @@ class Fee_Line_Input {
 			'FeeLineInput',
 			array(
 				'description' => __( 'Fee line data.', 'wp-graphql-woocommerce' ),
-				'interfaces' => array( 'Node' ),
 				'fields'      => array(
 					'id'        => array(
 						'type'        => 'ID',

--- a/includes/type/input/class-fee-line-input.php
+++ b/includes/type/input/class-fee-line-input.php
@@ -21,6 +21,7 @@ class Fee_Line_Input {
 			'FeeLineInput',
 			array(
 				'description' => __( 'Fee line data.', 'wp-graphql-woocommerce' ),
+				'interfaces' => array( 'Node' ),
 				'fields'      => array(
 					'id'        => array(
 						'type'        => 'ID',

--- a/includes/type/interface/class-product-attribute.php
+++ b/includes/type/interface/class-product-attribute.php
@@ -44,11 +44,7 @@ class Product_Attribute {
 	public static function get_fields() {
 		return array(
 			'id'          => array(
-				'type'        => array( 'non_null' => 'ID' ),
 				'description' => __( 'Attribute Global ID', 'wp-graphql-woocommerce' ),
-				'resolve'     => function ( $attribute ) {
-					return ! empty( $attribute->_relay_id ) ? $attribute->_relay_id : null;
-				},
 			),
 			'attributeId' => array(
 				'type'        => array( 'non_null' => 'Int' ),

--- a/includes/type/interface/class-product-attribute.php
+++ b/includes/type/interface/class-product-attribute.php
@@ -23,7 +23,7 @@ class Product_Attribute {
 			'ProductAttribute',
 			array(
 				'description' => __( 'Product attribute object', 'wp-graphql-woocommerce' ),
-				'interfaces' => array( 'Node' ),
+				'interfaces'  => array( 'Node' ),
 				'fields'      => self::get_fields(),
 				'resolveType' => function( $value ) use ( &$type_registry ) {
 					if ( $value->is_taxonomy() ) {

--- a/includes/type/interface/class-product-attribute.php
+++ b/includes/type/interface/class-product-attribute.php
@@ -23,6 +23,7 @@ class Product_Attribute {
 			'ProductAttribute',
 			array(
 				'description' => __( 'Product attribute object', 'wp-graphql-woocommerce' ),
+				'interfaces' => array( 'Node' ),
 				'fields'      => self::get_fields(),
 				'resolveType' => function( $value ) use ( &$type_registry ) {
 					if ( $value->is_taxonomy() ) {

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -32,6 +32,7 @@ class Product {
 			'Product',
 			array(
 				'description' => __( 'Product object', 'wp-graphql-woocommerce' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
 				'resolveType' => function( $value ) use ( &$type_registry ) {
 					$possible_types = WP_GraphQL_WooCommerce::get_enabled_product_types();

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -32,7 +32,7 @@ class Product {
 			'Product',
 			array(
 				'description' => __( 'Product object', 'wp-graphql-woocommerce' ),
-				'interfaces'  => [ 'Node' ],
+				'interfaces'  => array( 'Node' ),
 				'fields'      => self::get_fields(),
 				'resolveType' => function( $value ) use ( &$type_registry ) {
 					$possible_types = WP_GraphQL_WooCommerce::get_enabled_product_types();

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -297,6 +297,7 @@ class Cart_Type {
 			'CartItem',
 			array(
 				'description' => __( 'A item in the cart', 'wp-graphql-woocommerce' ),
+				'interfaces'  => array( 'Node' ),
 				'fields'      => array(
 					'key'         => array(
 						'type'        => array( 'non_null' => 'ID' ),
@@ -490,6 +491,7 @@ class Cart_Type {
 			'CartFee',
 			array(
 				'description' => __( 'An additional fee', 'wp-graphql-woocommerce' ),
+				'interfaces'  => array( 'Node' ),
 				'fields'      => array(
 					'id'       => array(
 						'type'        => array( 'non_null' => 'ID' ),
@@ -545,6 +547,7 @@ class Cart_Type {
 			'CartTax',
 			array(
 				'description' => __( 'An itemized cart tax item', 'wp-graphql-woocommerce' ),
+				'interfaces'  => array( 'Node' ),
 				'fields'      => array(
 					'id'         => array(
 						'type'        => array( 'non_null' => 'ID' ),

--- a/includes/type/object/class-downloadable-item-type.php
+++ b/includes/type/object/class-downloadable-item-type.php
@@ -27,6 +27,7 @@ class Downloadable_Item_Type {
 			'DownloadableItem',
 			array(
 				'description' => __( 'A downloadable item', 'wp-graphql-woocommerce' ),
+				'interfaces' => array( 'Node' ),
 				'fields'      => array(
 					'downloadId'         => array(
 						'type'        => array( 'non_null' => 'String' ),

--- a/includes/type/object/class-downloadable-item-type.php
+++ b/includes/type/object/class-downloadable-item-type.php
@@ -27,7 +27,7 @@ class Downloadable_Item_Type {
 			'DownloadableItem',
 			array(
 				'description' => __( 'A downloadable item', 'wp-graphql-woocommerce' ),
-				'interfaces' => array( 'Node' ),
+				'interfaces'  => array( 'Node' ),
 				'fields'      => array(
 					'downloadId'         => array(
 						'type'        => array( 'non_null' => 'String' ),

--- a/includes/type/object/class-order-item-type.php
+++ b/includes/type/object/class-order-item-type.php
@@ -48,6 +48,8 @@ class Order_Item_Type {
 						},
 					),
 				),
+				// Interfaces
+				array( 'Node' )
 			),
 			'FeeLine'      => array(
 				// Description.
@@ -83,6 +85,8 @@ class Order_Item_Type {
 						'description' => __( 'Line tax class', 'wp-graphql-woocommerce' ),
 					),
 				),
+				// Interfaces
+				array( 'Node' )
 			),
 			'ShippingLine' => array(
 				// Description.
@@ -117,6 +121,8 @@ class Order_Item_Type {
 						},
 					),
 				),
+				// Interfaces
+				array( 'Node' ),
 			),
 			'TaxLine'      => array(
 				// Description.
@@ -151,6 +157,8 @@ class Order_Item_Type {
 						},
 					),
 				),
+				// Interfaces
+				array( 'Node' ),
 			),
 			'LineItem'     => array(
 				// Description.
@@ -224,6 +232,8 @@ class Order_Item_Type {
 						},
 					),
 				),
+				// Interfaces
+				array( 'Node' ),
 			),
 		);
 
@@ -234,6 +244,7 @@ class Order_Item_Type {
 				array(
 					'description' => $config[0],
 					'fields'      => self::get_fields( $config[1] ),
+					'interfaces'  => isset( $config[2] ) && is_array( $config[2] ) ? $config[2] : null,
 				)
 			);
 		}

--- a/includes/type/object/class-order-item-type.php
+++ b/includes/type/object/class-order-item-type.php
@@ -48,8 +48,8 @@ class Order_Item_Type {
 						},
 					),
 				),
-				// Interfaces
-				array( 'Node' )
+				// Interfaces.
+				array( 'Node' ),
 			),
 			'FeeLine'      => array(
 				// Description.
@@ -85,8 +85,8 @@ class Order_Item_Type {
 						'description' => __( 'Line tax class', 'wp-graphql-woocommerce' ),
 					),
 				),
-				// Interfaces
-				array( 'Node' )
+				// Interfaces.
+				array( 'Node' ),
 			),
 			'ShippingLine' => array(
 				// Description.
@@ -121,7 +121,7 @@ class Order_Item_Type {
 						},
 					),
 				),
-				// Interfaces
+				// Interfaces.
 				array( 'Node' ),
 			),
 			'TaxLine'      => array(
@@ -157,7 +157,7 @@ class Order_Item_Type {
 						},
 					),
 				),
-				// Interfaces
+				// Interfaces.
 				array( 'Node' ),
 			),
 			'LineItem'     => array(
@@ -232,7 +232,7 @@ class Order_Item_Type {
 						},
 					),
 				),
-				// Interfaces
+				// Interfaces.
 				array( 'Node' ),
 			),
 		);
@@ -289,6 +289,7 @@ class Order_Item_Type {
 						'resolve'     => function( $source ) {
 							$item               = \WC_Order_Factory::get_order_item( $source['ID'] );
 							$item->cached_order = $source;
+
 							return ! empty( $item ) ? Factory::resolve_order_item( $item ) : null;
 						},
 					),
@@ -301,6 +302,7 @@ class Order_Item_Type {
 	 * Returns type fields definition
 	 *
 	 * @param array $fields - type specific fields.
+	 *
 	 * @return array
 	 */
 	private static function get_fields( $fields = array() ) {
@@ -314,7 +316,6 @@ class Order_Item_Type {
 					'type'        => 'Int',
 					'description' => __( 'The Id of the order the order item belongs to.', 'wp-graphql-woocommerce' ),
 				),
-
 				'metaData'   => Meta_Data_Type::get_metadata_field_definition(),
 			),
 			$fields

--- a/includes/type/object/class-payment-gateway-type.php
+++ b/includes/type/object/class-payment-gateway-type.php
@@ -23,7 +23,7 @@ class Payment_Gateway_Type {
 			'PaymentGateway',
 			array(
 				'description' => __( 'A payment gateway object', 'wp-graphql-woocommerce' ),
-				'interfaces' => array( 'Node' ),
+				'interfaces'  => array( 'Node' ),
 				'fields'      => array(
 					'id'          => array(
 						'type'        => array( 'non_null' => 'ID' ),

--- a/includes/type/object/class-payment-gateway-type.php
+++ b/includes/type/object/class-payment-gateway-type.php
@@ -23,9 +23,10 @@ class Payment_Gateway_Type {
 			'PaymentGateway',
 			array(
 				'description' => __( 'A payment gateway object', 'wp-graphql-woocommerce' ),
+				'interfaces' => array( 'Node' ),
 				'fields'      => array(
 					'id'          => array(
-						'type'        => array( 'non_null' => 'String' ),
+						'type'        => array( 'non_null' => 'ID' ),
 						'description' => __( 'gateway\'s title', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
 							return ! empty( $source->id ) ? $source->id : null;

--- a/includes/type/object/class-product-attribute-types.php
+++ b/includes/type/object/class-product-attribute-types.php
@@ -24,6 +24,11 @@ class Product_Attribute_Types {
 				'description' => __( 'A product attribute object', 'wp-graphql-woocommerce' ),
 				'interfaces'  => array( 'ProductAttribute' ),
 				'fields'      => array(
+					'id'    => array(
+						'resolve' => function( $attribute ) {
+							return ! empty( $attribute->_relay_id ) ? $attribute->_relay_id : null;
+						},
+					),
 					'scope' => array(
 						'type'        => array( 'non_null' => 'ProductAttributeTypesEnum' ),
 						'description' => __( 'Product attribute scope.', 'wp-graphql-woocommerce' ),
@@ -42,6 +47,11 @@ class Product_Attribute_Types {
 				'description' => __( 'A product attribute object', 'wp-graphql-woocommerce' ),
 				'interfaces'  => array( 'ProductAttribute' ),
 				'fields'      => array(
+					'id'    => array(
+						'resolve' => function( $attribute ) {
+							return ! empty( $attribute->_relay_id ) ? $attribute->_relay_id : null;
+						},
+					),
 					'scope' => array(
 						'type'        => array( 'non_null' => 'ProductAttributeTypesEnum' ),
 						'description' => __( 'Product attribute scope.', 'wp-graphql-woocommerce' ),

--- a/includes/type/object/class-shipping-rate-type.php
+++ b/includes/type/object/class-shipping-rate-type.php
@@ -23,6 +23,7 @@ class Shipping_Rate_Type {
 			'ShippingRate',
 			array(
 				'description' => __( 'Shipping rate object', 'wp-graphql-woocommerce' ),
+				'interfaces' => array( 'Node' ),
 				'fields'      => array(
 					'id'         => array(
 						'type'        => array( 'non_null' => 'ID' ),

--- a/includes/type/object/class-shipping-rate-type.php
+++ b/includes/type/object/class-shipping-rate-type.php
@@ -23,7 +23,7 @@ class Shipping_Rate_Type {
 			'ShippingRate',
 			array(
 				'description' => __( 'Shipping rate object', 'wp-graphql-woocommerce' ),
-				'interfaces' => array( 'Node' ),
+				'interfaces'  => array( 'Node' ),
 				'fields'      => array(
 					'id'         => array(
 						'type'        => array( 'non_null' => 'ID' ),

--- a/includes/type/object/class-variation-attribute-type.php
+++ b/includes/type/object/class-variation-attribute-type.php
@@ -23,7 +23,7 @@ class Variation_Attribute_Type {
 			'VariationAttribute',
 			array(
 				'description' => __( 'A product variation attribute object', 'wp-graphql-woocommerce' ),
-				'interfaces'  => array( 'Attribute' ),
+				'interfaces'  => array( 'Node', 'Attribute' ),
 				'fields'      => array(
 					'id'          => array(
 						'type'        => array( 'non_null' => 'ID' ),


### PR DESCRIPTION
- This updates Types that have the `id` field to implement the `Node` interface to be compatible with the upcoming WPGraphQL connection updates (https://github.com/wp-graphql/wp-graphql/pull/2022)

## Why?

When the GraphQL Spec updated to allow Interfaces to implement Interfaces, we're able to describe the schema better than ever now. 

We can now have generic types and interfaces such as: 

### Connection Interface

```graphql
interface Connection {
  edges: [Edge!]!
  nodes: [Node!]!
}

interface Edge {
  node: Node
}

interface Node {
  id: ID!
}

interface SingularConnection {
  node: Node!
}
```

Any connection that is added using `register_graphql_connection()` now adheres to this, so any connection can be seen in the Schema like so: 

![Screen Shot 2021-12-10 at 12 02 54 PM](https://user-images.githubusercontent.com/1260765/145627832-60852b90-7d63-4a5b-b845-7d2f9d26f3a0.png)

We can also see any "SingularConnections" (one-to-one connections) in the Schema: 

![Screen Shot 2021-12-10 at 12 03 26 PM](https://user-images.githubusercontent.com/1260765/145627896-a43e2f25-6a10-4f43-909b-736d44955f87.png)

But, in order for this to work, any Type that is being connected to must implement the `Node` interface, as it's returned as the `node` in a connection. 

This PR updates all the Types in the WooGraphQL Schema that are nodes to implement the `node` Interface
