### PR TITLE
Updates deprecated DataSource::resolve_post_object

### DIFF
--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -189,7 +189,7 @@ class Product {
 					if ( empty( $source->image_id ) || ! absint( $source->image_id ) ) {
 						return null;
 					}
-					return DataSource::resolve_post_object( $source->image_id, $context );
+					return $context->get_loader( 'post' )->load_deferred( $source->image_id );
 				},
 			],
 			'onSale'            => [

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -13,7 +13,6 @@ namespace WPGraphQL\WooCommerce\Type\WPInterface;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\WooCommerce\Data\Factory;
 use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 

--- a/includes/type/object/class-product-category-type.php
+++ b/includes/type/object/class-product-category-type.php
@@ -11,7 +11,6 @@
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 
 /**
  * Class - Product_Category_Type

--- a/includes/type/object/class-product-category-type.php
+++ b/includes/type/object/class-product-category-type.php
@@ -31,7 +31,7 @@ class Product_Category_Type {
 					'resolve'     => function( $source, array $args, AppContext $context ) {
 						$thumbnail_id = get_term_meta( $source->term_id, 'thumbnail_id', true );
 						return ! empty( $thumbnail_id )
-							? DataSource::resolve_post_object( $thumbnail_id, $context )
+							? $context->get_loader( 'post' )->load_deferred( $thumbnail_id )
 							: null;
 					},
 				],

--- a/includes/type/object/class-product-variation-type.php
+++ b/includes/type/object/class-product-variation-type.php
@@ -13,7 +13,6 @@ namespace WPGraphQL\WooCommerce\Type\WPObject;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\WooCommerce\Data\Factory;
 
 /**
@@ -75,8 +74,8 @@ class Product_Variation_Type {
 						],
 						'resolve'     => function( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-								// @codingStandardsIgnoreLine.
-								return $source->priceRaw;
+                                // @codingStandardsIgnoreLine.
+                                return $source->priceRaw;
 							} else {
 								return $source->price;
 							}
@@ -93,11 +92,11 @@ class Product_Variation_Type {
 						],
 						'resolve'     => function( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-								// @codingStandardsIgnoreLine.
-								return $source->regularPriceRaw;
+                                // @codingStandardsIgnoreLine.
+                                return $source->regularPriceRaw;
 							} else {
-								// @codingStandardsIgnoreLine.
-								return $source->regularPrice;
+                                // @codingStandardsIgnoreLine.
+                                return $source->regularPrice;
 							}
 						},
 					],
@@ -112,11 +111,11 @@ class Product_Variation_Type {
 						],
 						'resolve'     => function( $source, $args ) {
 							if ( isset( $args['format'] ) && 'raw' === $args['format'] ) {
-								// @codingStandardsIgnoreLine.
-								return $source->salePriceRaw;
+                                // @codingStandardsIgnoreLine.
+                                return $source->salePriceRaw;
 							} else {
-								// @codingStandardsIgnoreLine.
-								return $source->salePrice;
+                                // @codingStandardsIgnoreLine.
+                                return $source->salePrice;
 							}
 						},
 					],
@@ -232,9 +231,9 @@ class Product_Variation_Type {
 						'type'        => 'MediaItem',
 						'description' => __( 'Product variation main image', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source, array $args, AppContext $context ) {
- 							return ! empty( $source->image_id )
+							return ! empty( $source->image_id )
 								? $context->get_loader( 'post' )->load_deferred( $source->image_id )
- 								: null;
+								: null;
 						},
 					],
 

--- a/includes/type/object/class-product-variation-type.php
+++ b/includes/type/object/class-product-variation-type.php
@@ -232,7 +232,9 @@ class Product_Variation_Type {
 						'type'        => 'MediaItem',
 						'description' => __( 'Product variation main image', 'wp-graphql-woocommerce' ),
 						'resolve'     => function( $source, array $args, AppContext $context ) {
-							return ! empty( $source->image_id ) ? DataSource::resolve_post_object( $source->image_id, $context ) : null;
+ 							return ! empty( $source->image_id )
+								? $context->get_loader( 'post' )->load_deferred( $source->image_id )
+ 								: null;
 						},
 					],
 


### PR DESCRIPTION
### Your checklist for this pull request

Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------

Fixes deprecation errors:
Updates usage of deprecated function.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
> _PHP message: PHP Deprecated:  Function WPGraphQL\Data\DataSource::resolve_post_object is <strong>deprecated</strong> since version 0.8.4! Use Use $context->get_loader( 'post' )->load_deferred( $id ) instead. instead. in /var/www/html/web/wp/wp-includes/functions.php on line 5383_

Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version: 0.12.0** …
- **WPGraphQL Version: v1.13.7** …
- **WordPress Version: 6.1.1**
- **WooCommerce Version: 7.2.3**
