### PR TITLE
fix: is_post_private overrode in WC_Post model abstract class

### DIFF
--- a/includes/model/class-wc-post.php
+++ b/includes/model/class-wc-post.php
@@ -122,7 +122,11 @@ abstract class WC_Post extends Post {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Method for determining if the data should be considered private or not
+	 *
+	 * @param WP_Post $post_object The object of the post we need to verify permissions for.
+	 *
+	 * @return bool
 	 */
 	protected function is_post_private( $post_object = null ) {
 		$post_type_object = $this->post_type_object;
@@ -176,7 +180,7 @@ abstract class WC_Post extends Post {
 			if ( ! current_user_can( $cap, $parent->ID ) ) {
 				return true;
 			}
-		}
+		}//end if
 
 		return false;
 	}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Corrects viewing capability for all WC post types.


Does this close any currently open issues?
------------------------------------------
Fixes #624 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
