### PR TITLE
Fix Fee name not showing

### DIFF
--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -232,7 +232,7 @@ class Order_Mutation {
 
 			case 'fee':
 				return array(
-					'name'      => 'order_item_name',
+					'name'      => 'name',
 					'taxClass'  => 'tax_class',
 					'taxStatus' => 'tax_status',
 				);


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix Fee name not showing on the order when using the createOrder mutation.

Before
![Screenshot 2022-02-02 at 14 23 10](https://user-images.githubusercontent.com/5116925/152172564-83862607-12e6-4ed2-8be2-d70c46b544b5.jpg)
Always shows 'Fee' even tho the name input was passed

After
![Screenshot 2022-02-02 at 14 23 29](https://user-images.githubusercontent.com/5116925/152172712-5ddf3d0f-c551-47fa-ba24-172211734290.jpg)
Show's the name passed through the name input. In this case 'Planting Fee'


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 1.6.12
- **WPGraphQL Version:** 0.10.7
- **WordPress Version:** 5.9
- **WooCommerce Version:** 6.1.1
