### PR TITLE
fix:`$post_type` must be an array when passed to `in_array()`

### DIFF
--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -542,7 +542,8 @@ class Products {
 	 *
 	 * @return array Query arguments.
 	 */
-	public static function map_input_fields_to_wp_query( $query_args, $args, $source, $all_args, $context, $info, $post_type ) {
+  public static function map_input_fields_to_wp_query( $query_args, $args, $source, $all_args, $context, $info, $post_type ) {
+    $post_type = is_array( $post_type ) ? $post_type : array( $post_type );
 		if ( ! in_array( 'product', $post_type, true ) && ! in_array( 'product_variation', $post_type, true ) ) {
 			return $query_args;
 		}
@@ -689,7 +690,6 @@ class Products {
 		}//end if
 
 		// Handle visibility.
-		$post_type_obj = get_post_type_object( $post_type );
 		if ( ! empty( $where_args['visibility'] ) ) {
 			switch ( $where_args['visibility'] ) {
 				case 'search':

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -542,8 +542,8 @@ class Products {
 	 *
 	 * @return array Query arguments.
 	 */
-  public static function map_input_fields_to_wp_query( $query_args, $args, $source, $all_args, $context, $info, $post_type ) {
-    $post_type = is_array( $post_type ) ? $post_type : array( $post_type );
+	public static function map_input_fields_to_wp_query( $query_args, $args, $source, $all_args, $context, $info, $post_type ) {
+		$post_type = is_array( $post_type ) ? $post_type : array( $post_type );
 		if ( ! in_array( 'product', $post_type, true ) && ! in_array( 'product_variation', $post_type, true ) ) {
 			return $query_args;
 		}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
* `$post_type` must be an array when passed to `in_array()`
* Removes unused `$post_type_obj` variable.

Does this close any currently open issues?
------------------------------------------
Slack thread: https://wp-graphql.slack.com/archives/CJUBND25R/p1672096763874069

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
The Gatsby error log typically looked like this:
```JS
 ERROR #11321  API.NODE.EXECUTION

"gatsby-node.js" threw an error while running the createPages lifecycle:

Cannot return null for non-nullable field WpNodeWithFeaturedImageToMediaItemConnectionEdgeType.node.

GraphQL request:19:15
18 |             featuredImage {
19 |               node {
   |               ^
20 |                 id,Cannot return null for non-nullable field WpNodeWithFeaturedImageToMediaItemConnectionEdgeType.node.
```

Any other comments?
-------------------
Enabling the `DETECT_NODE_MUTATIONS` experimental Gatsby option creates a similar error, not sure why.


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.12.0
- **WPGraphQL Version:** 1.13.7
- **WordPress Version:** 6.1.1
- **WooCommerce Version:** 7.3.0
- **Gatsby Version:** 5.4.2
