### PR TITLE
feat: Country queries implemented.

### DIFF
--- a/includes/class-type-registry.php
+++ b/includes/class-type-registry.php
@@ -88,6 +88,7 @@ class Type_Registry {
 		Type\WPObject\Shipping_Rate_Type::register();
 		Type\WPObject\Cart_Error_Types::register();
 		Type\WPObject\Payment_Token_Types::register();
+		Type\WPObject\Country_State_Type::register();
 
 		// Object fields.
 		Type\WPObject\Product_Category_Type::register_fields();

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -258,6 +258,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 			require $include_directory_path . 'type/object/class-tax-rate-type.php';
 			require $include_directory_path . 'type/object/class-variation-attribute-type.php';
 			require $include_directory_path . 'type/object/class-payment-token-types.php';
+			require $include_directory_path . 'type/object/class-country-state.php';
 
 			// Include input type class files.
 			require $include_directory_path . 'type/input/class-cart-item-input.php';

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -258,7 +258,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 			require $include_directory_path . 'type/object/class-tax-rate-type.php';
 			require $include_directory_path . 'type/object/class-variation-attribute-type.php';
 			require $include_directory_path . 'type/object/class-payment-token-types.php';
-			require $include_directory_path . 'type/object/class-country-state.php';
+			require $include_directory_path . 'type/object/class-country-state-type.php';
 
 			// Include input type class files.
 			require $include_directory_path . 'type/input/class-cart-item-input.php';

--- a/includes/type/object/class-country-state-type.php
+++ b/includes/type/object/class-country-state-type.php
@@ -24,14 +24,14 @@ class Country_State_Type {
 			[
 				'description' => __( 'shipping country state object', 'wp-graphql-woocommerce' ),
 				'fields'      => [
-					'code'         => [
+					'code' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => __( 'Country state code', 'wp-graphql-woocommerce' ),
 						'resolve'     => function ( $source ) {
 							return ! empty( $source['code'] ) ? $source['code'] : null;
 						},
 					],
-					'name'   => [
+					'name' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => __( 'Country state name', 'wp-graphql-woocommerce' ),
 						'resolve'     => function ( $source ) {

--- a/includes/type/object/class-country-state.php
+++ b/includes/type/object/class-country-state.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WPObject Type - Country_State_Type
+ *
+ * Registers CountryState WPObject type
+ *
+ * @package WPGraphQL\WooCommerce\Type\WPObject
+ * @since   0.12.4
+ */
+
+namespace WPGraphQL\WooCommerce\Type\WPObject;
+
+/**
+ * Class Country_State_Type
+ */
+class Country_State_Type {
+
+	/**
+	 * Registers type
+	 */
+	public static function register() {
+		register_graphql_object_type(
+			'CountryState',
+			[
+				'description' => __( 'shipping country state object', 'wp-graphql-woocommerce' ),
+				'fields'      => [
+					'code'         => [
+						'type'        => [ 'non_null' => 'String' ],
+						'description' => __( 'Country state code', 'wp-graphql-woocommerce' ),
+						'resolve'     => function ( $source ) {
+							return ! empty( $source['code'] ) ? $source['code'] : null;
+						},
+					],
+					'name'   => [
+						'type'        => [ 'non_null' => 'String' ],
+						'description' => __( 'Country state name', 'wp-graphql-woocommerce' ),
+						'resolve'     => function ( $source ) {
+							return ! empty( $source['name'] ) ? $source['name'] : null;
+						},
+					],
+				],
+			]
+		);
+	}
+}

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -419,6 +419,42 @@ class Root_Query {
 						return Factory::resolve_tax_rate( $rate_id, $context );
 					},
 				],
+				'shippingCountries' => [
+					'type'        => [ 'list_of' => 'CountriesEnum' ],
+					'description' => __( 'Countries that the store sells to', 'wp-graphql-woocommerce' ),
+					'resolve'     => function() {
+						$wc_countries = new \WC_Countries();
+						$countries    = $wc_countries->get_allowed_countries();
+
+						return array_keys( $countries );
+					}
+				],
+				'shippingCountryStates' => [
+					'type'        => [ 'list_of' => 'CountryState' ],
+					'args'        => [
+						'country' => [
+							'type'        => [ 'non_null' => 'CountriesEnum' ],
+							'description' => __( 'Target country')
+						]
+					],
+					'description' => __( 'Countries that the store sells to', 'wp-graphql-woocommerce' ),
+					'resolve'     => function( $_, $args ) {
+						$country      = $args['country'];
+						$wc_countries = new \WC_Countries();
+						$states       = $wc_countries->get_shipping_country_states();
+
+						if ( ! empty( $states ) && ! empty( $states[ $country ] ) ) {
+							$formatted_states = [];
+							foreach( $states[ $country ] as $code => $name ) {
+								$formatted_states[] = compact( 'name', 'code' );
+							}
+
+							return $formatted_states;
+						}
+
+						return [];
+					}
+				]
 			]
 		);
 

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -26,7 +26,7 @@ class Root_Query {
 		register_graphql_fields(
 			'RootQuery',
 			[
-				'cart'             => [
+				'cart'                 => [
 					'type'        => 'Cart',
 					'args'        => [
 						'recalculateTotals' => [
@@ -49,7 +49,7 @@ class Root_Query {
 						return $cart;
 					},
 				],
-				'cartItem'         => [
+				'cartItem'             => [
 					'type'        => 'CartItem',
 					'args'        => [
 						'key' => [
@@ -66,7 +66,7 @@ class Root_Query {
 						return $item;
 					},
 				],
-				'cartFee'          => [
+				'cartFee'              => [
 					'type'        => 'CartFee',
 					'args'        => [
 						'id' => [
@@ -83,7 +83,7 @@ class Root_Query {
 						return $fee;
 					},
 				],
-				'coupon'           => [
+				'coupon'               => [
 					'type'        => 'Coupon',
 					'description' => __( 'A coupon object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -133,7 +133,7 @@ class Root_Query {
 						return Factory::resolve_crud_object( $coupon_id, $context );
 					},
 				],
-				'customer'         => [
+				'customer'             => [
 					'type'        => 'Customer',
 					'description' => __( 'A customer object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -173,7 +173,7 @@ class Root_Query {
 						return Factory::resolve_session_customer();
 					},
 				],
-				'order'            => [
+				'order'                => [
 					'type'        => 'Order',
 					'description' => __( 'A order object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -240,7 +240,7 @@ class Root_Query {
 						return $order;
 					},
 				],
-				'productVariation' => [
+				'productVariation'     => [
 					'type'        => 'ProductVariation',
 					'description' => __( 'A product variation object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -283,7 +283,7 @@ class Root_Query {
 						return Factory::resolve_crud_object( $variation_id, $context );
 					},
 				],
-				'refund'           => [
+				'refund'               => [
 					'type'        => 'Refund',
 					'description' => __( 'A refund object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -349,7 +349,7 @@ class Root_Query {
 						return $refund;
 					},
 				],
-				'shippingMethod'   => [
+				'shippingMethod'       => [
 					'type'        => 'ShippingMethod',
 					'description' => __( 'A shipping method object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -384,7 +384,7 @@ class Root_Query {
 						return Factory::resolve_shipping_method( $method_id );
 					},
 				],
-				'taxRate'          => [
+				'taxRate'              => [
 					'type'        => 'TaxRate',
 					'description' => __( 'A tax rate object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -419,7 +419,7 @@ class Root_Query {
 						return Factory::resolve_tax_rate( $rate_id, $context );
 					},
 				],
-				'shippingCountries' => [
+				'allowedCountries'     => [
 					'type'        => [ 'list_of' => 'CountriesEnum' ],
 					'description' => __( 'Countries that the store sells to', 'wp-graphql-woocommerce' ),
 					'resolve'     => function() {
@@ -427,15 +427,15 @@ class Root_Query {
 						$countries    = $wc_countries->get_allowed_countries();
 
 						return array_keys( $countries );
-					}
+					},
 				],
-				'shippingCountryStates' => [
+				'allowedCountryStates' => [
 					'type'        => [ 'list_of' => 'CountryState' ],
 					'args'        => [
 						'country' => [
 							'type'        => [ 'non_null' => 'CountriesEnum' ],
-							'description' => __( 'Target country')
-						]
+							'description' => __( 'Target country', 'wp-graphql-woocommerce' ),
+						],
 					],
 					'description' => __( 'Countries that the store sells to', 'wp-graphql-woocommerce' ),
 					'resolve'     => function( $_, $args ) {
@@ -445,7 +445,7 @@ class Root_Query {
 
 						if ( ! empty( $states ) && ! empty( $states[ $country ] ) ) {
 							$formatted_states = [];
-							foreach( $states[ $country ] as $code => $name ) {
+							foreach ( $states[ $country ] as $code => $name ) {
 								$formatted_states[] = compact( 'name', 'code' );
 							}
 
@@ -453,8 +453,8 @@ class Root_Query {
 						}
 
 						return [];
-					}
-				]
+					},
+				],
 			]
 		);
 

--- a/tests/_support/Factory/ShippingZoneFactory.php
+++ b/tests/_support/Factory/ShippingZoneFactory.php
@@ -30,6 +30,26 @@ class ShippingZoneFactory extends \WP_UnitTest_Factory_For_Thing {
 
 		$object = new \WC_Shipping_Zone();
 
+		if ( ! empty( $args['countries'] ) ) {
+			foreach ( $args['countries'] as $country ) {
+				$object->add_location( $country, 'country' );
+			}
+		}
+		if ( ! empty( $args['states'] ) ) {
+			foreach ( $args['states'] as $state ) {
+				$object->add_location( $state, 'state' );
+			}
+		}
+		if ( ! empty( $args['postcode'] ) ) {
+			foreach ( $args['postcode'] as $postcode ) {
+				$object->add_location( $postcode, 'postcode' );
+			}
+		}
+
+		if ( ! empty( $args['shipping_method'] ) ) {
+			$object->add_shipping_method( $args['shipping_method'] );
+		}
+
 		foreach ( $args as $key => $value ) {
 			if ( is_callable( [ $object, "set_{$key}" ] ) ) {
 				$object->{"set_{$key}"}( $value );

--- a/tests/wpunit/RootQueriesTest.php
+++ b/tests/wpunit/RootQueriesTest.php
@@ -1,91 +1,83 @@
 <?php
 
 class RootQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-    public function testShippingCountriesQuery() {
-        // Create shipping zones and shipping rates.
-        update_option( 'woocommerce_allowed_countries', 'specific' );
-		update_option( 'woocommerce_specific_allowed_countries', array( 'US', 'CA' ) );
+	public function testShippingCountriesQuery() {
+		// Create shipping zones and shipping rates.
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', [ 'US', 'CA' ] );
 
-        // Create query
-        $query = '
-            query {
-                shippingCountries
-            }
-        ';
+		// Create query
+		$query = '
+			query {
+				allowedCountries
+			}
+		';
 
-        $response = $this->graphql( compact( 'query' ) );
-        $expected = [
-            $this->expectedField( 'shippingCountries.#', 'US' ),
-            $this->expectedField( 'shippingCountries.#', 'CA' ),
-            $this->not()->expectedField( 'shippingCountries.#', 'GB' ),
-        ];
+		$response = $this->graphql( compact( 'query' ) );
+		$expected = [
+			$this->expectedField( 'allowedCountries.#', 'US' ),
+			$this->expectedField( 'allowedCountries.#', 'CA' ),
+			$this->not()->expectedField( 'allowedCountries.#', 'GB' ),
+		];
 
-        $this->assertQuerySuccessful( $response, $expected );
-    }
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 
-    public function testShippingCountryStatesQuery() {
-        // Create shipping zones and shipping rates.
-        update_option( 'woocommerce_allowed_countries', 'specific' );
-        update_option( 'woocommerce_specific_allowed_countries', ['US', 'CA' ] );
+	public function testShippingCountryStatesQuery() {
+		// Create shipping zones and shipping rates.
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', [ 'US', 'CA' ] );
 
-        // Create query
-        $query = '
-            query {
-                shippingCountryStates(country: US){
-                    name
-                    code
-                }
-            }
-        ';
+		// Create query
+		$query = '
+			query ($country: CountriesEnum!) {
+				allowedCountryStates(country: $country) {
+					name
+					code
+				}
+			}
+		';
 
-        $response = $this->graphql( compact( 'query' ) );
-        $expected = [
-            $this->expectedObject(
-                'shippingCountryStates.#',
-                [
-                    $this->expectedField( 'name', 'Alaska' ),
-                    $this->expectedField( 'code', 'AL' ),
-                ]
-            ),
-            $this->expectedObject(
-                'shippingCountryStates.#',
-                [
-                    $this->not()->expectedField( 'name', 'Ontario' ),
-                    $this->not()->expectedField( 'code', 'ON' ),
-                ]
-            ),
-        ];
+		$variables = [ 'country' => 'US' ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedObject(
+				'allowedCountryStates.#',
+				[
+					$this->expectedField( 'name', 'Alaska' ),
+					$this->expectedField( 'code', 'AL' ),
+				]
+			),
+			$this->expectedObject(
+				'allowedCountryStates.#',
+				[
+					$this->not()->expectedField( 'name', 'Ontario' ),
+					$this->not()->expectedField( 'code', 'ON' ),
+				]
+			),
+		];
 
-        $this->assertQuerySuccessful( $response, $expected );
+		$this->assertQuerySuccessful( $response, $expected );
 
-        // Create query
-        $query = '
-            query {
-                shippingCountryStates(country: CA){
-                    name
-                    code
-                }
-            }
-        ';
+		$variables = [ 'country' => 'CA' ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedObject(
+				'allowedCountryStates.#',
+				[
+					$this->expectedField( 'name', 'Ontario' ),
+					$this->expectedField( 'code', 'ON' ),
+				]
+			),
+			$this->expectedObject(
+				'allowedCountryStates.#',
+				[
+					$this->not()->expectedField( 'name', 'Alaska' ),
+					$this->not()->expectedField( 'code', 'AL' ),
+				]
+			),
+		];
 
-        $response = $this->graphql( compact( 'query' ) );
-        $expected = [
-            $this->expectedObject(
-                'shippingCountryStates.#',
-                [
-                    $this->expectedField( 'name', 'Ontario' ),
-                    $this->expectedField( 'code', 'ON' ),
-                ]
-            ),
-            $this->expectedObject(
-                'shippingCountryStates.#',
-                [
-                    $this->not()->expectedField( 'name', 'Alaska' ),
-                    $this->not()->expectedField( 'code', 'AL' ),
-                ]
-            ),
-        ];
-
-        $this->assertQuerySuccessful( $response, $expected );
-    }
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 }

--- a/tests/wpunit/RootQueriesTest.php
+++ b/tests/wpunit/RootQueriesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+class RootQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
+    public function testShippingCountriesQuery() {
+        // Create shipping zones and shipping rates.
+        update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'US', 'CA' ) );
+
+        // Create query
+        $query = '
+            query {
+                shippingCountries
+            }
+        ';
+
+        $response = $this->graphql( compact( 'query' ) );
+        $expected = [
+            $this->expectedField( 'shippingCountries.#', 'US' ),
+            $this->expectedField( 'shippingCountries.#', 'CA' ),
+            $this->not()->expectedField( 'shippingCountries.#', 'GB' ),
+        ];
+
+        $this->assertQuerySuccessful( $response, $expected );
+    }
+
+    public function testShippingCountryStatesQuery() {
+        // Create shipping zones and shipping rates.
+        update_option( 'woocommerce_allowed_countries', 'specific' );
+        update_option( 'woocommerce_specific_allowed_countries', ['US', 'CA' ] );
+
+        // Create query
+        $query = '
+            query {
+                shippingCountryStates(country: US){
+                    name
+                    code
+                }
+            }
+        ';
+
+        $response = $this->graphql( compact( 'query' ) );
+        $expected = [
+            $this->expectedObject(
+                'shippingCountryStates.#',
+                [
+                    $this->expectedField( 'name', 'Alaska' ),
+                    $this->expectedField( 'code', 'AL' ),
+                ]
+            ),
+            $this->expectedObject(
+                'shippingCountryStates.#',
+                [
+                    $this->not()->expectedField( 'name', 'Ontario' ),
+                    $this->not()->expectedField( 'code', 'ON' ),
+                ]
+            ),
+        ];
+
+        $this->assertQuerySuccessful( $response, $expected );
+
+        // Create query
+        $query = '
+            query {
+                shippingCountryStates(country: CA){
+                    name
+                    code
+                }
+            }
+        ';
+
+        $response = $this->graphql( compact( 'query' ) );
+        $expected = [
+            $this->expectedObject(
+                'shippingCountryStates.#',
+                [
+                    $this->expectedField( 'name', 'Ontario' ),
+                    $this->expectedField( 'code', 'ON' ),
+                ]
+            ),
+            $this->expectedObject(
+                'shippingCountryStates.#',
+                [
+                    $this->not()->expectedField( 'name', 'Alaska' ),
+                    $this->not()->expectedField( 'code', 'AL' ),
+                ]
+            ),
+        ];
+
+        $this->assertQuerySuccessful( $response, $expected );
+    }
+}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Add `allowedCountries` and `allowedCountryStates` queries for get a list of the countries and country states the WooCommerce store can sell too. See example queries below.

```graphql
query ($country: CountriesEnum!) {
	allowedCountries
	allowedCountryStates(country: $country) {
		name
		code
	}
}
```


Does this close any currently open issues?
------------------------------------------
Resolves #581 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
