### PR TITLE
fix: warnings in fillCart with empty coupons/shippingMethods

### DIFF
--- a/includes/mutation/class-cart-fill.php
+++ b/includes/mutation/class-cart-fill.php
@@ -194,7 +194,7 @@ class Cart_Fill {
 				throw new UserError( __( 'Failed to add any cart items. Please check input.', 'wp-graphql-woocommerce' ) );
 			}
 
-			$applied = array();
+			$applied         = array();
 			$invalid_coupons = array();
 			if ( ! empty( $input['coupons'] ) ) {
 				foreach ( $input['coupons'] as $code ) {
@@ -224,7 +224,7 @@ class Cart_Fill {
 				}
 			}//end if
 
-			$chosen_shipping_methods = array();
+			$chosen_shipping_methods  = array();
 			$invalid_shipping_methods = array();
 			if ( ! empty( $input['shippingMethods'] ) ) {
 				$posted_shipping_methods = $input['shippingMethods'];

--- a/includes/mutation/class-cart-fill.php
+++ b/includes/mutation/class-cart-fill.php
@@ -195,8 +195,8 @@ class Cart_Fill {
 			}
 
 			$applied = array();
+			$invalid_coupons = array();
 			if ( ! empty( $input['coupons'] ) ) {
-				$invalid_coupons = array();
 				foreach ( $input['coupons'] as $code ) {
 					$reason = '';
 					// If validate and successful applied to cart, return payload.
@@ -225,6 +225,7 @@ class Cart_Fill {
 			}//end if
 
 			$chosen_shipping_methods = array();
+			$invalid_shipping_methods = array();
 			if ( ! empty( $input['shippingMethods'] ) ) {
 				$posted_shipping_methods = $input['shippingMethods'];
 
@@ -232,7 +233,6 @@ class Cart_Fill {
 				$chosen_shipping_methods = \WC()->session->get( 'chosen_shipping_methods' );
 
 				// Update current shipping methods.
-				$invalid_shipping_methods = array();
 				foreach ( $posted_shipping_methods as $package => $chosen_method ) {
 					if ( empty( $chosen_method ) ) {
 						continue;


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
PHP warnings in the `fillCart` mutation when `coupons` or `shippingMethods` is empty.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.10.7
- **WPGraphQL Version:** 1.7.2
- **WordPress Version:** 5.9.1
- **WooCommerce Version:** 6.2.1
