### PR TITLE
fix: Fixed all product connection filtering regressions

### DIFF
--- a/includes/class-core-schema-filters.php
+++ b/includes/class-core-schema-filters.php
@@ -123,6 +123,11 @@ class Core_Schema_Filters {
 			10,
 			2
 		);
+
+		add_filter(
+			'graphql_wp_connection_type_config',
+			[ '\WPGraphQL\WooCommerce\Connection\Products', 'set_connection_config' ]
+		);
 	}
 
 	/**
@@ -251,6 +256,7 @@ class Core_Schema_Filters {
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = $singular_name;
 			$args['graphql_plural_name'] = 'all' . ucFirst( $singular_name );
+			$args['graphql_exclude_connections'] = ['variations'];
 		}
 
 		return $args;

--- a/includes/class-core-schema-filters.php
+++ b/includes/class-core-schema-filters.php
@@ -256,7 +256,6 @@ class Core_Schema_Filters {
 			$args['show_in_graphql']     = true;
 			$args['graphql_single_name'] = $singular_name;
 			$args['graphql_plural_name'] = 'all' . ucFirst( $singular_name );
-			$args['graphql_exclude_connections'] = ['variations'];
 		}
 
 		return $args;

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -225,7 +225,7 @@ class Products {
 				'fromFieldName' => 'parent',
 				'description'   => __( 'The parent of the node. The parent object can be of various types', 'wp-graphql-woocommerce' ),
 				'oneToOne'      => true,
-				'queryClass'     => '\WC_Product_Query',
+				'queryClass'    => '\WC_Product_Query',
 				'resolve'       => function( $source, $args, AppContext $context, ResolveInfo $info ) {
 					if ( empty( $source->parent_id ) ) {
 						return null;
@@ -273,7 +273,7 @@ class Products {
 								)
 							);
 
-							$variation_ids = ! empty( $variation_ids ) ? $variation_ids: ['0'];
+							$variation_ids = ! empty( $variation_ids ) ? $variation_ids : [ '0' ];
 
 							$resolver->set_query_arg( 'post__in', $variation_ids );
 
@@ -293,11 +293,10 @@ class Products {
 	 * @return array
 	 */
 	private static function get_product_connected_taxonomies() {
-		$taxonomies = [];
+		$taxonomies         = [];
 		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
 
 		foreach ( $allowed_taxonomies as $tax_object ) {
-
 			if ( ! in_array( 'product', $tax_object->object_type, true ) ) {
 				continue;
 			}
@@ -315,15 +314,15 @@ class Products {
 	 * @return array
 	 */
 	public static function set_connection_config( $config ) {
-		$toType   = $config['toType'];
-		$fromType = $config['fromType'];
-		if ( 'Product' === $toType ) {
+		$to_type   = $config['toType'];
+		$from_type = $config['fromType'];
+		if ( 'Product' === $to_type ) {
 			$config['connectionArgs'] = self::get_connection_args();
 			$config['queryClass']     = '\WC_Product_Query';
 		}
 
 		$taxonomies = self::get_product_connected_taxonomies();
-		if ( 'Product' === $toType && in_array( $config['fromType'], $taxonomies, true ) ) {
+		if ( 'Product' === $to_type && in_array( $from_type, $taxonomies, true ) ) {
 			$config['resolve'] = function( $source, array $args, AppContext $context, ResolveInfo $info ) {
 				add_filter( 'graphql_post_object_connection_args', [ __CLASS__, 'bypass_get_args_sanitization' ], 10, 3 );
 				$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -225,6 +225,7 @@ class Products {
 				'fromFieldName' => 'parent',
 				'description'   => __( 'The parent of the node. The parent object can be of various types', 'wp-graphql-woocommerce' ),
 				'oneToOne'      => true,
+				'queryClass'     => '\WC_Product_Query',
 				'resolve'       => function( $source, $args, AppContext $context, ResolveInfo $info ) {
 					if ( empty( $source->parent_id ) ) {
 						return null;
@@ -243,27 +244,6 @@ class Products {
 			]
 		);
 
-		// Taxonomy To Product resolver.
-		$resolve_product_from_taxonomy = function( $source, array $args, AppContext $context, ResolveInfo $info ) {
-			add_filter( 'graphql_post_object_connection_args', [ __CLASS__, 'bypass_get_args_sanitization' ], 10, 3 );
-			$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-			remove_filter( 'graphql_post_object_connection_args', [ __CLASS__, 'bypass_get_args_sanitization' ], 10, 3 );
-
-			$tax_query = [
-				[
-					// WPCS: slow query ok.
-					'taxonomy' => $source->taxonomyName, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					'field'    => 'term_id',
-					'terms'    => $source->term_id,
-				],
-			];
-			$resolver->set_query_arg( 'tax_query', $tax_query );
-
-			$resolver = self::set_ordering_query_args( $resolver, $args );
-
-			return $resolver->get_connection();
-		};
-
 		// From WooCommerce product attributes.
 		$attributes = WP_GraphQL_WooCommerce::get_product_attribute_taxonomies();
 		foreach ( $attributes as $attribute ) {
@@ -275,7 +255,9 @@ class Products {
 						'fromFieldName' => 'variations',
 						'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) {
 							global $wpdb;
+							add_filter( 'graphql_post_object_connection_args', [ __CLASS__, 'bypass_get_args_sanitization' ], 10, 3 );
 							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product_variation' );
+							remove_filter( 'graphql_post_object_connection_args', [ __CLASS__, 'bypass_get_args_sanitization' ], 10, 3 );
 
 							// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 							$attribute_meta_key = 'attribute_' . strtolower( preg_replace( '/([A-Z])/', '_$1', $source->taxonomyName ) );
@@ -291,8 +273,9 @@ class Products {
 								)
 							);
 
+							$variation_ids = ! empty( $variation_ids ) ? $variation_ids: ['0'];
+
 							$resolver->set_query_arg( 'post__in', $variation_ids );
-							$resolver->set_query_arg( 'post_type', 'product_variation' );
 
 							$resolver = self::set_ordering_query_args( $resolver, $args );
 
@@ -302,6 +285,65 @@ class Products {
 				)
 			);
 		}//end foreach
+	}
+
+	/**
+	 * Returns the singular name of all registered taxonomies connected the products.
+	 *
+	 * @return array
+	 */
+	private static function get_product_connected_taxonomies() {
+		$taxonomies = [];
+		$allowed_taxonomies = \WPGraphQL::get_allowed_taxonomies( 'objects' );
+
+		foreach ( $allowed_taxonomies as $tax_object ) {
+
+			if ( ! in_array( 'product', $tax_object->object_type, true ) ) {
+				continue;
+			}
+
+			$taxonomies[] = ucfirst( $tax_object->graphql_single_name );
+		}
+
+		return $taxonomies;
+	}
+
+	/**
+	 * Ensures all connection the `Product` type have proper connection config upon registration.
+	 *
+	 * @param array $config  Connection config.
+	 * @return array
+	 */
+	public static function set_connection_config( $config ) {
+		$toType   = $config['toType'];
+		$fromType = $config['fromType'];
+		if ( 'Product' === $toType ) {
+			$config['connectionArgs'] = self::get_connection_args();
+			$config['queryClass']     = '\WC_Product_Query';
+		}
+
+		$taxonomies = self::get_product_connected_taxonomies();
+		if ( 'Product' === $toType && in_array( $config['fromType'], $taxonomies, true ) ) {
+			$config['resolve'] = function( $source, array $args, AppContext $context, ResolveInfo $info ) {
+				add_filter( 'graphql_post_object_connection_args', [ __CLASS__, 'bypass_get_args_sanitization' ], 10, 3 );
+				$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
+				remove_filter( 'graphql_post_object_connection_args', [ __CLASS__, 'bypass_get_args_sanitization' ], 10, 3 );
+				$tax_query = [
+					[
+						'taxonomy'         => $source->taxonomyName, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						'terms'            => [ $source->term_id ],
+						'field'            => 'term_id',
+						'include_children' => false,
+					],
+				];
+				$resolver->set_query_arg( 'tax_query', $tax_query );
+
+				$resolver = self::set_ordering_query_args( $resolver, $args );
+
+				return $resolver->get_connection();
+			};
+		}
+		return $config;
 	}
 
 	/**

--- a/tests/_support/Factory/ProductVariationFactory.php
+++ b/tests/_support/Factory/ProductVariationFactory.php
@@ -32,13 +32,26 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 
 		// Create variation.
 		$variation = new $variation_class();
-		$variation->set_props( $args );
-		if ( ! empty( $args['meta_data'] ) ) {
-			$variation->set_meta_data( $args['meta_data'] );
+		foreach ( $args as $field => $field_value ) {
+			if ( ! is_callable( [ $variation, "set_{$field}" ] ) ) {
+				throw new \Exception(
+					sprintf( '"%1$s" is not a valid %2$s product variation field.', $field, $variation->get_type() )
+				);
+			}
+
+			$variation->{"set_{$field}"}( $field_value );
 		}
-		if ( ! empty( $args['attributes'] ) ) {
-			$variation->set_attributes( $args['attributes'] );
-		}
+
+
+		// if ( ! empty( $args['meta_data'] ) ) {
+		// 	$variation->set_meta_data( $args['meta_data'] );
+		// 	unset( $args['meta_data'] );
+		// }
+		// if ( ! empty( $args['attributes'] ) ) {
+		// 	$variation->set_attributes( $args['attributes'] );
+		// 	unset( $args['attributes'] );
+		// }
+		// $variation->set_props( $args );
 
 		return $variation->save();
 	}
@@ -51,7 +64,7 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 		foreach ( $fields as $field => $field_value ) {
 			if ( ! is_callable( [ $object, "set_{$field}" ] ) ) {
 				throw new \Exception(
-					sprintf( '"%1$s" is not a valid %2$s product field.', $field, $object->get_type() )
+					sprintf( '"%1$s" is not a valid %2$s product variation field.', $field, $object->get_type() )
 				);
 			}
 
@@ -73,12 +86,14 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 		// Create variation stub data.
 		$variation_data = [
 			[
+				'parent_id'     => $product,
 				'attributes'    => [ 'pa_size' => 'small' ],
 				'image_id'      => null,
 				'downloads'     => [ $this->factory->product->createDownload() ],
 				'regular_price' => 10,
 			],
 			[
+				'parent_id'     => $product,
 				'attributes'    => [ 'pa_size' => 'medium' ],
 				'image_id'      => $this->factory->post->create(
 					[
@@ -91,6 +106,7 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 				'regular_price' => 15,
 			],
 			[
+				'parent_id'     => $product,
 				'attributes'    => [ 'pa_size' => 'large' ],
 				'image_id'      => null,
 				'downloads'     => [],
@@ -101,14 +117,7 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 		$variations = [];
 		foreach ( $variation_data as $data ) {
 			$args      = array_merge( $data, $args );
-			$variation = $this->create_and_get(
-				$args,
-				[
-					'parent_id'       => $product,
-					'sku'             => uniqid(),
-					'variation_class' => '\WC_Product_Variation',
-				]
-			);
+			$variation = $this->create_and_get( $args, [ 'variation_class' => '\WC_Product_Variation' ] );
 
 			$variations[] = $variation->get_id();
 		}

--- a/tests/_support/Factory/ProductVariationFactory.php
+++ b/tests/_support/Factory/ProductVariationFactory.php
@@ -42,7 +42,6 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 			$variation->{"set_{$field}"}( $field_value );
 		}
 
-
 		// if ( ! empty( $args['meta_data'] ) ) {
 		// 	$variation->set_meta_data( $args['meta_data'] );
 		// 	unset( $args['meta_data'] );

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -60,10 +60,10 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 
 		$variables = [ 'id' => $this->toRelayId( 'product', $product_id ) ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
-		$expected  = [
-			$this->expectedField( 'product.id', $this->toRelayId( 'product', $product_id ) ),
-			...$this->expectedProductAttributeData( $product_id, 'product.attributes.nodes' ),
-		];
+		$expected  = array_merge(
+			[ $this->expectedField( 'product.id', $this->toRelayId( 'product', $product_id ) ) ],
+			$this->expectedProductAttributeData( $product_id, 'product.attributes.nodes' )
+		);
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -7,11 +7,11 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 
 		$expected = [];
 
-		foreach( $attributes as $attribute_name => $attribute ) {
+		foreach ( $attributes as $attribute_name => $attribute ) {
 			$expected[] = $this->expectedNode(
 				$path,
 				[
-					$this->expectedField( 'id', base64_encode( $attribute_name . ':' . $product_id . ':' . $attribute->get_name() ) ),
+					$this->expectedField( 'id', base64_encode( $attribute_name . ':' . $product_id . ':' . $attribute->get_name() ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 					$this->expectedField( 'attributeId', $attribute->get_id() ),
 					$this->expectedField( 'name', str_replace( 'pa_', '', $attribute->get_name() ) ),
 					$this->expectedField(
@@ -36,7 +36,7 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 		$product_id    = $this->factory->product->createVariable();
 		$variation_ids = $this->factory->product_variation->createSome( $product_id )['variations'];
 
-		$query         = '
+		$query = '
             query attributeQuery( $id: ID! ) {
                 product( id: $id ) {
                     ... on VariableProduct {

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -1,29 +1,42 @@
 <?php
 
-class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
-	private $shop_manager;
-	private $customer;
-	private $helper;
-	private $variation_helper;
-	private $product_id;
-	private $variation_ids;
+class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
+	public function expectedProductAttributeData( $product_id, $path ) {
+		$product    = wc_get_product( $product_id );
+		$attributes = $product->get_attributes();
 
-	public function setUp(): void {
-		parent::setUp();
+		$expected = [];
 
-		$this->shop_manager     = $this->factory->user->create( [ 'role' => 'shop_manager' ] );
-		$this->customer         = $this->factory->user->create( [ 'role' => 'customer' ] );
-		$this->helper           = $this->getModule( '\Helper\Wpunit' )->product();
-		$this->variation_helper = $this->getModule( '\Helper\Wpunit' )->product_variation();
-		$this->product_id       = $this->helper->create_variable();
-		$this->variation_ids    = $this->variation_helper->create( $this->product_id )['variations'];
+		foreach( $attributes as $attribute_name => $attribute ) {
+			$expected[] = $this->expectedNode(
+				$path,
+				[
+					$this->expectedField( 'id', base64_encode( $attribute_name . ':' . $product_id . ':' . $attribute->get_name() ) ),
+					$this->expectedField( 'attributeId', $attribute->get_id() ),
+					$this->expectedField( 'name', str_replace( 'pa_', '', $attribute->get_name() ) ),
+					$this->expectedField(
+						'label',
+						$attribute->is_taxonomy()
+							? ucwords( get_taxonomy( $attribute->get_name() )->labels->singular_name )
+							: self::IS_NULL
+					),
+					$this->expectedField( 'options', $attribute->get_slugs() ),
+					$this->expectedField( 'position', $attribute->get_position() ),
+					$this->expectedField( 'visible', $attribute->get_visible() ),
+					$this->expectedField( 'variation', $attribute->get_variation() ),
+				]
+			);
+		}
 
-		\WPGraphQL::clear_schema();
+		return $expected;
 	}
 
 	// tests
 	public function testProductAttributeQuery() {
-		$query = '
+		$product_id    = $this->factory->product->createVariable();
+		$variation_ids = $this->factory->product_variation->createSome( $product_id )['variations'];
+
+		$query         = '
             query attributeQuery( $id: ID! ) {
                 product( id: $id ) {
                     ... on VariableProduct {
@@ -45,30 +58,20 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
             }
         ';
 
-		$variables = [ 'id' => $this->helper->to_relay_id( $this->product_id ) ];
-		$actual    = graphql(
-			[
-				'query'          => $query,
-				'operation_name' => 'attributeQuery',
-				'variables'      => $variables,
-			]
-		);
+		$variables = [ 'id' => $this->toRelayId( 'product', $product_id ) ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
-			'data' => [
-				'product' => [
-					'id'         => $this->helper->to_relay_id( $this->product_id ),
-					'attributes' => $this->helper->print_attributes( $this->product_id ),
-				],
-			],
+			$this->expectedField( 'product.id', $this->toRelayId( 'product', $product_id ) ),
+			...$this->expectedProductAttributeData( $product_id, 'product.attributes.nodes' ),
 		];
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 
 	public function testProductAttributeToProductConnectionQuery() {
+		$product_id    = $this->factory->product->createVariable();
+		$variation_ids = $this->factory->product_variation->createSome( $product_id )['variations'];
+
 		$query = '
             query attributeConnectionQuery( $color: [String!] ) {
                 allPaColor( where: { name: $color } ) {
@@ -86,38 +89,18 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
         ';
 
 		$variables = [ 'color' => 'red' ];
-		$actual    = graphql(
-			[
-				'query'          => $query,
-				'operation_name' => 'attributeConnectionQuery',
-				'variables'      => $variables,
-			]
-		);
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
-			'data' => [
-				'allPaColor' => [
-					'nodes' => [
-						[
-							'products' => [
-								'nodes' => [
-									[
-										'id' => $this->helper->to_relay_id( $this->product_id ),
-									],
-								],
-							],
-						],
-					],
-				],
-			],
+			$this->expectedField( 'allPaColor.nodes.0.products.nodes.0.id', $this->toRelayId( 'product', $product_id ) ),
 		];
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 
 	public function testProductAttributeToVariationConnectionQuery() {
+		$product_id    = $this->factory->product->createVariable();
+		$variation_ids = $this->factory->product_variation->createSome( $product_id )['variations'];
+
 		$query = '
             query attributeConnectionQuery( $size: [String!] ) {
                 allPaSize( where: { name: $size } ) {
@@ -133,44 +116,26 @@ class ProductAttributeQueriesTest extends \Codeception\TestCase\WPTestCase {
         ';
 
 		$variables = [ 'size' => 'small' ];
-		$actual    = graphql(
-			[
-				'query'          => $query,
-				'operation_name' => 'attributeConnectionQuery',
-				'variables'      => $variables,
-			]
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = array_map(
+			function( $id ) {
+				return $this->expectedField( 'allPaSize.nodes.0.variations.nodes.#.id', $this->toRelayId( 'product_variation', $id ) );
+			},
+			array_filter(
+				$variation_ids,
+				function( $id ) {
+					$variation       = new \WC_Product_Variation( $id );
+					$small_attribute = array_filter(
+						$variation->get_attributes(),
+						function( $attribute ) {
+							return 'small' === $attribute;
+						}
+					);
+					return ! empty( $small_attribute );
+				}
+			)
 		);
-		$expected  = [
-			'data' => [
-				'allPaSize' => [
-					'nodes' => [
-						[
-							'variations' => [
-								'nodes' => $this->variation_helper->print_nodes(
-									$this->variation_ids,
-									[
-										'filter' => function( $id ) {
-											$variation       = new \WC_Product_Variation( $id );
-											$small_attribute = array_filter(
-												$variation->get_attributes(),
-												function( $attribute ) {
-													return 'small' === $attribute;
-												}
-											);
-											return ! empty( $small_attribute );
-										},
-									]
-								),
-							],
-						],
-					],
-				],
-			],
-		];
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 }

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -933,20 +933,31 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 
 		$product_id = $this->factory->product->createSimple(
 			[
-				'tag_ids'      => [ $test_tag ],
-				'category_ids' => [ $test_category ],
+				'tag_ids'       => [ $test_tag ],
+				'category_ids'  => [ $test_category ],
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+		$expensive_product_id = $this->factory->product->createSimple(
+			[
+				'tag_ids'       => [ $test_tag ],
+				'category_ids'  => [ $test_category ],
+				'price'         => 100,
+				'regular_price' => 100,
 			]
 		);
 
 		$query = '
-			query {
+			query($orderby: [ProductsOrderbyInput], $orderby2: [ProductsOrderbyInput]) {
 				productTags( where: { hideEmpty: true } ) {
 					nodes {
 						name
-						products {
+						products(where: {orderby: $orderby}) {
 							nodes {
 								... on SimpleProduct {
 									id
+									price
 								}
 							}
 						}
@@ -958,10 +969,11 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 						image {
 							id
 						}
-						products {
+						products(where: {orderby: $orderby2}) {
 							nodes {
 								... on SimpleProduct {
 									id
+									price
 								}
 							}
 						}
@@ -970,30 +982,38 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 			}
 		';
 
-		$response = graphql( compact( 'query' ) );
-		$expected = [
+		$variables = [
+			'orderby' => [
+				[
+					'field' => 'PRICE',
+					'order' => 'ASC',
+				],
+			],
+			'orderby2' => [
+				[
+					'field' => 'PRICE',
+					'order' => 'DESC',
+				],
+			],
+		];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
 			$this->expectedNode(
 				'productTags.nodes',
 				[
-					'name'     => 'test-product-tag-2',
-					'products' => [
-						'nodes' => [
-							[ 'id' => $this->toRelayId( 'product', $product_id ) ],
-						],
-					],
+					$this->expectedField( 'name', 'test-product-tag-2' ),
+					$this->expectedField( 'products.nodes.0.id', $this->toRelayId( 'product', $product_id ) ),
+					$this->expectedField( 'products.nodes.1.id', $this->toRelayId( 'product', $expensive_product_id ) ),
 				],
 				0
 			),
 			$this->expectedNode(
 				'productCategories.nodes',
 				[
-					'name'     => 'test-product-category-2',
-					'image'    => [ 'id' => $this->toRelayId( 'post', $image_id ) ],
-					'products' => [
-						'nodes' => [
-							[ 'id' => $this->toRelayId( 'product', $product_id ) ],
-						],
-					],
+					$this->expectedField( 'name', 'test-product-category-2' ),
+					$this->expectedField( 'image.id', $this->toRelayId( 'post', $image_id ) ),
+					$this->expectedField( 'products.nodes.1.id', $this->toRelayId( 'product', $product_id ) ),
+					$this->expectedField( 'products.nodes.0.id', $this->toRelayId( 'product', $expensive_product_id ) ),
 				],
 				0
 			),

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -931,7 +931,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$test_category = $this->factory->product->createProductCategory( 'test-product-category-2' );
 		update_term_meta( $test_category, 'thumbnail_id', $image_id );
 
-		$product_id = $this->factory->product->createSimple(
+		$product_id           = $this->factory->product->createSimple(
 			[
 				'tag_ids'       => [ $test_tag ],
 				'category_ids'  => [ $test_category ],
@@ -983,7 +983,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		';
 
 		$variables = [
-			'orderby' => [
+			'orderby'  => [
 				[
 					'field' => 'PRICE',
 					'order' => 'ASC',


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
WhereArgs are now consistent across all product connections.


Does this close any currently open issues?
------------------------------------------
Fixes #694 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
