### PR TITLE
fix: Meta data type error fixed.

### DIFF
--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -44,7 +44,15 @@ class Meta_Data_Type {
 						'type'        => 'String',
 						'description' => __( 'Meta value.', 'wp-graphql-woocommerce' ),
 						'resolve'     => function ( $source ) {
-							return ! empty( $source->value ) ? (string) $source->value : null;
+							if ( empty( $source->value ) ) {
+								return null;
+							}
+
+							if ( is_array( $source->value ) || is_object( $source->value ) ) {
+								return wp_json_encode( $source->value );
+							}
+
+							return (string) $source->value;
 						},
 					],
 				],

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -115,6 +115,13 @@ class Root_Query {
 								break;
 						}
 
+						// Check if user authorized to view coupon.
+						$post_type     = get_post_type_object( 'shop_coupon' );
+						$is_authorized = current_user_can( $post_type->cap->edit_others_posts );
+						if ( ! $is_authorized ) {
+							return null;
+						}
+						
 						if ( empty( $coupon_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
 							throw new UserError( sprintf( __( 'No coupon ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
@@ -212,7 +219,7 @@ class Root_Query {
 						// Check if user authorized to view order.
 						$post_type     = get_post_type_object( 'shop_order' );
 						$is_authorized = current_user_can( $post_type->cap->edit_others_posts );
-						if ( get_current_user_id() ) {
+						if ( ! $is_authorized && get_current_user_id() ) {
 							$orders = wc_get_orders(
 								[
 									'type'          => 'shop_order',

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -121,7 +121,7 @@ class Root_Query {
 						if ( ! $is_authorized ) {
 							return null;
 						}
-						
+
 						if ( empty( $coupon_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
 							throw new UserError( sprintf( __( 'No coupon ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );

--- a/tests/wpunit/CouponQueriesTest.php
+++ b/tests/wpunit/CouponQueriesTest.php
@@ -120,13 +120,24 @@ class CouponQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 
 		/**
 		 * Assertion One
+		 * 
+		 * Confirm customer's can't query coupons by ID.
 		 */
 		$this->loginAsCustomer();
 		$variables = [ 'id' => $this->toRelayId( 'shop_coupon', $coupon_id ) ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
-		$expected  = $this->expectedCouponData( $coupon_id );
+		$expected  = [ $this->expectedField( 'coupon', self::IS_NULL ) ];
 
 		$this->assertQuerySuccessful( $response, $expected );
+
+		/**
+		 * Assertion Two
+		 * 
+		 * Confirm shop managers can query coupons by ID.
+		 */
+		$this->loginAsShopManager();
+		$response = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertQuerySuccessful( $response, $this->expectedCouponData( $coupon_id ) );
 	}
 
 	public function testCouponQueryAndIds() {
@@ -147,7 +158,7 @@ class CouponQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 		 *
 		 * Testing "ID" ID type.
 		 */
-		$this->loginAsCustomer();
+		$this->loginAsShopManager();
 		$variables = [
 			'id'     => $relay_id,
 			'idType' => 'ID',

--- a/tests/wpunit/CouponQueriesTest.php
+++ b/tests/wpunit/CouponQueriesTest.php
@@ -120,7 +120,7 @@ class CouponQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 
 		/**
 		 * Assertion One
-		 * 
+		 *
 		 * Confirm customer's can't query coupons by ID.
 		 */
 		$this->loginAsCustomer();
@@ -132,7 +132,7 @@ class CouponQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 
 		/**
 		 * Assertion Two
-		 * 
+		 *
 		 * Confirm shop managers can query coupons by ID.
 		 */
 		$this->loginAsShopManager();


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Returns flatten array meta values bypassing the array to string conversion array.
- As shop-level cap check to `coupon` query.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
