### PR TITLE
[Fix] Error when switching percent to fixed

### DIFF
--- a/includes/mutation/class-coupon-create.php
+++ b/includes/mutation/class-coupon-create.php
@@ -209,6 +209,13 @@ class Coupon_Create {
 				case 'description':
 					$coupon->set_description( wp_filter_post_kses( $value ) );
 					break;
+				case 'amount':
+					if ( $coupon_args['discountType'] == 'PERCENT' ){
+						$coupon->set_discount_type( 'PERCENT' );
+					}
+
+					$coupon->set_amount( $value );
+					break;
 				default:
 					if ( is_callable( array( $coupon, "set_{$key}" ) ) ) {
 						$coupon->{"set_{$key}"}( $value );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

updateCoupon mutation error
---------------------------------------------------
I can't change the coupon discount type from "FIXED PRODUCT" to "PERCENT" when the amount is higher than 100 and the amount input is set before the discountType in the mutation.

What does this implement/fix? Explain your changes.
---------------------------------------------------
My fix sets the coupon discount type before Woocommerce checks if the amount is valid or not.

Steps to reproduce the issue
---------------------------------------------------
1- Create a new coupon with discount type 'FIXED_PRODUCT' and set an amount of 200
2- Change the discount type to 'PERCENT', keeping the same amount. IMPORTANT: put the amount input before the discountType in the mutation.
3. An error will be generated, because when validating the amount, the discount type will still be the old one (PERCENT) and 200 is invalid for percentage.


- **WooGraphQL Version:** 0.10.7
- **WPGraphQL Version:** 1.6.12
- **WordPress Version:** 5.8.3
- **WooCommerce Version:** 6.1.0
