### PR TITLE
fix: change deprecated incr_cache_prefix

### DIFF
--- a/includes/utils/class-ql-session-handler.php
+++ b/includes/utils/class-ql-session-handler.php
@@ -400,7 +400,7 @@ class QL_Session_Handler extends WC_Session_Handler {
 	 * For refreshing session data mid-request when changes occur in concurrent requests.
 	 */
 	public function reload_data() {
-		\WC_Cache_Helper::incr_cache_prefix( WC_SESSION_CACHE_GROUP );
+		\WC_Cache_Helper::invalidate_cache_group( WC_SESSION_CACHE_GROUP );
 		$this->_data = $this->get_session( $this->_customer_id );
 	}
 }


### PR DESCRIPTION

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR only changes one method to another the suggested one.
https://woocommerce.wp-a2z.org/oik_api/WC_Cache_Helper::incr_cache_prefix/

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
The error message:
[fatal error]: 'WC_Cache_Helper::incr_cache_prefix is <strong>deprecated</strong> since verion 3.9.0! Use WC_Cache_Helper::invalidate_cache_group instead.'

Any other comments?
-------------------
Simple modification.


Where has this been tested?
---------------------------

- **WooGraphQL Version:**   0.10.6
- **WPGraphQL Version:** 1.6.11
- **WordPress Version:** 5.8.3
- **WooCommerce Version:** 6.1.0
