### PR TITLE
feat: "product" and "variation" connections added to LineItem type

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         wordpress: ['5.9', '5.6', '5.3']
         composer_version: ['v2']
         include:
-          - php: '8.0'
+          - php: '7.4'
             wordpress: '5.9'
             coverage: '--coverage --coverage-xml'
             xdebug: 1

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.4', '7.3', '7.2']
-        wordpress: ['5.7', '5.6', '5.3']
+        php: ['8.0', '7.4', '7.3', '7.2']
+        wordpress: ['5.9', '5.6', '5.3']
         composer_version: ['v2']
         include:
-          - php: '7.4'
-            wordpress: '5.7'
+          - php: '8.0'
+            wordpress: '5.9'
             coverage: '--coverage --coverage-xml'
             xdebug: 1
           - php: '7.3'

--- a/access-functions.php
+++ b/access-functions.php
@@ -96,6 +96,7 @@ function wc_graphql_get_order_statuses() {
  * @return string
  */
 function wc_graphql_price( $price, $args = array() ) {
+	$price = floatval( $price );
 	$args = apply_filters(
 		'wc_price_args', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		wp_parse_args(

--- a/access-functions.php
+++ b/access-functions.php
@@ -97,7 +97,7 @@ function wc_graphql_get_order_statuses() {
  */
 function wc_graphql_price( $price, $args = array() ) {
 	$price = floatval( $price );
-	$args = apply_filters(
+	$args  = apply_filters(
 		'wc_price_args', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		wp_parse_args(
 			$args,

--- a/includes/type/object/class-order-item-type.php
+++ b/includes/type/object/class-order-item-type.php
@@ -12,6 +12,7 @@ namespace WPGraphQL\WooCommerce\Type\WPObject;
 
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Factory;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 
 /**
  * Class Order_Item_Type
@@ -201,26 +202,37 @@ class Order_Item_Type {
 						'type'        => 'TaxStatusEnum',
 						'description' => __( 'Line item\'s taxes', 'wp-graphql-woocommerce' ),
 					),
-					'product'       => array(
-						'type'        => 'Product',
-						'description' => 'Line item\'s product object',
-						'resolve'     => function( $item, array $args, AppContext $context ) {
-							// @codingStandardsIgnoreStart
-							return ! empty( $item->productId )
-								? Factory::resolve_crud_object( $item->productId, $context )
-								: null;
-							// @codingStandardsIgnoreEnd
+				),
+				// Connections.
+				array(
+					'product'   => array(
+						'toType'     => 'Product',
+						'oneToOne'   => true,
+						'resolve'    => function ( $source, array $args, AppContext $context, $info ) {
+							$id       = $source->productId;
+							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
+
+							return $resolver
+								->one_to_one()
+								->set_query_arg( 'p', $id )
+								->get_connection();
 						},
 					),
-					'variation'     => array(
-						'type'        => 'ProductVariation',
-						'description' => 'Line item\'s product variation object',
-						'resolve'     => function( $item, array $args, AppContext $context ) {
-							// @codingStandardsIgnoreStart
-							return ! empty( $item->variationId )
-								? Factory::resolve_crud_object( $item->variationId, $context )
-								: null;
-							// @codingStandardsIgnoreEnd
+					'variation' => array(
+						'toType'     => 'ProductVariation',
+						'oneToOne'   => true,
+						'resolve'    => function ( $source, array $args, AppContext $context, $info ) {
+							$id       = $source->variationId;
+							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product_variation' );
+
+							if ( ! $id ) {
+								return null;
+							}
+
+							return $resolver
+								->one_to_one()
+								->set_query_arg( 'p', $id )
+								->get_connection();
 						},
 					),
 				),
@@ -234,6 +246,7 @@ class Order_Item_Type {
 				array(
 					'description' => $config[0],
 					'fields'      => self::get_fields( $config[1] ),
+					'connections' => ! empty( $config[2] ) ? $config[2] : null,
 				)
 			);
 		}

--- a/includes/type/object/class-order-item-type.php
+++ b/includes/type/object/class-order-item-type.php
@@ -206,10 +206,10 @@ class Order_Item_Type {
 				// Connections.
 				array(
 					'product'   => array(
-						'toType'     => 'Product',
-						'oneToOne'   => true,
-						'resolve'    => function ( $source, array $args, AppContext $context, $info ) {
-							$id       = $source->productId;
+						'toType'   => 'Product',
+						'oneToOne' => true,
+						'resolve'  => function ( $source, array $args, AppContext $context, $info ) {
+							$id       = $source->productId; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
 
 							return $resolver
@@ -219,10 +219,10 @@ class Order_Item_Type {
 						},
 					),
 					'variation' => array(
-						'toType'     => 'ProductVariation',
-						'oneToOne'   => true,
-						'resolve'    => function ( $source, array $args, AppContext $context, $info ) {
-							$id       = $source->variationId;
+						'toType'   => 'ProductVariation',
+						'oneToOne' => true,
+						'resolve'  => function ( $source, array $args, AppContext $context, $info ) {
+							$id       = $source->variationId; // @phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product_variation' );
 
 							if ( ! $id ) {

--- a/tests/_support/Helper/GraphQLE2E.php
+++ b/tests/_support/Helper/GraphQLE2E.php
@@ -573,10 +573,14 @@ class GraphQLE2E extends \Codeception\Module {
                                 totalTax
                                 taxStatus
                                 product {
-                                    id
+                                    node {
+										id 
+									}
                                 }
                                 variation {
-                                    id
+                                    node {
+										id 
+									}
                                 }
                             }
                         }

--- a/tests/_support/Helper/crud-helpers/order.php
+++ b/tests/_support/Helper/crud-helpers/order.php
@@ -76,7 +76,8 @@ class OrderHelper extends WCG_Helper {
 			$customer_id = $args['customer_id'];
 		}
 
-        ShippingMethodHelper::create_legacy_flat_rate_instance();
+		$shipping_method_helper = ShippingMethodHelper::instance();
+        $shipping_method_helper->create_legacy_flat_rate_instance();
 
         // Create order
 		$order_data = array_merge(

--- a/tests/wpunit/CheckoutMutationTest.php
+++ b/tests/wpunit/CheckoutMutationTest.php
@@ -251,15 +251,19 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
                                     totalTax
                                     taxStatus
                                     product {
-                                        ... on SimpleProduct {
-                                            id
-                                        }
-                                        ... on VariableProduct {
-                                            id
-                                        }
+										node {
+											... on SimpleProduct {
+												id
+											}
+											... on VariableProduct {
+												id
+											}
+										}
                                     }
                                     variation {
-                                        id
+										node {
+                                        	id
+										}
                                     }
                                 }
                             }
@@ -480,10 +484,12 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
 												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
 												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
+												'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
 												'variation' => ! empty( $item->get_variation_id() )
 													? array(
-														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														'node' => array(
+															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														),
 													)
 													: null,
 											);
@@ -676,10 +682,12 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
 												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
 												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
+												'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
 												'variation' => ! empty( $item->get_variation_id() )
 													? array(
-														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														'node' => array(
+															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														),
 													)
 													: null,
 											);
@@ -877,10 +885,12 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
 												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
 												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
+												'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
 												'variation' => ! empty( $item->get_variation_id() )
 													? array(
-														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														'node' => array(
+															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														),
 													)
 													: null,
 											);
@@ -1059,10 +1069,12 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
 												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
 												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
+												'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
 												'variation' => ! empty( $item->get_variation_id() )
 													? array(
-														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														'node' => array(
+															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														),
 													)
 													: null,
 											);
@@ -1217,15 +1229,17 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
                                 totalTax
                                 taxStatus
                                 product {
-                                    ... on SimpleProduct {
-                                        id
-                                    }
-                                    ... on VariableProduct {
-                                        id
-                                    }
+									node {
+										... on SimpleProduct {
+											id
+										}
+										... on VariableProduct {
+											id
+										}
+									}
                                 }
                                 variation {
-                                    id
+                                    node { id }
                                 }
                             }
                         }
@@ -1288,10 +1302,12 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
 											'total'       => ! empty( $item->get_total() ) ? $item->get_total() : null,
 											'totalTax'    => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 											'taxStatus'   => strtoupper( $item->get_tax_status() ),
-											'product'     => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
-											'variation'   => ! empty( $item->get_variation_id() )
+											'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
+											'variation' => ! empty( $item->get_variation_id() )
 												? array(
-													'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+													'node' => array(
+														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+													),
 												)
 												: null,
 										);

--- a/tests/wpunit/CheckoutMutationTest.php
+++ b/tests/wpunit/CheckoutMutationTest.php
@@ -1302,8 +1302,8 @@ class CheckoutMutationTest extends \Codeception\TestCase\WPTestCase {
 											'total'       => ! empty( $item->get_total() ) ? $item->get_total() : null,
 											'totalTax'    => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 											'taxStatus'   => strtoupper( $item->get_tax_status() ),
-											'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
-											'variation' => ! empty( $item->get_variation_id() )
+											'product'     => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
+											'variation'   => ! empty( $item->get_variation_id() )
 												? array(
 													'node' => array(
 														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),

--- a/tests/wpunit/OrderItemQueriesTest.php
+++ b/tests/wpunit/OrderItemQueriesTest.php
@@ -257,15 +257,17 @@ class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
                             }
                             taxStatus
                             product {
-                                ... on SimpleProduct {
-                                    id
-                                }
-                                ... on VariableProduct {
-                                    id
-                                }
+								node {
+									... on SimpleProduct {
+										id
+									}
+									... on VariableProduct {
+										id
+									}
+								}
                             }
                             variation {
-                                id
+                                node { id }
                             }
                         }
                     }
@@ -301,12 +303,12 @@ class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 						$this->expectedField( 'totalTax', $this->maybe( $item->get_total_tax(), self::IS_NULL ) ),
 						$this->expectedField( 'itemDownloads', null ),
 						$this->expectedField( 'taxStatus', strtoupper( $item->get_tax_status() ) ),
-						$this->expectedField( 'product.id', $this->toRelayId( 'product', $item->get_product_id() ) ),
+						$this->expectedField( 'product.node.id', $this->toRelayId( 'product', $item->get_product_id() ) ),
 						$this->expectedField(
-							'variation.id',
+							'variation.node.id',
 							! empty( $item->get_variation_id() )
 								? $this->toRelayId( 'product_variation', $item->get_variation_id() )
-								: null
+								: self::IS_NULL
 						),
 					)
 				);

--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -187,15 +187,17 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
                                 totalTax
                                 taxStatus
                                 product {
-                                    ... on SimpleProduct {
-                                        id
-                                    }
-                                    ... on VariableProduct {
-                                        id
-                                    }
+									node {
+										... on SimpleProduct {
+											id
+										}
+										... on VariableProduct {
+											id
+										}
+									}
                                 }
                                 variation {
-                                    id
+                                    node { id }
                                 }
                             }
                         }
@@ -436,10 +438,12 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
 												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
+												'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
 												'variation' => ! empty( $item->get_variation_id() )
 													? array(
-														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														'node' => array(
+															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														),
 													)
 													: null,
 											);
@@ -758,10 +762,12 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
 												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
 												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ),
+												'product'  => array( 'node' => array( 'id' => $this->product->to_relay_id( $item->get_product_id() ) ) ),
 												'variation' => ! empty( $item->get_variation_id() )
 													? array(
-														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														'node' => array(
+															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+														),
 													)
 													: null,
 											);


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- `LineItem` fields' `product` and `variation` changed to connections to be consist with the `CartItem` type.


Does this close any currently open issues?
------------------------------------------
Fixes #478 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.10.6
- **WPGraphQL Version:** 1.6.12
- **WordPress Version:** 5.9
- **WooCommerce Version:** 5.6.0
