### PR TITLE
Fix wrong function args in sale price and remove wc_get_price_to_display from raw price.

### DIFF
--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -241,7 +241,7 @@ class Product extends WC_Post {
 							: null;
 					},
 					'priceRaw'        => function() {
-						return ! empty( $this->wc_data->get_price() ) ? \wc_get_price_to_display( $this->wc_data ) : null;
+						return ! empty( $this->wc_data->get_price() ) ? $this->wc_data->get_price() : null;
 					},
 					'regularPrice'    => function() {
 						return ! empty( $this->wc_data->get_regular_price() )
@@ -255,8 +255,8 @@ class Product extends WC_Post {
 						return ! empty( $this->wc_data->get_sale_price() )
 							? \wc_graphql_price(
 								\wc_get_price_to_display(
+									$this->wc_data,
 									[
-										$this->wc_data,
 										'price' => $this->wc_data->get_sale_price(),
 									]
 								)


### PR DESCRIPTION
- [X] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [X] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [X] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
In this [commit ](https://github.com/wp-graphql/wp-graphql-woocommerce/commit/bde5fc5bbd0627abac41e66acf72abe649d9845d#diff-39f30bb249526aed8658884c4a8fc3064cfa2322b0b692f6353cdf24f6c7eabdR259), the arguments passed into the function `\wc_get_price_to_display` are incorrect. 

The function receives as a parameter the `$product` and an array `$args.` 

We are currently including the `$product` inside the `$args` array. 

https://woocommerce.github.io/code-reference/namespaces/default.html#function_wc_get_price_to_display

Additionally, this PR removes `\wc_get_price_to_display` from the `priceRaw` to be consistent with the other raw prices. 

Raw price should not be passed into functions such as `\wc_get_price_to_display` or `\wc_graphql_price`
