### PR TITLE
feat: Auth no longer needed for the raw order totals

### DIFF
--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -219,82 +219,58 @@ class Order extends WC_Post {
 					$price = ! empty( $this->wc_data->get_discount_total() ) ? $this->wc_data->get_discount_total() : 0;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'discountTotalRaw'      => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_discount_total() ) ? $this->wc_data->get_discount_total() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'discountTotalRaw'      => function() {
+					return ! empty( $this->wc_data->get_discount_total() ) ? $this->wc_data->get_discount_total() : 0;
+				},
 				'discountTax'           => function() {
 					$price = ! empty( $this->wc_data->get_discount_tax() ) ? $this->wc_data->get_discount_tax() : 0;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'discountTaxRaw'        => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_discount_tax() ) ? $this->wc_data->get_discount_tax() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'discountTaxRaw'        => function() {
+					return ! empty( $this->wc_data->get_discount_tax() ) ? $this->wc_data->get_discount_tax() : 0;
+				},
 				'shippingTotal'         => function() {
 					$price = ! empty( $this->wc_data->get_shipping_total() ) ? $this->wc_data->get_shipping_total() : 0;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'shippingTotalRaw'      => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_shipping_total() ) ? $this->wc_data->get_shipping_total() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'shippingTotalRaw'      => function() {
+					return ! empty( $this->wc_data->get_shipping_total() ) ? $this->wc_data->get_shipping_total() : 0;
+				},
 				'shippingTax'           => function() {
 					$price = ! empty( $this->wc_data->get_shipping_tax() ) ? $this->wc_data->get_shipping_tax() : 0;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'shippingTaxRaw'        => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_shipping_tax() ) ? $this->wc_data->get_shipping_tax() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'shippingTaxRaw'        => function() {
+					return ! empty( $this->wc_data->get_shipping_tax() ) ? $this->wc_data->get_shipping_tax() : 0;
+				},
 				'cartTax'               => function() {
 					$price = ! empty( $this->wc_data->get_cart_tax() ) ? $this->wc_data->get_cart_tax() : 0;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'cartTaxRaw'            => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_cart_tax() ) ? $this->wc_data->get_cart_tax() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'cartTaxRaw'            => function() {
+					return ! empty( $this->wc_data->get_cart_tax() ) ? $this->wc_data->get_cart_tax() : 0;
+				},
 				'total'                 => function() {
 					$price = ! empty( $this->wc_data->get_total() ) ? $this->wc_data->get_total() : 0;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'totalRaw'              => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_total() ) ? $this->wc_data->get_total() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'totalRaw'              => function() {
+					return ! empty( $this->wc_data->get_total() ) ? $this->wc_data->get_total() : 0;
+				},
 				'totalTax'              => function() {
 					$price = ! empty( $this->wc_data->get_total_tax() ) ? $this->wc_data->get_total_tax() : 0;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'totalTaxRaw'           => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_total_tax() ) ? $this->wc_data->get_total_tax() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'totalTaxRaw'           => function() {
+					return ! empty( $this->wc_data->get_total_tax() ) ? $this->wc_data->get_total_tax() : 0;
+				},
 				'subtotal'              => function() {
 					$price = ! empty( $this->wc_data->get_subtotal() ) ? $this->wc_data->get_subtotal() : null;
 					return \wc_graphql_price( $price, [ 'currency' => $this->wc_data->get_currency() ] );
 				},
-				'subtotalRaw'           => [
-					'callback'   => function() {
-						return ! empty( $this->wc_data->get_subtotal() ) ? $this->wc_data->get_subtotal() : 0;
-					},
-					'capability' => $this->post_type_object->cap->edit_posts,
-				],
+				'subtotalRaw'           => function() {
+					return ! empty( $this->wc_data->get_subtotal() ) ? $this->wc_data->get_subtotal() : 0;
+				},
 				'orderNumber'           => function() {
 					return ! empty( $this->wc_data->get_order_number() ) ? $this->wc_data->get_order_number() : null;
 				},


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Makes the Order type's RAW format available to guest users.


Does this close any currently open issues?
------------------------------------------
Fixes #685 
Fixes #


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
