### PR TITLE
[Bugfix] Update order status

### DIFF
--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -138,7 +138,7 @@ class Order_Update {
 
 			// Set status.
 			if ( ! empty( $input['status'] ) ) {
-				$order->set_status( $input['status'] );
+				$order->update_status( $input['status'] );
 			}
 
 			// Actions for after the order is saved.


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Order status was not being updated. Use "update_status" method instead of "set_status".

Does this close any currently open issues?
------------------------------------------
- https://github.com/wp-graphql/wp-graphql-woocommerce/issues/562
…

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.10.6
- **WPGraphQL Version:** 1.6.10
- **WordPress Version:** 5.8.2
- **WooCommerce Version:** 5.9.0
