### PR TITLE
fix case sensitive apply coupon mutation

### DIFF
--- a/includes/data/mutation/class-cart-mutation.php
+++ b/includes/data/mutation/class-cart-mutation.php
@@ -170,7 +170,7 @@ class Cart_Mutation {
 		$the_coupon = new \WC_Coupon( $code );
 
 		// Prevent adding coupons by post ID.
-		if ( $the_coupon->get_code() !== $code ) {
+		if ( strtoupper( $the_coupon->get_code() ) !== strtoupper( $code ) ) {
 			$reason = __( 'No coupon found with the code provided', 'wp-graphql-woocommerce' );
 			return false;
 		}


### PR DESCRIPTION
The applyCoupon mutation is case sensitive, but coupons are not. This fixes trying to add a coupon code with lower case letters, such as `10off`. Previously you would get an error that the coupon doesn't exist because of mismatch in the case.

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …0.12.0
- **WPGraphQL Version:** …1.13.7
- **WordPress Version:** 6.1.1
- **WooCommerce Version:** 7.4.0
