### PR TITLE
fix: Connections need to connect to Types that implement the Node interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ php-coveralls.phar
 codeception.yml
 .editorconfig
 plugin-build
+local

--- a/includes/data/connection/class-product-attribute-connection-resolver.php
+++ b/includes/data/connection/class-product-attribute-connection-resolver.php
@@ -84,7 +84,6 @@ class Product_Attribute_Connection_Resolver {
 	 */
 	public function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$attributes = $this->get_items( $source->attributes, $source, $args, $context, $info );
-
 		$connection = Relay::connectionFromArray( $attributes, $args );
 		$nodes      = [];
 		if ( ! empty( $connection['edges'] ) && is_array( $connection['edges'] ) ) {

--- a/includes/type/interface/class-attribute.php
+++ b/includes/type/interface/class-attribute.php
@@ -23,6 +23,7 @@ class Attribute {
 			'Attribute',
 			[
 				'description' => __( 'Attribute object', 'wp-graphql-woocommerce' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'name'  => [
 						'type'        => 'String',

--- a/includes/type/interface/class-product-attribute.php
+++ b/includes/type/interface/class-product-attribute.php
@@ -23,6 +23,7 @@ class Product_Attribute {
 			'ProductAttribute',
 			[
 				'description' => __( 'Product attribute object', 'wp-graphql-woocommerce' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
 				'resolveType' => function( $value ) use ( &$type_registry ) {
 					if ( $value->is_taxonomy() ) {

--- a/includes/type/interface/class-product-attribute.php
+++ b/includes/type/interface/class-product-attribute.php
@@ -8,6 +8,8 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPInterface;
 
+use GraphQLRelay\Relay;
+
 /**
  * Class Product_Attribute
  */
@@ -46,9 +48,6 @@ class Product_Attribute {
 			'id'          => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => __( 'Attribute Global ID', 'wp-graphql-woocommerce' ),
-				'resolve'     => function ( $attribute ) {
-					return ! empty( $attribute->_relay_id ) ? $attribute->_relay_id : null;
-				},
 			],
 			'attributeId' => [
 				'type'        => [ 'non_null' => 'Int' ],

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -32,6 +32,7 @@ class Product {
 			'Product',
 			[
 				'description' => __( 'Product object', 'wp-graphql-woocommerce' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
 				'resolveType' => function( $value ) use ( &$type_registry ) {
 					$possible_types = WP_GraphQL_WooCommerce::get_enabled_product_types();

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -429,6 +429,7 @@ class Cart_Type {
 			'CartItem',
 			[
 				'description' => __( 'A item in the cart', 'wp-graphql-woocommerce' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'key'         => [
 						'type'        => [ 'non_null' => 'ID' ],

--- a/includes/type/object/class-downloadable-item-type.php
+++ b/includes/type/object/class-downloadable-item-type.php
@@ -27,6 +27,7 @@ class Downloadable_Item_Type {
 			'DownloadableItem',
 			[
 				'description' => __( 'A downloadable item', 'wp-graphql-woocommerce' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'downloadId'         => [
 						'type'        => [ 'non_null' => 'String' ],

--- a/includes/type/object/class-order-item-type.php
+++ b/includes/type/object/class-order-item-type.php
@@ -247,6 +247,7 @@ class Order_Item_Type {
 					'description' => $config[0],
 					'fields'      => self::get_fields( $config[1] ),
 					'connections' => ! empty( $config[2] ) ? $config[2] : null,
+					'interfaces'  => [ 'Node' ],
 				]
 			);
 		}

--- a/includes/type/object/class-payment-gateway-type.php
+++ b/includes/type/object/class-payment-gateway-type.php
@@ -23,9 +23,10 @@ class Payment_Gateway_Type {
 			'PaymentGateway',
 			[
 				'description' => __( 'A payment gateway object', 'wp-graphql-woocommerce' ),
+				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'          => [
-						'type'        => [ 'non_null' => 'String' ],
+						'type'        => [ 'non_null' => 'ID' ],
 						'description' => __( 'gateway\'s title', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source ) {
 							return ! empty( $source->id ) ? $source->id : null;

--- a/includes/type/object/class-product-attribute-types.php
+++ b/includes/type/object/class-product-attribute-types.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * WPObject Types - LocalProductAttribute && GlobalProductAttribute
+ * WPObject Types - LocalProductAttributeLocalProductAttribute && GlobalProductAttribute
  *
  * @package WPGraphQL\WooCommerce\Type\WPObject
  * @since   0.3.2
  */
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
+
+use GraphQLRelay\Relay;
 
 /**
  * Class Product_Attribute_Types
@@ -24,6 +26,13 @@ class Product_Attribute_Types {
 				'description' => __( 'A product attribute object', 'wp-graphql-woocommerce' ),
 				'interfaces'  => [ 'ProductAttribute' ],
 				'fields'      => [
+					'id'          => [
+						'type'        => [ 'non_null' => 'ID' ],
+						'description' => __( 'Attribute Global ID', 'wp-graphql-woocommerce' ),
+						'resolve'     => function ( $attribute ) {
+							return ! empty( $attribute->_relay_id ) ? $attribute->_relay_id : Relay::toGlobalId( 'LocalProductAttribute', $attribute->get_id() );
+						},
+					],
 					'scope' => [
 						'type'        => [ 'non_null' => 'ProductAttributeTypesEnum' ],
 						'description' => __( 'Product attribute scope.', 'wp-graphql-woocommerce' ),
@@ -42,6 +51,13 @@ class Product_Attribute_Types {
 				'description' => __( 'A product attribute object', 'wp-graphql-woocommerce' ),
 				'interfaces'  => [ 'ProductAttribute' ],
 				'fields'      => [
+					'id'          => [
+						'type'        => [ 'non_null' => 'ID' ],
+						'description' => __( 'Attribute Global ID', 'wp-graphql-woocommerce' ),
+						'resolve'     => function ( $attribute ) {
+							return ! empty( $attribute->_relay_id ) ? $attribute->_relay_id : Relay::toGlobalId( 'GlobalProductAttribute', $attribute->get_id() );
+						},
+					],
 					'scope' => [
 						'type'        => [ 'non_null' => 'ProductAttributeTypesEnum' ],
 						'description' => __( 'Product attribute scope.', 'wp-graphql-woocommerce' ),

--- a/tests/wpunit/CoreInterfaceQueriesTest.php
+++ b/tests/wpunit/CoreInterfaceQueriesTest.php
@@ -55,17 +55,15 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'product' => [
-					'id'            => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
-					'commentCount'  => 1,
-					'commentStatus' => 'open',
-				],
+			'product' => [
+				'id'            => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
+				'commentCount'  => 1,
+				'commentStatus' => 'open',
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 	}
 
 	public function testOrderAsNodeWithComments() {
@@ -99,17 +97,15 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'order' => [
-					'id'            => \GraphQLRelay\Relay::toGlobalId( 'shop_order', $order_id ),
-					'commentCount'  => 2,
-					'commentStatus' => 'open',
-				],
+			'order' => [
+				'id'            => \GraphQLRelay\Relay::toGlobalId( 'shop_order', $order_id ),
+				'commentCount'  => 2,
+				'commentStatus' => 'open',
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 
 		/**
 		 * Assertion Two
@@ -121,17 +117,15 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'order' => [
-					'id'            => \GraphQLRelay\Relay::toGlobalId( 'shop_order', $order_id ),
-					'commentCount'  => 1,
-					'commentStatus' => 'closed',
-				],
+			'order' => [
+				'id'            => \GraphQLRelay\Relay::toGlobalId( 'shop_order', $order_id ),
+				'commentCount'  => 1,
+				'commentStatus' => 'closed',
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 	}
 
 	public function testProductAsNodeWithContentEditor() {
@@ -163,16 +157,14 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'product' => [
-					'id'      => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
-					'content' => $product->get_description(),
-				],
+			'product' => [
+				'id'      => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
+				'content' => $product->get_description(),
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 	}
 
 	public function testProductAsNodeWithFeaturedImage() {
@@ -204,17 +196,15 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'product' => [
-					'id'                      => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
-					'featuredImageId'         => \GraphQLRelay\Relay::toGlobalId( 'post', $attachment_id ),
-					'featuredImageDatabaseId' => $attachment_id,
-				],
+			'product' => [
+				'id'                      => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
+				'featuredImageId'         => \GraphQLRelay\Relay::toGlobalId( 'post', $attachment_id ),
+				'featuredImageDatabaseId' => $attachment_id,
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 	}
 
 	public function testProductAsContentNode() {
@@ -257,31 +247,29 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'product' => [
-					'id'                        => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
-					'databaseId'                => $wp_product->ID,
-					'date'                      => (string) $wc_product->get_date_created(),
-					'dateGmt'                   => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_date_gmt ),
-					'enclosure'                 => get_post_meta( $wp_product->ID, 'enclosure', true ) ?? null,
-					'status'                    => $wp_product->post_status,
-					'slug'                      => $wp_product->post_name,
-					'modified'                  => (string) $wc_product->get_date_modified(),
-					'modifiedGmt'               => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_modified_gmt ),
-					'guid'                      => $wp_product->guid,
-					'desiredSlug'               => null,
-					'link'                      => get_permalink( $wp_product->ID ),
-					'uri'                       => str_ireplace( home_url(), '', get_permalink( $wp_product->ID ) ),
-					'isRestricted'              => false,
-					'isPreview'                 => null,
-					'previewRevisionDatabaseId' => null,
-					'previewRevisionId'         => null,
-				],
+			'product' => [
+				'id'                        => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
+				'databaseId'                => $wp_product->ID,
+				'date'                      => (string) $wc_product->get_date_created(),
+				'dateGmt'                   => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_date_gmt ),
+				'enclosure'                 => get_post_meta( $wp_product->ID, 'enclosure', true ) ?? null,
+				'status'                    => $wp_product->post_status,
+				'slug'                      => $wp_product->post_name,
+				'modified'                  => (string) $wc_product->get_date_modified(),
+				'modifiedGmt'               => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_modified_gmt ),
+				'guid'                      => $wp_product->guid,
+				'desiredSlug'               => null,
+				'link'                      => get_permalink( $wp_product->ID ),
+				'uri'                       => str_ireplace( home_url(), '', get_permalink( $wp_product->ID ) ),
+				'isRestricted'              => false,
+				'isPreview'                 => null,
+				'previewRevisionDatabaseId' => null,
+				'previewRevisionId'         => null,
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 	}
 
 	public function testProductAsUniformResourceIdentifiable() {
@@ -308,16 +296,14 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'product' => [
-					'id'  => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
-					'uri' => str_ireplace( home_url(), '', get_permalink( $wp_product->ID ) ),
-				],
+			'product' => [
+				'id'  => \GraphQLRelay\Relay::toGlobalId( 'product', $product_id ),
+				'uri' => str_ireplace( home_url(), '', get_permalink( $wp_product->ID ) ),
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 	}
 
 	public function testNodeInterfacesOnProductVariation() {
@@ -364,33 +350,31 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 		// Define expected data object.
 		$expected = [
-			'data' => [
-				'productVariation' => [
-					'id'                        => \GraphQLRelay\Relay::toGlobalId( 'product_variation', $variation_id ),
-					'databaseId'                => $wp_product->ID,
-					'date'                      => (string) $wc_product->get_date_created(),
-					'dateGmt'                   => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_date_gmt ),
-					'enclosure'                 => get_post_meta( $wp_product->ID, 'enclosure', true ) ?? null,
-					'status'                    => $wp_product->post_status,
-					'slug'                      => $wp_product->post_name,
-					'modified'                  => (string) $wc_product->get_date_modified(),
-					'modifiedGmt'               => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_modified_gmt ),
-					'guid'                      => $wp_product->guid,
-					'desiredSlug'               => null,
-					'link'                      => get_permalink( $wp_product->ID ),
-					'uri'                       => str_ireplace( home_url(), '', get_permalink( $wp_product->ID ) ),
-					'isRestricted'              => false,
-					'isPreview'                 => null,
-					'previewRevisionDatabaseId' => null,
-					'previewRevisionId'         => null,
-					'featuredImageId'           => \GraphQLRelay\Relay::toGlobalId( 'post', $wc_product->get_image_id() ),
-					'featuredImageDatabaseId'   => $wc_product->get_image_id(),
-				],
+			'productVariation' => [
+				'id'                        => \GraphQLRelay\Relay::toGlobalId( 'product_variation', $variation_id ),
+				'databaseId'                => $wp_product->ID,
+				'date'                      => (string) $wc_product->get_date_created(),
+				'dateGmt'                   => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_date_gmt ),
+				'enclosure'                 => get_post_meta( $wp_product->ID, 'enclosure', true ) ?? null,
+				'status'                    => $wp_product->post_status,
+				'slug'                      => $wp_product->post_name,
+				'modified'                  => (string) $wc_product->get_date_modified(),
+				'modifiedGmt'               => \WPGraphQL\Utils\Utils::prepare_date_response( $wp_product->post_modified_gmt ),
+				'guid'                      => $wp_product->guid,
+				'desiredSlug'               => null,
+				'link'                      => get_permalink( $wp_product->ID ),
+				'uri'                       => str_ireplace( home_url(), '', get_permalink( $wp_product->ID ) ),
+				'isRestricted'              => false,
+				'isPreview'                 => null,
+				'previewRevisionDatabaseId' => null,
+				'previewRevisionId'         => null,
+				'featuredImageId'           => \GraphQLRelay\Relay::toGlobalId( 'post', $wc_product->get_image_id() ),
+				'featuredImageDatabaseId'   => $wc_product->get_image_id(),
 			],
 		];
 
 		// Assert query response valid.
-		$this->assertEquals( $expected, $response );
+		$this->assertEquals( $expected, $response['data'] );
 	}
 
 	public function testQueryProductWithNodeByUri() {

--- a/tests/wpunit/CustomerMutationsTest.php
+++ b/tests/wpunit/CustomerMutationsTest.php
@@ -234,28 +234,26 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( is_a( $user, WP_User::class ) );
 
 		$expected = [
-			'data' => [
-				'registerCustomer' => [
-					'clientMutationId' => 'someId',
-					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
-					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
-					'customer'         => [
-						'databaseId' => $user->ID,
-						'email'      => $this->email,
-						'username'   => $this->username,
-						'firstName'  => $this->first_name,
-						'lastName'   => $this->last_name,
-						'billing'    => $this->empty_billing(),
-						'shipping'   => $this->empty_shipping(),
-					],
-					'viewer'           => [
-						'userId' => $user->ID,
-					],
+			'registerCustomer' => [
+				'clientMutationId' => 'someId',
+				'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+				'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+				'customer'         => [
+					'databaseId' => $user->ID,
+					'email'      => $this->email,
+					'username'   => $this->username,
+					'firstName'  => $this->first_name,
+					'lastName'   => $this->last_name,
+					'billing'    => $this->empty_billing(),
+					'shipping'   => $this->empty_shipping(),
+				],
+				'viewer'           => [
+					'userId' => $user->ID,
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testRegisterMutationWithBillingInfo() {
@@ -283,28 +281,26 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( is_a( $user, WP_User::class ) );
 
 		$expected = [
-			'data' => [
-				'registerCustomer' => [
-					'clientMutationId' => 'someId',
-					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
-					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
-					'customer'         => [
-						'databaseId' => $user->ID,
-						'email'      => $this->email,
-						'username'   => $this->username,
-						'firstName'  => $this->first_name,
-						'lastName'   => $this->last_name,
-						'billing'    => array_merge( $this->empty_billing(), $this->billing ),
-						'shipping'   => $this->empty_shipping(),
-					],
-					'viewer'           => [
-						'userId' => $user->ID,
-					],
+			'registerCustomer' => [
+				'clientMutationId' => 'someId',
+				'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+				'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+				'customer'         => [
+					'databaseId' => $user->ID,
+					'email'      => $this->email,
+					'username'   => $this->username,
+					'firstName'  => $this->first_name,
+					'lastName'   => $this->last_name,
+					'billing'    => array_merge( $this->empty_billing(), $this->billing ),
+					'shipping'   => $this->empty_shipping(),
+				],
+				'viewer'           => [
+					'userId' => $user->ID,
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testRegisterMutationWithShippingSameAsBillingInfo() {
@@ -333,31 +329,29 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( is_a( $user, WP_User::class ) );
 
 		$expected = [
-			'data' => [
-				'registerCustomer' => [
-					'clientMutationId' => 'someId',
-					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
-					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
-					'customer'         => [
-						'databaseId' => $user->ID,
-						'email'      => $this->email,
-						'username'   => $this->username,
-						'firstName'  => $this->first_name,
-						'lastName'   => $this->last_name,
-						'billing'    => array_merge( $this->empty_billing(), $this->billing ),
-						'shipping'   => array_merge(
-							$this->empty_shipping(),
-							array_intersect_key( $this->billing, $this->empty_shipping() )
-						),
-					],
-					'viewer'           => [
-						'userId' => $user->ID,
-					],
+			'registerCustomer' => [
+				'clientMutationId' => 'someId',
+				'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+				'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+				'customer'         => [
+					'databaseId' => $user->ID,
+					'email'      => $this->email,
+					'username'   => $this->username,
+					'firstName'  => $this->first_name,
+					'lastName'   => $this->last_name,
+					'billing'    => array_merge( $this->empty_billing(), $this->billing ),
+					'shipping'   => array_merge(
+						$this->empty_shipping(),
+						array_intersect_key( $this->billing, $this->empty_shipping() )
+					),
+				],
+				'viewer'           => [
+					'userId' => $user->ID,
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testRegisterMutationWithBillingAndShippingInfo() {
@@ -386,28 +380,26 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( is_a( $user, WP_User::class ) );
 
 		$expected = [
-			'data' => [
-				'registerCustomer' => [
-					'clientMutationId' => 'someId',
-					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
-					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
-					'customer'         => [
-						'databaseId' => $user->ID,
-						'email'      => $this->email,
-						'username'   => $this->username,
-						'firstName'  => $this->first_name,
-						'lastName'   => $this->last_name,
-						'billing'    => array_merge( $this->empty_billing(), $this->billing ),
-						'shipping'   => array_merge( $this->empty_shipping(), $this->shipping ),
-					],
-					'viewer'           => [
-						'userId' => $user->ID,
-					],
+			'registerCustomer' => [
+				'clientMutationId' => 'someId',
+				'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+				'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+				'customer'         => [
+					'databaseId' => $user->ID,
+					'email'      => $this->email,
+					'username'   => $this->username,
+					'firstName'  => $this->first_name,
+					'lastName'   => $this->last_name,
+					'billing'    => array_merge( $this->empty_billing(), $this->billing ),
+					'shipping'   => array_merge( $this->empty_shipping(), $this->shipping ),
+				],
+				'viewer'           => [
+					'userId' => $user->ID,
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testUpdateMutation() {
@@ -448,25 +440,23 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$expected = [
-			'data' => [
-				'updateCustomer' => [
-					'clientMutationId' => 'someId',
-					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
-					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
-					'customer'         => [
-						'databaseId' => $user->ID,
-						'email'      => $this->new_email,
-						'username'   => $this->username,
-						'firstName'  => $this->new_first_name,
-						'lastName'   => $this->new_last_name,
-						'billing'    => array_merge( $this->empty_billing(), $this->new_billing ),
-						'shipping'   => array_merge( $this->empty_shipping(), $this->new_shipping ),
-					],
+			'updateCustomer' => [
+				'clientMutationId' => 'someId',
+				'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+				'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+				'customer'         => [
+					'databaseId' => $user->ID,
+					'email'      => $this->new_email,
+					'username'   => $this->username,
+					'firstName'  => $this->new_first_name,
+					'lastName'   => $this->new_last_name,
+					'billing'    => array_merge( $this->empty_billing(), $this->new_billing ),
+					'shipping'   => array_merge( $this->empty_shipping(), $this->new_shipping ),
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testUpdateMutationWithShippingSameAsBilling() {
@@ -503,28 +493,26 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$expected = [
-			'data' => [
-				'updateCustomer' => [
-					'clientMutationId' => 'someId',
-					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
-					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
-					'customer'         => [
-						'databaseId' => $user->ID,
-						'email'      => $this->email,
-						'username'   => $this->username,
-						'firstName'  => $this->first_name,
-						'lastName'   => $this->last_name,
-						'billing'    => array_merge( $this->empty_billing(), $this->billing ),
-						'shipping'   => array_merge(
-							$this->empty_shipping(),
-							array_intersect_key( $this->billing, $this->empty_shipping() )
-						),
-					],
+			'updateCustomer' => [
+				'clientMutationId' => 'someId',
+				'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+				'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+				'customer'         => [
+					'databaseId' => $user->ID,
+					'email'      => $this->email,
+					'username'   => $this->username,
+					'firstName'  => $this->first_name,
+					'lastName'   => $this->last_name,
+					'billing'    => array_merge( $this->empty_billing(), $this->billing ),
+					'shipping'   => array_merge(
+						$this->empty_shipping(),
+						array_intersect_key( $this->billing, $this->empty_shipping() )
+					),
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testRegisterMutationWithoutAnyInfo() {
@@ -549,28 +537,26 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( is_a( $user, WP_User::class ) );
 
 		$expected = [
-			'data' => [
-				'registerCustomer' => [
-					'clientMutationId' => 'someId',
-					'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
-					'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
-					'customer'         => [
-						'databaseId' => $user->ID,
-						'email'      => $this->email,
-						'username'   => $user->user_login,
-						'firstName'  => $this->first_name,
-						'lastName'   => $this->last_name,
-						'billing'    => $this->empty_billing(),
-						'shipping'   => $this->empty_shipping(),
-					],
-					'viewer'           => [
-						'userId' => $user->ID,
-					],
+			'registerCustomer' => [
+				'clientMutationId' => 'someId',
+				'authToken'        => \WPGraphQL\JWT_Authentication\Auth::get_token( $user ),
+				'refreshToken'     => \WPGraphQL\JWT_Authentication\Auth::get_refresh_token( $user ),
+				'customer'         => [
+					'databaseId' => $user->ID,
+					'email'      => $this->email,
+					'username'   => $user->user_login,
+					'firstName'  => $this->first_name,
+					'lastName'   => $this->last_name,
+					'billing'    => $this->empty_billing(),
+					'shipping'   => $this->empty_shipping(),
+				],
+				'viewer'           => [
+					'userId' => $user->ID,
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testCustomerMutationsWithMeta() {
@@ -613,23 +599,21 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( is_a( $user, WP_User::class ) );
 
 		$expected = [
-			'data' => [
-				'registerCustomer' => [
-					'customer' => [
-						'databaseId' => $user->ID,
-						'email'      => 'user@woographql.test',
-						'metaData'   => [
-							[
-								'key'   => 'test_meta_key',
-								'value' => 'test_meta_value',
-							],
+			'registerCustomer' => [
+				'customer' => [
+					'databaseId' => $user->ID,
+					'email'      => 'user@woographql.test',
+					'metaData'   => [
+						[
+							'key'   => 'test_meta_key',
+							'value' => 'test_meta_value',
 						],
 					],
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Two
@@ -667,23 +651,21 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$expected = [
-			'data' => [
-				'updateCustomer' => [
-					'customer' => [
-						'databaseId' => $user->ID,
-						'email'      => 'user@woographql.test',
-						'metaData'   => [
-							[
-								'key'   => 'test_meta_key',
-								'value' => 'new_meta_value',
-							],
+			'updateCustomer' => [
+				'customer' => [
+					'databaseId' => $user->ID,
+					'email'      => 'user@woographql.test',
+					'metaData'   => [
+						[
+							'key'   => 'test_meta_key',
+							'value' => 'new_meta_value',
 						],
 					],
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Three
@@ -719,21 +701,19 @@ class CustomerMutationsTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$expected = [
-			'data' => [
-				'updateCustomer' => [
-					'customer' => [
-						'id'       => 'guest',
-						'metaData' => [
-							[
-								'key'   => 'test_meta_key',
-								'value' => 'test_meta_value',
-							],
+			'updateCustomer' => [
+				'customer' => [
+					'id'       => 'guest',
+					'metaData' => [
+						[
+							'key'   => 'test_meta_key',
+							'value' => 'test_meta_value',
 						],
 					],
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 }

--- a/tests/wpunit/MetaDataQueriesTest.php
+++ b/tests/wpunit/MetaDataQueriesTest.php
@@ -121,21 +121,19 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$actual   = graphql( [ 'query' => $query ] );
 		$expected = [
-			'data' => [
-				'cart' => [
-					'contents' => [
-						'nodes' => [
-							[
-								'key'       => $this->cart_item_key,
-								'extraData' => [
-									[
-										'key'   => 'meta_1',
-										'value' => 'test_meta_1',
-									],
-									[
-										'key'   => 'meta_2',
-										'value' => 'test_meta_2',
-									],
+			'cart' => [
+				'contents' => [
+					'nodes' => [
+						[
+							'key'       => $this->cart_item_key,
+							'extraData' => [
+								[
+									'key'   => 'meta_1',
+									'value' => 'test_meta_1',
+								],
+								[
+									'key'   => 'meta_2',
+									'value' => 'test_meta_2',
 								],
 							],
 						],
@@ -147,7 +145,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Two
@@ -162,17 +160,15 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'cart' => [
-					'contents' => [
-						'nodes' => [
-							[
-								'key'       => $this->cart_item_key,
-								'extraData' => [
-									[
-										'key'   => 'meta_2',
-										'value' => 'test_meta_2',
-									],
+			'cart' => [
+				'contents' => [
+					'nodes' => [
+						[
+							'key'       => $this->cart_item_key,
+							'extraData' => [
+								[
+									'key'   => 'meta_2',
+									'value' => 'test_meta_2',
 								],
 							],
 						],
@@ -184,7 +180,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Three
@@ -199,17 +195,15 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'cart' => [
-					'contents' => [
-						'nodes' => [
-							[
-								'key'       => $this->cart_item_key,
-								'extraData' => [
-									[
-										'key'   => 'meta_2',
-										'value' => 'test_meta_2',
-									],
+			'cart' => [
+				'contents' => [
+					'nodes' => [
+						[
+							'key'       => $this->cart_item_key,
+							'extraData' => [
+								[
+									'key'   => 'meta_2',
+									'value' => 'test_meta_2',
 								],
 							],
 						],
@@ -221,7 +215,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testCouponMetaDataQueries() {
@@ -252,18 +246,16 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'coupon' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'coupon' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
 					],
 				],
 			],
@@ -272,7 +264,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Two
@@ -290,14 +282,12 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'coupon' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'coupon' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
 					],
 				],
 			],
@@ -306,7 +296,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Three
@@ -324,14 +314,12 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'coupon' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'coupon' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
 					],
 				],
 			],
@@ -340,7 +328,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Four
@@ -359,18 +347,16 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'coupon' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_1',
-							'value' => '75',
-						],
+			'coupon' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_1',
+						'value' => '75',
 					],
 				],
 			],
@@ -379,7 +365,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Five
@@ -398,18 +384,16 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'coupon' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_1',
-							'value' => '75',
-						],
+			'coupon' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_1',
+						'value' => '75',
 					],
 				],
 			],
@@ -418,7 +402,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Six
@@ -436,22 +420,20 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'coupon' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
-						[
-							'key'   => 'meta_1',
-							'value' => '75',
-						],
+			'coupon' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
+					],
+					[
+						'key'   => 'meta_1',
+						'value' => '75',
 					],
 				],
 			],
@@ -460,7 +442,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testCustomerMetaDataQueries() {
@@ -482,18 +464,16 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$this->set_user( $this->customer_id );
 		$actual   = graphql( [ 'query' => $query ] );
 		$expected = [
-			'data' => [
-				'customer' => [
-					'id'       => Relay::toGlobalId( 'customer', $this->customer_id ),
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'customer' => [
+				'id'       => Relay::toGlobalId( 'customer', $this->customer_id ),
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
 					],
 				],
 			],
@@ -502,7 +482,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testOrderMetaDataQueries() {
@@ -541,31 +521,29 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'order' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'order' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
 					],
-					'feeLines' => [
-						'nodes' => [
-							[
-								'metaData' => [
-									[
-										'key'   => 'meta_1',
-										'value' => 'test_meta_1',
-									],
-									[
-										'key'   => 'meta_2',
-										'value' => 'test_meta_2',
-									],
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
+					],
+				],
+				'feeLines' => [
+					'nodes' => [
+						[
+							'metaData' => [
+								[
+									'key'   => 'meta_1',
+									'value' => 'test_meta_1',
+								],
+								[
+									'key'   => 'meta_2',
+									'value' => 'test_meta_2',
 								],
 							],
 						],
@@ -577,7 +555,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testProductMetaDataQueries() {
@@ -607,18 +585,16 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'product' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'product' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
 					],
 				],
 			],
@@ -627,7 +603,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testProductVariationMetaDataQueries() {
@@ -655,18 +631,16 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'productVariation' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'productVariation' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
 					],
 				],
 			],
@@ -675,7 +649,7 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testRefundMetaDataQueries() {
@@ -704,18 +678,16 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'refund' => [
-					'id'       => $id,
-					'metaData' => [
-						[
-							'key'   => 'meta_1',
-							'value' => 'test_meta_1',
-						],
-						[
-							'key'   => 'meta_2',
-							'value' => 'test_meta_2',
-						],
+			'refund' => [
+				'id'       => $id,
+				'metaData' => [
+					[
+						'key'   => 'meta_1',
+						'value' => 'test_meta_1',
+					],
+					[
+						'key'   => 'meta_2',
+						'value' => 'test_meta_2',
 					],
 				],
 			],
@@ -724,6 +696,6 @@ class MetaDataQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 }

--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -334,131 +334,129 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$order = \WC_Order_Factory::get_order( $actual['data']['createOrder']['order']['databaseId'] );
 
 		$expected = [
-			'data' => [
-				'createOrder' => [
-					'clientMutationId' => 'someId',
-					'order'            => array_merge(
-						$this->order->print_query( $order->get_id() ),
-						[
-							'couponLines'   => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'databaseId' => $item->get_id(),
-												'orderId'  => $item->get_order_id(),
-												'code'     => $item->get_code(),
-												'discount' => ! empty( $item->get_discount() ) ? $item->get_discount() : null,
-												'discountTax' => ! empty( $item->get_discount_tax() ) ? $item->get_discount_tax() : null,
-												'coupon'   => [
-													'id' => $this->coupon->to_relay_id( \wc_get_coupon_id_by_code( $item->get_code() ) ),
-												],
-											];
-										},
-										$order->get_items( 'coupon' )
-									)
-								),
-							],
-							'feeLines'      => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'databaseId' => $item->get_id(),
-												'orderId'  => $item->get_order_id(),
-												'amount'   => $item->get_amount(),
-												'name'     => $item->get_name(),
-												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'total'    => $item->get_total(),
-												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
-												'taxClass' => ! empty( $item->get_tax_class() )
-													? WPEnumType::get_safe_name( $item->get_tax_class() )
-													: 'STANDARD',
-											];
-										},
-										$order->get_items( 'fee' )
-									)
-								),
-							],
-							'shippingLines' => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'databaseId' => $item->get_id(),
-												'orderId'  => $item->get_order_id(),
-												'methodTitle' => $item->get_method_title(),
-												'total'    => $item->get_total(),
-												'totalTax' => ! empty( $item->get_total_tax() )
-													? $item->get_total_tax()
-													: null,
-												'taxClass' => ! empty( $item->get_tax_class() )
-													? $item->get_tax_class() === 'inherit'
-														? WPEnumType::get_safe_name( 'inherit cart' )
-														: WPEnumType::get_safe_name( $item->get_tax_class() )
-													: 'STANDARD',
-											];
-										},
-										$order->get_items( 'shipping' )
-									)
-								),
-							],
-							'taxLines'      => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'rateCode' => $item->get_rate_code(),
-												'label'    => $item->get_label(),
-												'taxTotal' => $item->get_tax_total(),
-												'shippingTaxTotal' => $item->get_shipping_tax_total(),
-												'isCompound' => $item->is_compound(),
-												'taxRate'  => [ 'databaseId' => $item->get_rate_id() ],
-											];
-										},
-										$order->get_items( 'tax' )
-									)
-								),
-							],
-							'lineItems'     => [
-								'nodes' => array_values(
-									array_map(
-										function( $item ) {
-											return [
-												'productId' => $item->get_product_id(),
-												'variationId' => ! empty( $item->get_variation_id() )
-													? $item->get_variation_id()
-													: null,
-												'quantity' => $item->get_quantity(),
-												'taxClass' => ! empty( $item->get_tax_class() )
-													? strtoupper( $item->get_tax_class() )
-													: 'STANDARD',
-												'subtotal' => ! empty( $item->get_subtotal() ) ? $item->get_subtotal() : null,
-												'subtotalTax' => ! empty( $item->get_subtotal_tax() ) ? $item->get_subtotal_tax() : null,
-												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
-												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
-												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => [ 'node' => [ 'id' => $this->product->to_relay_id( $item->get_product_id() ) ] ],
-												'variation' => ! empty( $item->get_variation_id() )
-													? [
-														'node' => [
-															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
-														],
-													]
-													: null,
-											];
-										},
-										$order->get_items()
-									)
-								),
-							],
-						]
-					),
-				],
+			'createOrder' => [
+				'clientMutationId' => 'someId',
+				'order'            => array_merge(
+					$this->order->print_query( $order->get_id() ),
+					[
+						'couponLines'   => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'databaseId' => $item->get_id(),
+											'orderId'  => $item->get_order_id(),
+											'code'     => $item->get_code(),
+											'discount' => ! empty( $item->get_discount() ) ? $item->get_discount() : null,
+											'discountTax' => ! empty( $item->get_discount_tax() ) ? $item->get_discount_tax() : null,
+											'coupon'   => [
+												'id' => $this->coupon->to_relay_id( \wc_get_coupon_id_by_code( $item->get_code() ) ),
+											],
+										];
+									},
+									$order->get_items( 'coupon' )
+								)
+							),
+						],
+						'feeLines'      => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'databaseId' => $item->get_id(),
+											'orderId'  => $item->get_order_id(),
+											'amount'   => $item->get_amount(),
+											'name'     => $item->get_name(),
+											'taxStatus' => strtoupper( $item->get_tax_status() ),
+											'total'    => $item->get_total(),
+											'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
+											'taxClass' => ! empty( $item->get_tax_class() )
+												? WPEnumType::get_safe_name( $item->get_tax_class() )
+												: 'STANDARD',
+										];
+									},
+									$order->get_items( 'fee' )
+								)
+							),
+						],
+						'shippingLines' => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'databaseId' => $item->get_id(),
+											'orderId'  => $item->get_order_id(),
+											'methodTitle' => $item->get_method_title(),
+											'total'    => $item->get_total(),
+											'totalTax' => ! empty( $item->get_total_tax() )
+												? $item->get_total_tax()
+												: null,
+											'taxClass' => ! empty( $item->get_tax_class() )
+												? $item->get_tax_class() === 'inherit'
+													? WPEnumType::get_safe_name( 'inherit cart' )
+													: WPEnumType::get_safe_name( $item->get_tax_class() )
+												: 'STANDARD',
+										];
+									},
+									$order->get_items( 'shipping' )
+								)
+							),
+						],
+						'taxLines'      => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'rateCode' => $item->get_rate_code(),
+											'label'    => $item->get_label(),
+											'taxTotal' => $item->get_tax_total(),
+											'shippingTaxTotal' => $item->get_shipping_tax_total(),
+											'isCompound' => $item->is_compound(),
+											'taxRate'  => [ 'databaseId' => $item->get_rate_id() ],
+										];
+									},
+									$order->get_items( 'tax' )
+								)
+							),
+						],
+						'lineItems'     => [
+							'nodes' => array_values(
+								array_map(
+									function( $item ) {
+										return [
+											'productId' => $item->get_product_id(),
+											'variationId' => ! empty( $item->get_variation_id() )
+												? $item->get_variation_id()
+												: null,
+											'quantity' => $item->get_quantity(),
+											'taxClass' => ! empty( $item->get_tax_class() )
+												? strtoupper( $item->get_tax_class() )
+												: 'STANDARD',
+											'subtotal' => ! empty( $item->get_subtotal() ) ? $item->get_subtotal() : null,
+											'subtotalTax' => ! empty( $item->get_subtotal_tax() ) ? $item->get_subtotal_tax() : null,
+											'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
+											'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
+											'taxStatus' => strtoupper( $item->get_tax_status() ),
+											'product'  => [ 'node' => [ 'id' => $this->product->to_relay_id( $item->get_product_id() ) ] ],
+											'variation' => ! empty( $item->get_variation_id() )
+												? [
+													'node' => [
+														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+													],
+												]
+												: null,
+										];
+									},
+									$order->get_items()
+								)
+							),
+						],
+					]
+				),
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testUpdateOrderMutation() {
@@ -658,132 +656,130 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 		$order = \WC_Order_Factory::get_order( $order->get_id() );
 
 		$expected = [
-			'data' => [
-				'updateOrder' => [
-					'clientMutationId' => 'someId',
-					'order'            => array_merge(
-						$this->order->print_query( $order->get_id() ),
-						[
-							'couponLines'   => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'databaseId' => $item->get_id(),
-												'orderId'  => $item->get_order_id(),
-												'code'     => $item->get_code(),
-												'discount' => ! empty( $item->get_discount() ) ? $item->get_discount() : null,
-												'discountTax' => ! empty( $item->get_discount_tax() ) ? $item->get_discount_tax() : null,
-												'coupon'   => [
-													'id' => $this->coupon->to_relay_id( \wc_get_coupon_id_by_code( $item->get_code() ) ),
-												],
-											];
-										},
-										$order->get_items( 'coupon' )
-									)
-								),
-							],
-							'feeLines'      => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'databaseId' => $item->get_id(),
-												'orderId'  => $item->get_order_id(),
-												'amount'   => ! empty( $item->get_amount() ) ? $item->get_amount() : null,
-												'name'     => $item->get_name(),
-												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'total'    => $item->get_total(),
-												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
-												'taxClass' => ! empty( $item->get_tax_class() )
-													? WPEnumType::get_safe_name( $item->get_tax_class() )
-													: 'STANDARD',
-											];
-										},
-										$order->get_items( 'fee' )
-									)
-								),
-							],
-							'shippingLines' => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'databaseId' => $item->get_id(),
-												'orderId'  => $item->get_order_id(),
-												'methodTitle' => $item->get_method_title(),
-												'total'    => $item->get_total(),
-												'totalTax' => ! empty( $item->get_total_tax() )
-													? $item->get_total_tax()
-													: null,
-												'taxClass' => ! empty( $item->get_tax_class() )
-													? $item->get_tax_class() === 'inherit'
-														? WPEnumType::get_safe_name( 'inherit cart' )
-														: WPEnumType::get_safe_name( $item->get_tax_class() )
-													: 'STANDARD',
-											];
-										},
-										$order->get_items( 'shipping' )
-									)
-								),
-							],
-							'taxLines'      => [
-								'nodes' => array_reverse(
-									array_map(
-										function( $item ) {
-											return [
-												'rateCode' => $item->get_rate_code(),
-												'label'    => $item->get_label(),
-												'taxTotal' => $item->get_tax_total(),
-												'shippingTaxTotal' => $item->get_shipping_tax_total(),
-												'isCompound' => $item->is_compound(),
-												'taxRate'  => [ 'databaseId' => $item->get_rate_id() ],
-											];
-										},
-										$order->get_items( 'tax' )
-									)
-								),
-							],
-							'lineItems'     => [
-								'nodes' => array_values(
-									array_map(
-										function( $item ) {
-											return [
-												'productId' => $item->get_product_id(),
-												'variationId' => ! empty( $item->get_variation_id() )
-													? $item->get_variation_id()
-													: null,
-												'quantity' => $item->get_quantity(),
-												'taxClass' => ! empty( $item->get_tax_class() )
-													? strtoupper( $item->get_tax_class() )
-													: 'STANDARD',
-												'subtotal' => ! empty( $item->get_subtotal() ) ? $item->get_subtotal() : null,
-												'subtotalTax' => ! empty( $item->get_subtotal_tax() ) ? $item->get_subtotal_tax() : null,
-												'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
-												'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
-												'taxStatus' => strtoupper( $item->get_tax_status() ),
-												'product'  => [ 'node' => [ 'id' => $this->product->to_relay_id( $item->get_product_id() ) ] ],
-												'variation' => ! empty( $item->get_variation_id() )
-													? [
-														'node' => [
-															'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
-														],
-													]
-													: null,
-											];
-										},
-										$order->get_items()
-									)
-								),
-							],
-						]
-					),
-				],
+			'updateOrder' => [
+				'clientMutationId' => 'someId',
+				'order'            => array_merge(
+					$this->order->print_query( $order->get_id() ),
+					[
+						'couponLines'   => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'databaseId' => $item->get_id(),
+											'orderId'  => $item->get_order_id(),
+											'code'     => $item->get_code(),
+											'discount' => ! empty( $item->get_discount() ) ? $item->get_discount() : null,
+											'discountTax' => ! empty( $item->get_discount_tax() ) ? $item->get_discount_tax() : null,
+											'coupon'   => [
+												'id' => $this->coupon->to_relay_id( \wc_get_coupon_id_by_code( $item->get_code() ) ),
+											],
+										];
+									},
+									$order->get_items( 'coupon' )
+								)
+							),
+						],
+						'feeLines'      => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'databaseId' => $item->get_id(),
+											'orderId'  => $item->get_order_id(),
+											'amount'   => ! empty( $item->get_amount() ) ? $item->get_amount() : null,
+											'name'     => $item->get_name(),
+											'taxStatus' => strtoupper( $item->get_tax_status() ),
+											'total'    => $item->get_total(),
+											'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
+											'taxClass' => ! empty( $item->get_tax_class() )
+												? WPEnumType::get_safe_name( $item->get_tax_class() )
+												: 'STANDARD',
+										];
+									},
+									$order->get_items( 'fee' )
+								)
+							),
+						],
+						'shippingLines' => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'databaseId' => $item->get_id(),
+											'orderId'  => $item->get_order_id(),
+											'methodTitle' => $item->get_method_title(),
+											'total'    => $item->get_total(),
+											'totalTax' => ! empty( $item->get_total_tax() )
+												? $item->get_total_tax()
+												: null,
+											'taxClass' => ! empty( $item->get_tax_class() )
+												? $item->get_tax_class() === 'inherit'
+													? WPEnumType::get_safe_name( 'inherit cart' )
+													: WPEnumType::get_safe_name( $item->get_tax_class() )
+												: 'STANDARD',
+										];
+									},
+									$order->get_items( 'shipping' )
+								)
+							),
+						],
+						'taxLines'      => [
+							'nodes' => array_reverse(
+								array_map(
+									function( $item ) {
+										return [
+											'rateCode' => $item->get_rate_code(),
+											'label'    => $item->get_label(),
+											'taxTotal' => $item->get_tax_total(),
+											'shippingTaxTotal' => $item->get_shipping_tax_total(),
+											'isCompound' => $item->is_compound(),
+											'taxRate'  => [ 'databaseId' => $item->get_rate_id() ],
+										];
+									},
+									$order->get_items( 'tax' )
+								)
+							),
+						],
+						'lineItems'     => [
+							'nodes' => array_values(
+								array_map(
+									function( $item ) {
+										return [
+											'productId' => $item->get_product_id(),
+											'variationId' => ! empty( $item->get_variation_id() )
+												? $item->get_variation_id()
+												: null,
+											'quantity' => $item->get_quantity(),
+											'taxClass' => ! empty( $item->get_tax_class() )
+												? strtoupper( $item->get_tax_class() )
+												: 'STANDARD',
+											'subtotal' => ! empty( $item->get_subtotal() ) ? $item->get_subtotal() : null,
+											'subtotalTax' => ! empty( $item->get_subtotal_tax() ) ? $item->get_subtotal_tax() : null,
+											'total'    => ! empty( $item->get_total() ) ? $item->get_total() : null,
+											'totalTax' => ! empty( $item->get_total_tax() ) ? $item->get_total_tax() : null,
+											'taxStatus' => strtoupper( $item->get_tax_status() ),
+											'product'  => [ 'node' => [ 'id' => $this->product->to_relay_id( $item->get_product_id() ) ] ],
+											'variation' => ! empty( $item->get_variation_id() )
+												? [
+													'node' => [
+														'id' => $this->variation->to_relay_id( $item->get_variation_id() ),
+													],
+												]
+												: null,
+										];
+									},
+									$order->get_items()
+								)
+							),
+						],
+					]
+				),
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
-		$this->assertNotEquals( $initial_response, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
+		$this->assertNotEquals( $initial_response, $actual['data'] );
 	}
 
 	public function testDeleteOrderMutation() {

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -54,18 +54,16 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'product' => [
-					'id'         => $this->helper->to_relay_id( $this->product_id ),
-					'attributes' => $this->helper->print_attributes( $this->product_id ),
-				],
+			'product' => [
+				'id'         => $this->helper->to_relay_id( $this->product_id ),
+				'attributes' => $this->helper->print_attributes( $this->product_id ),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testProductAttributeToProductConnectionQuery() {
@@ -94,15 +92,13 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'allPaColor' => [
-					'nodes' => [
-						[
-							'products' => [
-								'nodes' => [
-									[
-										'id' => $this->helper->to_relay_id( $this->product_id ),
-									],
+			'allPaColor' => [
+				'nodes' => [
+					[
+						'products' => [
+							'nodes' => [
+								[
+									'id' => $this->helper->to_relay_id( $this->product_id ),
 								],
 							],
 						],
@@ -114,7 +110,7 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testProductAttributeToVariationConnectionQuery() {
@@ -141,27 +137,25 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'allPaSize' => [
-					'nodes' => [
-						[
-							'variations' => [
-								'nodes' => $this->variation_helper->print_nodes(
-									$this->variation_ids,
-									[
-										'filter' => function( $id ) {
-											$variation       = new \WC_Product_Variation( $id );
-											$small_attribute = array_filter(
-												$variation->get_attributes(),
-												function( $attribute ) {
-													return 'small' === $attribute;
-												}
-											);
-											return ! empty( $small_attribute );
-										},
-									]
-								),
-							],
+			'allPaSize' => [
+				'nodes' => [
+					[
+						'variations' => [
+							'nodes' => $this->variation_helper->print_nodes(
+								$this->variation_ids,
+								[
+									'filter' => function( $id ) {
+										$variation       = new \WC_Product_Variation( $id );
+										$small_attribute = array_filter(
+											$variation->get_attributes(),
+											function( $attribute ) {
+												return 'small' === $attribute;
+											}
+										);
+										return ! empty( $small_attribute );
+									},
+								]
+							),
 						],
 					],
 				],
@@ -171,6 +165,6 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 }

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -713,6 +713,11 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		// No need to reassign the $expected for this assertion.
 
+		codecept_debug( [
+			'response' => $response,
+			'expected' => $expected,
+		]);
+
 		$this->assertQuerySuccessful( $response, $expected );
 
 		/**

--- a/tests/wpunit/ProductReviewMutationsTest.php
+++ b/tests/wpunit/ProductReviewMutationsTest.php
@@ -55,17 +55,15 @@ class ProductReviewMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual   = $this->run_mutation( 'writeReview', $input );
 		$expected = [
-			'data' => [
-				'writeReview' => [
-					'clientMutationId' => 'some_id',
-					'rating'           => 1.0,
-					'review'           => [
-						'content' => 'It came covered in poop!!!',
-					],
+			'writeReview' => [
+				'clientMutationId' => 'some_id',
+				'rating'           => 1.0,
+				'review'           => [
+					'content' => 'It came covered in poop!!!',
 				],
 			],
 		];
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testUpdateReviewMutation() {
@@ -91,17 +89,15 @@ class ProductReviewMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual   = $this->run_mutation( 'updateReview', $input );
 		$expected = [
-			'data' => [
-				'updateReview' => [
-					'clientMutationId' => 'some_id',
-					'rating'           => 5.0,
-					'review'           => [
-						'content' => 'Turns out it was Nutella. My bad =P',
-					],
+			'updateReview' => [
+				'clientMutationId' => 'some_id',
+				'rating'           => 5.0,
+				'review'           => [
+					'content' => 'Turns out it was Nutella. My bad =P',
 				],
 			],
 		];
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testDeleteReviewMutation() {
@@ -125,17 +121,15 @@ class ProductReviewMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual   = $this->run_mutation( 'deleteReview', $input );
 		$expected = [
-			'data' => [
-				'deleteReview' => [
-					'clientMutationId' => 'some_id',
-					'rating'           => 1.0,
-					'review'           => [
-						'content' => 'It came covered in poop!!!',
-					],
+			'deleteReview' => [
+				'clientMutationId' => 'some_id',
+				'rating'           => 1.0,
+				'review'           => [
+					'content' => 'It came covered in poop!!!',
 				],
 			],
 		];
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testRestoreReviewMutation() {
@@ -162,16 +156,14 @@ class ProductReviewMutationsTest extends \Codeception\TestCase\WPTestCase {
 
 		$actual   = $this->run_mutation( 'restoreReview', $input );
 		$expected = [
-			'data' => [
-				'restoreReview' => [
-					'clientMutationId' => 'some_id',
-					'rating'           => 1.0,
-					'review'           => [
-						'content' => 'It came covered in poop!!!',
-					],
+			'restoreReview' => [
+				'clientMutationId' => 'some_id',
+				'rating'           => 1.0,
+				'review'           => [
+					'content' => 'It came covered in poop!!!',
 				],
 			],
 		];
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 }

--- a/tests/wpunit/ProductVariationQueriesTest.php
+++ b/tests/wpunit/ProductVariationQueriesTest.php
@@ -84,12 +84,12 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 				'variables' => $variables,
 			]
 		);
-		$expected  = [ 'data' => [ 'productVariation' => $this->helper->print_query( $variation_id ) ] ];
+		$expected  = [ 'productVariation' => $this->helper->print_query( $variation_id ) ];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		$this->getModule( '\Helper\Wpunit' )->clear_loader_cache( 'wc_post' );
 
@@ -109,12 +109,12 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 				'variables' => $variables,
 			]
 		);
-		$expected = [ 'data' => [ 'productVariation' => $this->helper->print_query( $variation_id ) ] ];
+		$expected = [ 'productVariation' => $this->helper->print_query( $variation_id ) ];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testVariationsQueryAndWhereArgs() {
@@ -257,15 +257,13 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'productVariation' => [
-					'id'    => $id,
-					'image' => [
-						'id' => Relay::toGlobalId(
-							'post',
-							$this->helper->field( $this->products['variations'][1], 'image_id' )
-						),
-					],
+			'productVariation' => [
+				'id'    => $id,
+				'image' => [
+					'id' => Relay::toGlobalId(
+						'post',
+						$this->helper->field( $this->products['variations'][1], 'image_id' )
+					),
 				],
 			],
 		];
@@ -273,7 +271,7 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testProductVariationDownloads() {
@@ -305,17 +303,15 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'productVariation' => [
-					'id'        => $id,
-					'downloads' => $this->helper->print_downloads( $this->products['variations'][0] ),
-				],
+			'productVariation' => [
+				'id'        => $id,
+				'downloads' => $this->helper->print_downloads( $this->products['variations'][0] ),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 }

--- a/tests/wpunit/ShippingMethodQueriesTest.php
+++ b/tests/wpunit/ShippingMethodQueriesTest.php
@@ -47,12 +47,12 @@ class ShippingMethodQueriesTest extends \Codeception\TestCase\WPTestCase {
 				'variables' => $variables,
 			]
 		);
-		$expected  = [ 'data' => [ 'shippingMethod' => $this->helper->print_query( $this->method ) ] ];
+		$expected  = [ 'shippingMethod' => $this->helper->print_query( $this->method ) ];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Two
@@ -69,12 +69,12 @@ class ShippingMethodQueriesTest extends \Codeception\TestCase\WPTestCase {
 				'variables' => $variables,
 			]
 		);
-		$expected  = [ 'data' => [ 'shippingMethod' => $this->helper->print_query( $this->method ) ] ];
+		$expected  = [ 'shippingMethod' => $this->helper->print_query( $this->method ) ];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testShippingMethodsQuery() {
@@ -104,11 +104,11 @@ class ShippingMethodQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 * Tests query
 		 */
 		$actual   = do_graphql_request( $query, 'shippingMethodQuery' );
-		$expected = [ 'data' => [ 'shippingMethods' => [ 'nodes' => $methods ] ] ];
+		$expected = [ 'shippingMethods' => [ 'nodes' => $methods ] ];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 }

--- a/tests/wpunit/TaxRateQueriesTest.php
+++ b/tests/wpunit/TaxRateQueriesTest.php
@@ -48,12 +48,12 @@ class TaxRateQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$variables = [ 'id' => $id ];
 		$actual    = do_graphql_request( $query, 'taxRateQuery', $variables );
-		$expected  = [ 'data' => [ 'taxRate' => $this->helper->print_query( $this->rate ) ] ];
+		$expected  = [ 'taxRate' => $this->helper->print_query( $this->rate ) ];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Two
@@ -65,12 +65,12 @@ class TaxRateQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'idType' => 'DATABASE_ID',
 		];
 		$actual    = do_graphql_request( $query, 'taxRateQuery', $variables );
-		$expected  = [ 'data' => [ 'taxRate' => $this->helper->print_query( $this->rate ) ] ];
+		$expected  = [ 'taxRate' => $this->helper->print_query( $this->rate ) ];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testTaxesQuery() {
@@ -123,22 +123,20 @@ class TaxRateQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 */
 		$actual   = graphql( [ 'query' => $query ] );
 		$expected = [
-			'data' => [
-				'taxRates' => [
-					'nodes' => array_map(
-						function( $id ) {
-							return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
-						},
-						$rates
-					),
-				],
+			'taxRates' => [
+				'nodes' => array_map(
+					function( $id ) {
+						return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
+					},
+					$rates
+				),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Two
@@ -153,30 +151,28 @@ class TaxRateQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'taxRates' => [
-					'nodes' => array_map(
-						function( $id ) {
-							return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
-						},
-						array_values(
-							array_filter(
-								$rates,
-								function( $id ) {
-									$rate = $this->helper->get_rate_object( $id );
-									return 'reduced-rate' === $rate->tax_rate_class;
-								}
-							)
+			'taxRates' => [
+				'nodes' => array_map(
+					function( $id ) {
+						return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
+					},
+					array_values(
+						array_filter(
+							$rates,
+							function( $id ) {
+								$rate = $this->helper->get_rate_object( $id );
+								return 'reduced-rate' === $rate->tax_rate_class;
+							}
 						)
-					),
-				],
+					)
+				),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Three
@@ -191,22 +187,20 @@ class TaxRateQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'taxRates' => [
-					'nodes' => array_map(
-						function( $id ) {
-							return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
-						},
-						[ $rates[2] ]
-					),
-				],
+			'taxRates' => [
+				'nodes' => array_map(
+					function( $id ) {
+						return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
+					},
+					[ $rates[2] ]
+				),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 
 		/**
 		 * Assertion Four
@@ -221,21 +215,19 @@ class TaxRateQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'taxRates' => [
-					'nodes' => array_map(
-						function( $id ) {
-							return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
-						},
-						[ $rates[1], $rates[2] ]
-					),
-				],
+			'taxRates' => [
+				'nodes' => array_map(
+					function( $id ) {
+						return [ 'id' => Relay::toGlobalId( 'tax_rate', $id ) ];
+					},
+					[ $rates[1], $rates[2] ]
+				),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 }

--- a/tests/wpunit/VariationAttributeQueriesTest.php
+++ b/tests/wpunit/VariationAttributeQueriesTest.php
@@ -52,18 +52,16 @@ class VariationAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'productVariation' => [
-					'id'         => $this->variation->to_relay_id( $this->variation_id ),
-					'attributes' => $this->variation->print_attributes( $this->variation_id ),
-				],
+			'productVariation' => [
+				'id'         => $this->variation->to_relay_id( $this->variation_id ),
+				'attributes' => $this->variation->print_attributes( $this->variation_id ),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 	public function testProductToVariationAttributeQuery() {
@@ -98,18 +96,16 @@ class VariationAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$expected  = [
-			'data' => [
-				'product' => [
-					'id'                => $this->product->to_relay_id( $this->product_id ),
-					'defaultAttributes' => $this->variation->print_attributes( $this->product_id, 'PRODUCT' ),
-				],
+			'product' => [
+				'id'                => $this->product->to_relay_id( $this->product_id ),
+				'defaultAttributes' => $this->variation->print_attributes( $this->product_id, 'PRODUCT' ),
 			],
 		];
 
 		// use --debug flag to view.
 		codecept_debug( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected, $actual['data'] );
 	}
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR Implements the "Node" interface on any Type that is used as a toType in a connection, as Connections need to connect to Node types

This PR implements the Node interface on these types, but does not handle the resolution of the ID field on each type, nor the resolution of a `node( id: $id ) { ... }` query

My goal is to unblock users, and we can finesse some of those details as follow-up PRs


Does this close any currently open issues?
------------------------------------------
Closes #673 
