### PR TITLE
ENHANCEMENT: product metaData values

### DIFF
--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -44,7 +44,8 @@ class Meta_Data_Type {
 						'type'        => 'String',
 						'description' => __( 'Meta value.', 'wp-graphql-woocommerce' ),
 						'resolve'     => function ( $source ) {
-							return ! empty( $source->value ) ? (string) $source->value : null;
+							$value = is_array($source->value) ? serialize($source->value) : $source->value;
+							return ! empty( $source->value ) ? (string) $value : null;
 						},
 					),
 				),


### PR DESCRIPTION
When a product meta_data value is an array the output is "Array". Instead of this my proposal is to return a json string when $source->value is an array

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
