### PR TITLE
fix: Customer order connection args priority fixed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "/codeception.yml",
         "/composer.json",
         "/composer.lock",
-        "/docker-composer.yml",
+        "/docker-compose.yml",
         "/Dockerfile",
         "/netlify.toml",
         "/README.md"

--- a/composer.lock
+++ b/composer.lock
@@ -8,23 +8,28 @@
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.1.0",
+            "version": "v6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "fbb2967a3a68b07e37678c00c0cf51165051495f"
+                "reference": "ea7dda77098b96e666c5ef382452f94841e439cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/fbb2967a3a68b07e37678c00c0cf51165051495f",
-                "reference": "fbb2967a3a68b07e37678c00c0cf51165051495f",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/ea7dda77098b96e666c5ef382452f94841e439cd",
+                "reference": "ea7dda77098b96e666c5ef382452f94841e439cd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1||^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5||9.5"
+                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "phpspec/prophecy-phpunit": "^1.1",
+                "phpunit/phpunit": "^7.5||^9.5",
+                "psr/cache": "^1.0||^2.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
@@ -59,9 +64,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.1.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.3.2"
             },
-            "time": "2022-03-23T18:26:04+00:00"
+            "time": "2022-12-19T17:10:46+00:00"
         }
     ],
     "packages-dev": [
@@ -182,5 +187,5 @@
         "php": ">=7.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tests/_support/Factory/OrderFactory.php
+++ b/tests/_support/Factory/OrderFactory.php
@@ -36,9 +36,11 @@ class OrderFactory extends \WP_UnitTest_Factory_For_Thing {
 			throw new \Exception( $order->get_error_message( $args->get_error_code() ) );
 		}
 
-		// Set meta data.
-		if ( ! empty( $args['meta_data'] ) ) {
-			$order->set_meta_data( $args['meta_data'] );
+		// Set props.
+		foreach ( $args as $key => $value ) {
+			if ( is_callable( [ $order, "set_{$key}" ] ) ) {
+				$order->{"set_{$key}"}( $value );
+			}
 		}
 
 		return $order->save();
@@ -339,8 +341,10 @@ class OrderFactory extends \WP_UnitTest_Factory_For_Thing {
 
 	public function set_to_customer_billing_address( $order, $customer, $save = true ) {
 		$order    = \wc_get_order( $order );
+		if ( ! $customer ) {
+			return $order;
+		}
 		$customer = new \WC_Customer( $customer );
-
 		// Set billing address
 		$order->set_billing_first_name( $customer->get_first_name() );
 		$order->set_billing_last_name( $customer->get_last_name() );
@@ -363,6 +367,9 @@ class OrderFactory extends \WP_UnitTest_Factory_For_Thing {
 
 	public function set_to_customer_shipping_address( $order, $customer, $save = true ) {
 		$order    = \wc_get_order( $order );
+		if ( ! $customer ) {
+			return $order;
+		}
 		$customer = new \WC_Customer( $customer );
 
 		// Set shipping address


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes Customer -> Order connection argument priority by prioritize the `customer ID` then the `billing email` for guest without a Customer ID.


Does this close any currently open issues?
------------------------------------------
Fixes #689 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
