### PR TITLE
Adds tax calculation to regular and sale prices.

### DIFF
--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -245,7 +245,7 @@ class Product extends WC_Post {
 					},
 					'regularPrice'    => function() {
 						return ! empty( $this->wc_data->get_regular_price() )
-							? \wc_graphql_price( \wc_get_price_to_display( [ 'price' => $this->wc_data->get_regular_price() ] ) )
+							? \wc_graphql_price( \wc_get_price_to_display( $this->wc_data, [ 'price' => $this->wc_data->get_regular_price() ] ) )
 							: null;
 					},
 					'regularPriceRaw' => function() {
@@ -253,7 +253,7 @@ class Product extends WC_Post {
 					},
 					'salePrice'       => function() {
 						return ! empty( $this->wc_data->get_sale_price() )
-							? \wc_graphql_price( \wc_get_price_to_display( [ 'price' => $this->wc_data->get_sale_price() ] ) )
+							? \wc_graphql_price( \wc_get_price_to_display( [ $this->wc_data, 'price' => $this->wc_data->get_sale_price() ] ) )
 							: null;
 					},
 					'salePriceRaw'    => function() {

--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -245,7 +245,7 @@ class Product extends WC_Post {
 					},
 					'regularPrice'    => function() {
 						return ! empty( $this->wc_data->get_regular_price() )
-							? \wc_graphql_price( $this->wc_data->get_regular_price() )
+							? \wc_graphql_price( \wc_get_price_to_display( array( "price" => $this->wc_data->get_regular_price() ) ) )
 							: null;
 					},
 					'regularPriceRaw' => function() {
@@ -253,7 +253,7 @@ class Product extends WC_Post {
 					},
 					'salePrice'       => function() {
 						return ! empty( $this->wc_data->get_sale_price() )
-							? \wc_graphql_price( $this->wc_data->get_sale_price() )
+							? \wc_graphql_price( \wc_get_price_to_display( array( "price" => $this->wc_data->get_sale_price() ) ) )
 							: null;
 					},
 					'salePriceRaw'    => function() {

--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -253,7 +253,14 @@ class Product extends WC_Post {
 					},
 					'salePrice'       => function() {
 						return ! empty( $this->wc_data->get_sale_price() )
-							? \wc_graphql_price( \wc_get_price_to_display( [ $this->wc_data, 'price' => $this->wc_data->get_sale_price() ] ) )
+							? \wc_graphql_price(
+								\wc_get_price_to_display(
+									[
+										$this->wc_data,
+										'price' => $this->wc_data->get_sale_price(),
+									]
+								)
+							)
 							: null;
 					},
 					'salePriceRaw'    => function() {

--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -245,7 +245,7 @@ class Product extends WC_Post {
 					},
 					'regularPrice'    => function() {
 						return ! empty( $this->wc_data->get_regular_price() )
-							? \wc_graphql_price( \wc_get_price_to_display( array( "price" => $this->wc_data->get_regular_price() ) ) )
+							? \wc_graphql_price( \wc_get_price_to_display( [ 'price' => $this->wc_data->get_regular_price() ] ) )
 							: null;
 					},
 					'regularPriceRaw' => function() {
@@ -253,7 +253,7 @@ class Product extends WC_Post {
 					},
 					'salePrice'       => function() {
 						return ! empty( $this->wc_data->get_sale_price() )
-							? \wc_graphql_price( \wc_get_price_to_display( array( "price" => $this->wc_data->get_sale_price() ) ) )
+							? \wc_graphql_price( \wc_get_price_to_display( [ 'price' => $this->wc_data->get_sale_price() ] ) )
 							: null;
 					},
 					'salePriceRaw'    => function() {

--- a/tests/wpunit/QLSessionHandlerTest.php
+++ b/tests/wpunit/QLSessionHandlerTest.php
@@ -74,9 +74,9 @@ class QLSessionHandlerTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 
 		// Expect token to be value.
 		$token = $session->get_session_token();
-		$this->assertTrue( ! empty( $token->field ) );
-		$this->assertObjectHasAttribute( 'exp', $token );
-		$this->assertObjectHasAttribute( 'data', $token );
+		$this->assertTrue( ! empty( $token->iat ) );
+		$this->assertTrue( ! empty( $token->exp ) );
+		$this->assertTrue( ! empty( $token->data ) );
 	}
 
 	public function test_get_session_header() {
@@ -108,9 +108,9 @@ class QLSessionHandlerTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 		$token = $session->build_token();
 
 		$decode_token = JWT::decode( $token, new Key( GRAPHQL_WOOCOMMERCE_SECRET_KEY, 'HS256' ) );
-		$this->assertObjectHasAttribute( 'iat', $decode_token );
-		$this->assertObjectHasAttribute( 'exp', $decode_token );
-		$this->assertObjectHasAttribute( 'data', $decode_token );
+		$this->assertTrue( ! empty( $decode_token->iat ) );
+		$this->assertTrue( ! empty( $decode_token->iat ) );
+		$this->assertTrue( ! empty( $decode_token->iat ) );
 
 		$this->assertEquals( $token, $session->build_token() );
 	}

--- a/tests/wpunit/QLSessionHandlerTest.php
+++ b/tests/wpunit/QLSessionHandlerTest.php
@@ -109,8 +109,8 @@ class QLSessionHandlerTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 
 		$decode_token = JWT::decode( $token, new Key( GRAPHQL_WOOCOMMERCE_SECRET_KEY, 'HS256' ) );
 		$this->assertTrue( ! empty( $decode_token->iat ) );
-		$this->assertTrue( ! empty( $decode_token->iat ) );
-		$this->assertTrue( ! empty( $decode_token->iat ) );
+		$this->assertTrue( ! empty( $decode_token->exp ) );
+		$this->assertTrue( ! empty( $decode_token->data ) );
 
 		$this->assertEquals( $token, $session->build_token() );
 	}

--- a/tests/wpunit/QLSessionHandlerTest.php
+++ b/tests/wpunit/QLSessionHandlerTest.php
@@ -74,7 +74,7 @@ class QLSessionHandlerTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 
 		// Expect token to be value.
 		$token = $session->get_session_token();
-		$this->assertObjectHasAttribute( 'iat', $token );
+		$this->assertTrue( ! empty( $token->field ) );
 		$this->assertObjectHasAttribute( 'exp', $token );
 		$this->assertObjectHasAttribute( 'data', $token );
 	}


### PR DESCRIPTION
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [X] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
It adds `wc_get_price_to_display` so the prices returned in the field include the appropriate taxes.


Rationele
---------------------------------------------------
The [patch in v0.12.1](https://github.com/wp-graphql/wp-graphql-woocommerce/commit/82e5e72ff9260a55a4430691b42a7401246ee93e) fixes the price field for SimpleProduct and other product type inherited it's definition of it. regularPrice and salePrice however were left untouched. 

This PR allows regularPrice and salePrice to include or exclude the tax as these are the prices meant to be displayed to the end user.

Slack discussion/thread. 
https://wp-graphql.slack.com/archives/CCYJRDN4A/p1675417354842819?thread_ts=1675273227.466449&cid=CCYJRDN4A