### PR TITLE
feat: Account URL added to Auth URLs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "allow-plugins": {
             "johnpbloch/wordpress-core-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "composer/installers": true
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
         "allow-plugins": {
             "johnpbloch/wordpress-core-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true,
-            "composer/installers": true
+            "phpstan/extension-installer": true
         }
     },
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -385,16 +385,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.18",
+            "version": "1.10.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "52b6416c579663eebdd2f1d97df21971daf3b43f"
+                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/52b6416c579663eebdd2f1d97df21971daf3b43f",
-                "reference": "52b6416c579663eebdd2f1d97df21971daf3b43f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
+                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
                 "shasum": ""
             },
             "require": {
@@ -443,7 +443,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-07T22:00:43+00:00"
+            "time": "2023-06-21T20:07:58+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",

--- a/includes/admin/class-general.php
+++ b/includes/admin/class-general.php
@@ -33,6 +33,11 @@ class General extends Section {
 		return array_values( array_diff_key( $nonce_values, [ $excluded => '' ] ) );
 	}
 
+	/**
+	 * Returns the enabled authorizing URL fields.
+	 *
+	 * @return array
+	 */
 	public static function enabled_authorizing_url_fields_value() {
 		return apply_filters(
 			'woographql_enabled_authorizing_url_fields',
@@ -51,17 +56,17 @@ class General extends Section {
 	 * @return array
 	 */
 	public static function get_fields() {
-		$custom_endpoint                  = apply_filters( 'woographql_authorizing_url_endpoint', null );
-		$enabled_authorizing_url_fields   = woographql_setting( 'enable_authorizing_url_fields', [] );
-		$enabled_authorizing_url_fields   = ! empty( $enabled_authorizing_url_fields ) ? array_keys( $enabled_authorizing_url_fields ) : [];
-		$all_urls_checked                 = self::enabled_authorizing_url_fields_value();
+		$custom_endpoint                = apply_filters( 'woographql_authorizing_url_endpoint', null );
+		$enabled_authorizing_url_fields = woographql_setting( 'enable_authorizing_url_fields', [] );
+		$enabled_authorizing_url_fields = ! empty( $enabled_authorizing_url_fields ) ? array_keys( $enabled_authorizing_url_fields ) : [];
+		$all_urls_checked               = self::enabled_authorizing_url_fields_value();
 
 		$cart_url_hardcoded               = defined( 'CART_URL_NONCE_PARAM' ) && ! empty( constant( 'CART_URL_NONCE_PARAM' ) );
 		$checkout_url_hardcoded           = defined( 'CHECKOUT_URL_NONCE_PARAM' ) && ! empty( constant( 'CHECKOUT_URL_NONCE_PARAM' ) );
 		$account_url_hardcoded            = defined( 'ACCOUNT_URL_NONCE_PARAM' ) && ! empty( constant( 'ACCOUNT_URL_NONCE_PARAM' ) );
 		$add_payment_method_url_hardcoded = defined( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) && ! empty( constant( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) );
 
-		$enable_auth_urls_hardcoded       = defined( 'WPGRAPHQL_WOOCOMMERCE_ENABLE_AUTH_URLS' ) && ! empty( constant( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) );
+		$enable_auth_urls_hardcoded = defined( 'WPGRAPHQL_WOOCOMMERCE_ENABLE_AUTH_URLS' ) && ! empty( constant( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) );
 
 		return [
 			[
@@ -91,7 +96,7 @@ class General extends Section {
 					[
 						'cart_url'               => __( 'Cart URL. Field name: <strong>cartUrl</strong>', 'wp-graphql-woocommerce' ),
 						'checkout_url'           => __( 'Checkout URL. Field name: <strong>checkoutUrl</strong>', 'wp-graphql-woocommerce' ),
-						'account_url'            => __( 'Account URL. Field name: <strong>accountUrl</strong>', 'wp-graphql-wooocommerce' ),
+						'account_url'            => __( 'Account URL. Field name: <strong>accountUrl</strong>', 'wp-graphql-woocommerce' ),
 						'add_payment_method_url' => __( 'Add Payment Method URL. Field name: <strong>addPaymentMethodUrl</strong>', 'wp-graphql-woocommerce' ),
 					]
 				),

--- a/includes/admin/class-general.php
+++ b/includes/admin/class-general.php
@@ -25,11 +25,24 @@ class General extends Section {
 			[
 				'cart_url'               => woographql_setting( 'cart_url_nonce_param', '_wc_cart' ),
 				'checkout_url'           => woographql_setting( 'checkout_url_nonce_param', '_wc_checkout' ),
+				'account_url'            => woographql_setting( 'account_url_nonce_param', '_wc_account' ),
 				'add_payment_method_url' => woographql_setting( 'add_payment_method_url_nonce_param', '_wc_payment' ),
 			]
 		);
 
 		return array_values( array_diff_key( $nonce_values, [ $excluded => '' ] ) );
+	}
+
+	public static function enabled_authorizing_url_fields_value() {
+		return apply_filters(
+			'woographql_enabled_authorizing_url_fields',
+			[
+				'cart_url'               => 'cart_url',
+				'checkout_url'           => 'checkout_url',
+				'account_url'            => 'account_url',
+				'add_payment_method_url' => 'add_payment_method_url',
+			]
+		);
 	}
 
 	/**
@@ -38,23 +51,17 @@ class General extends Section {
 	 * @return array
 	 */
 	public static function get_fields() {
-		$custom_endpoint                = apply_filters( 'woographql_authorizing_url_endpoint', null );
-		$enabled_authorizing_url_fields = woographql_setting( 'enable_authorizing_url_fields', [] );
-		$enabled_authorizing_url_fields = ! empty( $enabled_authorizing_url_fields ) ? array_keys( $enabled_authorizing_url_fields ) : [];
-		$all_urls_checked               = apply_filters(
-			'woographql_enabled_authorizing_url_fields',
-			[
-				'cart_url'               => 'cart_url',
-				'checkout_url'           => 'checkout_url',
-				'add_payment_method_url' => 'add_payment_method_url',
-			]
-		);
+		$custom_endpoint                  = apply_filters( 'woographql_authorizing_url_endpoint', null );
+		$enabled_authorizing_url_fields   = woographql_setting( 'enable_authorizing_url_fields', [] );
+		$enabled_authorizing_url_fields   = ! empty( $enabled_authorizing_url_fields ) ? array_keys( $enabled_authorizing_url_fields ) : [];
+		$all_urls_checked                 = self::enabled_authorizing_url_fields_value();
 
 		$cart_url_hardcoded               = defined( 'CART_URL_NONCE_PARAM' ) && ! empty( constant( 'CART_URL_NONCE_PARAM' ) );
 		$checkout_url_hardcoded           = defined( 'CHECKOUT_URL_NONCE_PARAM' ) && ! empty( constant( 'CHECKOUT_URL_NONCE_PARAM' ) );
+		$account_url_hardcoded            = defined( 'ACCOUNT_URL_NONCE_PARAM' ) && ! empty( constant( 'ACCOUNT_URL_NONCE_PARAM' ) );
 		$add_payment_method_url_hardcoded = defined( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) && ! empty( constant( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) );
 
-		$enable_auth_urls_hardcoded = defined( 'WPGRAPHQL_WOOCOMMERCE_ENABLE_AUTH_URLS' ) && ! empty( constant( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) );
+		$enable_auth_urls_hardcoded       = defined( 'WPGRAPHQL_WOOCOMMERCE_ENABLE_AUTH_URLS' ) && ! empty( constant( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) );
 
 		return [
 			[
@@ -84,6 +91,7 @@ class General extends Section {
 					[
 						'cart_url'               => __( 'Cart URL. Field name: <strong>cartUrl</strong>', 'wp-graphql-woocommerce' ),
 						'checkout_url'           => __( 'Checkout URL. Field name: <strong>checkoutUrl</strong>', 'wp-graphql-woocommerce' ),
+						'account_url'            => __( 'Account URL. Field name: <strong>accountUrl</strong>', 'wp-graphql-wooocommerce' ),
 						'add_payment_method_url' => __( 'Add Payment Method URL. Field name: <strong>addPaymentMethodUrl</strong>', 'wp-graphql-woocommerce' ),
 					]
 				),
@@ -153,6 +161,30 @@ class General extends Section {
 						);
 
 						return '_wc_checkout';
+					}
+
+					return $value;
+				},
+			],
+			[
+				'name'              => 'account_url_nonce_param',
+				'label'             => __( 'Account URL nonce name', 'wp-graphql-woocommerce' ),
+				'desc'              => __( 'Query parameter name of the nonce included in the "accountUrl" field', 'wp-graphql-woocommerce' )
+					. ( $account_url_hardcoded ? __( ' This setting is disabled. The "ACCOUNT_URL_NONCE_PARAM" flag has been set with code', 'wp-graphql-woocommerce' ) : '' ),
+				'type'              => 'text',
+				'value'             => $account_url_hardcoded ? ACCOUNT_URL_NONCE_PARAM : woographql_setting( 'account_url_nonce_param', '_wc_account' ),
+				'disabled'          => defined( 'ACCOUNT_URL_NONCE_PARAM' ) || ! in_array( 'account_url', $enabled_authorizing_url_fields, true ),
+				'sanitize_callback' => function ( $value ) {
+					$other_nonces = self::get_other_nonce_values( 'account_url' );
+					if ( in_array( $value, $other_nonces, true ) ) {
+						add_settings_error(
+							'account_url_nonce_param',
+							'unique',
+							__( 'The <strong>Account URL nonce name</strong> field must be unique', 'wp-graphql-woocommerce' ),
+							'error'
+						);
+
+						return '_wc_account';
 					}
 
 					return $value;

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -57,14 +57,7 @@ class WooCommerce_Filters {
 	 */
 	public static function enabled_authorizing_url_fields() {
 		if ( defined( 'WPGRAPHQL_WOOCOMMERCE_ENABLE_AUTH_URLS' ) ) {
-			return apply_filters(
-				'woographql_enabled_authorizing_url_fields',
-				[
-					'cart_url'               => 'cart_url',
-					'checkout_url'           => 'checkout_url',
-					'add_payment_method_url' => 'add_payment_method_url',
-				]
-			);
+			return \WPGraphQL\WooCommerce\Admin\General::enabled_authorizing_url_fields_value();
 		}
 		return woographql_setting( 'enable_authorizing_url_fields', [] );
 	}

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -685,7 +685,7 @@ class Cart_Type {
 										}
 									}
 
-									return Variation_Attribute_Connection_Resolver::to_data_array( $attributes, $variation->ID );
+									return Variation_Attribute_Connection_Resolver::variation_attributes_to_data_array( $attributes, $variation->ID );
 								},
 							],
 						],

--- a/includes/utils/class-protected-router.php
+++ b/includes/utils/class-protected-router.php
@@ -222,6 +222,7 @@ class Protected_Router {
 		foreach ( array_keys( $enabled_authorizing_url_fields ) as $field ) {
 			$nonce_names[ $field ] = WooCommerce_Filters::get_authorizing_url_nonce_param_name( $field );
 		}
+
 		return array_filter( $nonce_names );
 	}
 
@@ -249,17 +250,23 @@ class Protected_Router {
 	/**
 	 * Returns the target endpoint url for the provided field.
 	 *
+	 * @todo Add error logging here when WC Page needs to be created.
+	 *
 	 * @param string $field  Field.
 	 * @return string|null
 	 */
 	public function get_target_endpoint( $field ) {
 		switch ( $field ) {
 			case 'cart_url':
-				return wc_get_endpoint_url( 'cart' );
+				$cart_page_id  = wc_get_page_id( 'cart' );
+				$cart_page_url = get_permalink( $cart_page_id );
+				return $cart_page_url ? $cart_page_url : null;
 			case 'checkout_url':
 				return wc_get_endpoint_url( 'checkout' );
 			case 'account_url':
-				return wc_get_endpoint_url( 'myaccount' );
+				$account_page_id  = get_option( 'woocommerce_myaccount_page_id' );
+				$account_page_url = get_permalink( $account_page_id );
+				return $account_page_url ? $account_page_url : null;
 			case 'add_payment_method_url':
 				return wc_get_account_endpoint_url( 'add-payment-method' );
 			default:

--- a/includes/utils/class-protected-router.php
+++ b/includes/utils/class-protected-router.php
@@ -237,8 +237,10 @@ class Protected_Router {
 				return 'load-cart_';
 			case 'checkout_url':
 				return 'load-checkout_';
-			case 'add_payment_method_url':
+			case 'account_url':
 				return 'load-account_';
+			case 'add_payment_method_url':
+				return 'add-payment-method_';
 			default:
 				return apply_filters( 'woographql_auth_nonce_prefix', null, $field, $this );
 		}
@@ -256,6 +258,8 @@ class Protected_Router {
 				return wc_get_endpoint_url( 'cart' );
 			case 'checkout_url':
 				return wc_get_endpoint_url( 'checkout' );
+			case 'account_url':
+				return wc_get_endpoint_url( 'myaccount' );
 			case 'add_payment_method_url':
 				return wc_get_account_endpoint_url( 'add-payment-method' );
 			default:

--- a/includes/utils/class-transfer-session-handler.php
+++ b/includes/utils/class-transfer-session-handler.php
@@ -10,8 +10,24 @@ namespace WPGraphQL\WooCommerce\Utils;
 
 /**
  * Class Transfer_Session_Handler
+ *
+ * @property string|int $_customer_id
+ *
+ * @package WPGraphQL\WooCommerce\Utils
  */
 class Transfer_Session_Handler extends \WC_Session_Handler {
+	/**
+	 * Setup cookie and customer ID.
+	 *
+	 * @return void
+	 */
+	public function init_session_cookie() {
+		// Retrieve a customer's previous session from DB.
+		$this->set_session_expiration();
+		$this->_customer_id = $this->generate_customer_id();
+		$this->_data        = $this->get_session_data();
+	}
+
 	/**
 	 * Return true, if valid credential exists
 	 *

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -21,6 +21,9 @@ if ( ! defined( 'CART_URL_NONCE_PARAM' ) ) {
 if ( ! defined( 'CHECKOUT_URL_NONCE_PARAM' ) ) {
 	define( 'CHECKOUT_URL_NONCE_PARAM', '_wc_checkout' );
 }
+if ( ! defined( 'ACCOUNT_URL_NONCE_PARAM' ) ) {
+	define( 'ACCOUNT_URL_NONCE_PARAM', '_wc_account' );
+}
 if ( ! defined( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) ) {
 	define( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM', '_wc_payment' );
 }

--- a/tests/_support/Factory/ProductFactory.php
+++ b/tests/_support/Factory/ProductFactory.php
@@ -141,6 +141,11 @@ class ProductFactory extends \WP_UnitTest_Factory_For_Thing {
 				'attribute_data' => [
 					$this->createAttribute( 'size', [ 'small', 'medium', 'large' ] ), // Create Size attribute.
 					$this->createAttribute( 'color', [ 'red', 'blue', 'green' ] ), // Create Color attribute.
+					[
+						'attribute_id'       => 0,
+						'attribute_taxonomy' => 'logo',
+						'term_ids'           => [ 'Yes', 'No' ],
+					], // Create Logo attribute.
 				],
 			],
 			$args

--- a/tests/_support/Factory/ProductVariationFactory.php
+++ b/tests/_support/Factory/ProductVariationFactory.php
@@ -74,26 +74,33 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 	}
 
 	public function get_object_by_id( $product_id ) {
-		return \wc_get_product( absint( $product_id ) );
+		return wc_get_product( absint( $product_id ) );
 	}
 
-	public function createSome( $product = null, $args = [] ) {
-		if ( ! $product ) {
-			$product = $this->factory->product->createVariable();
+	public function createSome( $product_id = null, $args = [] ) {
+		if ( ! $product_id ) {
+			$product_id = $this->factory->product->createVariable();
 		}
+		$product = wc_get_product( $product_id );
 
 		// Create variation stub data.
 		$variation_data = [
 			[
-				'parent_id'     => $product,
-				'attributes'    => [ 'pa_size' => 'small' ],
+				'parent_id'     => $product_id,
+				'attributes'    => [
+					'pa_size' => 'small',
+					'logo'    => 'Yes',
+				],
 				'image_id'      => null,
 				'downloads'     => [ $this->factory->product->createDownload() ],
 				'regular_price' => 10,
 			],
 			[
-				'parent_id'     => $product,
-				'attributes'    => [ 'pa_size' => 'medium' ],
+				'parent_id'     => $product_id,
+				'attributes'    => [
+					'pa_size' => 'medium',
+					'logo'    => 'No',
+				],
 				'image_id'      => $this->factory->post->create(
 					[
 						'post_status'  => 'publish',
@@ -105,8 +112,11 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 				'regular_price' => 15,
 			],
 			[
-				'parent_id'     => $product,
-				'attributes'    => [ 'pa_size' => 'large' ],
+				'parent_id'     => $product_id,
+				'attributes'    => [
+					'pa_size' => 'large',
+					'logo'    => 'Yes',
+				],
 				'image_id'      => null,
 				'downloads'     => [],
 				'regular_price' => 20,
@@ -121,6 +131,16 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 			$variations[] = $variation->get_id();
 		}
 
-		return compact( 'product', 'variations' );
+		$product->set_default_attributes(
+			[
+				'pa_size' => 'medium',
+			]
+		);
+		$product->save();
+
+		return [
+			'product'    => $product_id,
+			'variations' => $variations,
+		];
 	}
 }

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -18,7 +18,7 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 						'label',
 						$attribute->is_taxonomy()
 							? ucwords( get_taxonomy( $attribute->get_name() )->labels->singular_name )
-							: self::IS_NULL
+							: ucfirst( $attribute->get_name() )
 					),
 					$this->expectedField( 'options', $attribute->get_slugs() ),
 					$this->expectedField( 'position', $attribute->get_position() ),

--- a/tests/wpunit/ProtectedRouterTest.php
+++ b/tests/wpunit/ProtectedRouterTest.php
@@ -48,9 +48,9 @@ class ProtectedRouterTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 
 	public function testGetTargetEndpoint() {
 		$router = \WPGraphQL\WooCommerce\Utils\Protected_Router::instance();
-		$this->assertEquals( wc_get_endpoint_url( 'cart' ), $router->get_target_endpoint( 'cart_url' ) );
+		$this->assertEquals( get_permalink( wc_get_page_id( 'cart' ) ), $router->get_target_endpoint( 'cart_url' ) );
 		$this->assertEquals( wc_get_endpoint_url( 'checkout' ), $router->get_target_endpoint( 'checkout_url' ) );
-		$this->assertEquals( wc_get_account_endpoint_url( 'dashboard' ), $router->get_target_endpoint( 'account_url' ) );
+		$this->assertEquals( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ), $router->get_target_endpoint( 'account_url' ) );
 		$this->assertEquals( wc_get_account_endpoint_url( 'add-payment-method' ), $router->get_target_endpoint( 'add_payment_method_url' ) );
 		$this->assertEquals( null, $router->get_nonce_prefix( 'invalid' ) );
 	}

--- a/tests/wpunit/ProtectedRouterTest.php
+++ b/tests/wpunit/ProtectedRouterTest.php
@@ -30,6 +30,7 @@ class ProtectedRouterTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 			[
 				'cart_url'               => '_wc_cart',
 				'checkout_url'           => '_wc_checkout',
+				'account_url'            => '_wc_account',
 				'add_payment_method_url' => '_wc_payment',
 			],
 			$router->get_nonce_names()
@@ -40,7 +41,8 @@ class ProtectedRouterTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 		$router = \WPGraphQL\WooCommerce\Utils\Protected_Router::instance();
 		$this->assertEquals( 'load-cart_', $router->get_nonce_prefix( 'cart_url' ) );
 		$this->assertEquals( 'load-checkout_', $router->get_nonce_prefix( 'checkout_url' ) );
-		$this->assertEquals( 'load-account_', $router->get_nonce_prefix( 'add_payment_method_url' ) );
+		$this->assertEquals( 'load-account_', $router->get_nonce_prefix( 'account_url' ) );
+		$this->assertEquals( 'add-payment-method_', $router->get_nonce_prefix( 'add_payment_method_url' ) );
 		$this->assertEquals( null, $router->get_nonce_prefix( 'invalid' ) );
 	}
 
@@ -48,6 +50,7 @@ class ProtectedRouterTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 		$router = \WPGraphQL\WooCommerce\Utils\Protected_Router::instance();
 		$this->assertEquals( wc_get_endpoint_url( 'cart' ), $router->get_target_endpoint( 'cart_url' ) );
 		$this->assertEquals( wc_get_endpoint_url( 'checkout' ), $router->get_target_endpoint( 'checkout_url' ) );
+		$this->assertEquals( wc_get_account_endpoint_url( 'dashboard' ), $router->get_target_endpoint( 'account_url' ) );
 		$this->assertEquals( wc_get_account_endpoint_url( 'add-payment-method' ), $router->get_target_endpoint( 'add_payment_method_url' ) );
 		$this->assertEquals( null, $router->get_nonce_prefix( 'invalid' ) );
 	}

--- a/tests/wpunit/TransferSessionHandlerTest.php
+++ b/tests/wpunit/TransferSessionHandlerTest.php
@@ -19,6 +19,36 @@ class TransferSessionHandlerTest extends \Tests\WPGraphQL\WooCommerce\TestCase\W
 		$this->session = new Transfer_Session_Handler();
 	}
 
+	public function tearDown(): void {
+		// after
+		parent::tearDown();
+
+		$_REQUEST = [];
+	}
+
+	public function testInitSessionCookie() {
+		// Assert session data is empty, when invalid creds are provided.
+		$_REQUEST['_wc_cart']   = 'test';
+		$_REQUEST['session_id'] = 'test-session-id';
+		$this->session->init_session_cookie();
+		$this->assertEmpty( $this->session->get_session_data() );
+		$this->assertEquals( 'test-session-id', $this->session->get_customer_id() );
+		$this->session->set( 'test', 'test' );
+		$this->session->save_data();
+
+		// Reset session data.
+		unset( $_REQUEST['_wc_cart'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		unset( $_REQUEST['session_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->session->init_session_cookie();
+		$this->assertEmpty( $this->session->get_session_data() );
+
+		// Assert session data is empty, when invalid creds are provided.
+		$_REQUEST['_wc_cart']   = 'test';
+		$_REQUEST['session_id'] = 'test-session-id';
+		$this->session->init_session_cookie();
+		$this->assertEmpty( $this->session->get_session_data() );
+	}
+
 	public function testGenerateCustomerId() {
 		// Assert random customer ID is generated when invalid creds are provided.
 		$this->session->init_session_cookie();


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds `accountUrl` and `accountNonce` to the Authorizing URLs option.
- Fixes issues related to auth URLs usage.
- Fixes the `simpleProduct`'s `defaultAttributes` field.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
