### PR TITLE
Change deprecated method is_graphql_request

### DIFF
--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -44,7 +44,7 @@ class WooCommerce_Filters {
 	 * @return string
 	 */
 	public static function woocommerce_session_handler( $session_class ) {
-		if ( \WPGraphQL\Router::is_graphql_request() ) {
+		if ( \WPGraphQL\Router::is_graphql_http_request() ) {
 			$session_class = '\WPGraphQL\WooCommerce\Utils\QL_Session_Handler';
 		}
 


### PR DESCRIPTION
Method WPGraphQL\Router::is_graphql_request to WPGraphQL\Router::is_graphql_http_request

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [v] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [v] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR only changes one method to another the suggested one.
WPGraphQL\Router::is_graphql_request is deprecated since 0.4.1. Use Router::is_graphql_http_request instead.
https://github.com/wp-graphql/wp-graphql/blob/develop/src/Router.php#L220


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.11.2
- **WPGraphQL Version:** 1.12.2
- **WordPress Version:** 6.1
- **WooCommerce Version:** 7.1.0
