### PR TITLE
feat: "NAME" added to "PostTypeOrderbyEnum" values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "process-timeout": 0,
         "sort-packages": true,
         "allow-plugins": {
-            "johnpbloch/wordpress-core-installer": true
+            "johnpbloch/wordpress-core-installer": true,
+            "composer/installers": true
         }
     },
     "autoload-dev": {

--- a/includes/type/enum/class-post-type-orderby-enum.php
+++ b/includes/type/enum/class-post-type-orderby-enum.php
@@ -27,6 +27,10 @@ class Post_Type_Orderby_Enum {
 	 */
 	protected static function post_type_values() {
 		return [
+			'NAME'       => [
+				'value'       => 'post_title',
+				'description' => __( 'Order by name', 'wp-graphql-woocommerce' ),
+			],
 			'SLUG'       => [
 				'value'       => 'post_name',
 				'description' => __( 'Order by slug', 'wp-graphql-woocommerce' ),


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds the value  "NAME"  to the "PostTypeOrderbyEnum" enumeration type. It's tied the `post_title` field of products.


Does this close any currently open issues?
------------------------------------------
Fixes #588 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
