### PR TITLE
fix: PaymentToken child types fixed.

### DIFF
--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -224,19 +224,54 @@ class Customer_Type {
 		/**
 		 * Register "availablePaymentMethods" field to "Customer" type.
 		 */
-		register_graphql_field(
+		register_graphql_fields(
 			'Customer',
-			'availablePaymentMethods',
 			[
-				'type'        => [ 'list_of' => 'PaymentToken' ],
-				'description' => __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' ),
-				'resolve'     => function( $source ) {
-					if ( get_current_user_id() === $source->ID ) {
-						return array_values( \WC_Payment_Tokens::get_customer_tokens( $source->ID ) );
-					}
-
-					throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
-				},
+				'availablePaymentMethods' => [
+					'type'        => [ 'list_of' => 'PaymentToken' ],
+					'description' => __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' ),
+					'resolve'     => function( $source ) {
+						if ( get_current_user_id() === $source->ID ) {
+							return array_values( \WC_Payment_Tokens::get_customer_tokens( $source->ID ) );
+						}
+	
+						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
+					},
+				],
+				'availablePaymentMethodsCC' => [
+					'type'        => [ 'list_of' => 'PaymentTokenCC' ],
+					'description' => __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' ),
+					'resolve'     => function( $source ) {
+						if ( get_current_user_id() === $source->ID ) {
+							$tokens = array_filter(
+								array_values( \WC_Payment_Tokens::get_customer_tokens( $source->ID ) ),
+								function ( $token ) {
+									return 'CC' === $token->get_type();
+								}
+							);
+							return $tokens;
+						}
+	
+						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
+					},
+				],
+				'availablePaymentMethodsEC' => [
+					'type'        => [ 'list_of' => 'PaymentTokenECheck' ],
+					'description' => __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' ),
+					'resolve'     => function( $source ) {
+						if ( get_current_user_id() === $source->ID ) {
+							$tokens = array_filter(
+								array_values( \WC_Payment_Tokens::get_customer_tokens( $source->ID ) ),
+								function ( $token ) {
+									return 'eCheck' === $token->get_type();
+								}
+							);
+							return $tokens;
+						}
+	
+						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
+					},
+				],
 			]
 		);
 	}

--- a/tests/wpunit/CustomerQueriesTest.php
+++ b/tests/wpunit/CustomerQueriesTest.php
@@ -505,6 +505,19 @@ class CustomerQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 							last4
 						}
 					}
+					availablePaymentMethodsCC {
+						id
+						tokenId
+						last4
+						expiryMonth
+						expiryYear
+						cardType
+					}
+					availablePaymentMethodsEC {
+						id
+						tokenId
+						last4
+					}
 				}
 			}
 		';
@@ -547,7 +560,45 @@ class CustomerQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 				]
 			),
 			$this->expectedNode(
+				'customer.availablePaymentMethodsCC',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'token', $token_cc->get_id() ) ),
+					$this->expectedField( 'tokenId', $token_cc->get_id() ),
+					$this->expectedField( 'last4', 1234 ),
+					$this->expectedField( 'expiryMonth', $expiry_month ),
+					$this->expectedField( 'expiryYear', $expiry_year ),
+					$this->expectedField( 'cardType', 'visa' ),
+				]
+			),
+			$this->expectedNode(
+				'customer.availablePaymentMethodsEC',
+				[
+					$this->not()->expectedField( 'id', $this->toRelayId( 'token', $token_cc->get_id() ) ),
+					$this->not()->expectedField( 'tokenId', $token_cc->get_id() ),
+					$this->not()->expectedField( 'last4', 1234 ),
+					$this->not()->expectedField( 'expiryMonth', $expiry_month ),
+					$this->not()->expectedField( 'expiryYear', $expiry_year ),
+					$this->not()->expectedField( 'cardType', 'visa' ),
+				]
+			),
+			$this->expectedNode(
 				'customer.availablePaymentMethods',
+				[
+					$this->expectedField( 'id', $this->toRelayId( 'token', $token_ec->get_id() ) ),
+					$this->expectedField( 'tokenId', $token_ec->get_id() ),
+					$this->expectedField( 'last4', 4567 ),
+				]
+			),
+			$this->expectedNode(
+				'customer.availablePaymentMethodsCC',
+				[
+					$this->not()->expectedField( 'id', $this->toRelayId( 'token', $token_ec->get_id() ) ),
+					$this->not()->expectedField( 'tokenId', $token_ec->get_id() ),
+					$this->not()->expectedField( 'last4', 4567 ),
+				]
+			),
+			$this->expectedNode(
+				'customer.availablePaymentMethodsEC',
 				[
 					$this->expectedField( 'id', $this->toRelayId( 'token', $token_ec->get_id() ) ),
 					$this->expectedField( 'tokenId', $token_ec->get_id() ),


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Introduces the `availablePaymentMethodsCC` and `availablePaymentMethodsEC` customer fields to complete necessary expose of child types for schema validation.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
