### PR TITLE
fix: remove `codecept_debug()` call from production code

### DIFF
--- a/includes/data/class-db-hooks.php
+++ b/includes/data/class-db-hooks.php
@@ -68,7 +68,6 @@ class DB_Hooks {
 			? $clauses['orderby'] . ','
 			: '';
 
-		\codecept_debug( $orderby );
 		if ( ! isset( $args['graphql_cursor_compare'] ) ) {
 			$clauses['orderby'] = "{$orderby} {$tables['orders']}.id DESC ";
 		} else {


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes a production call to `codecept_debug()` from the `add_cursor()` method.
This likely snuck in during debugging and can throw a fatal error when the composer `dev-dependencies` are not installed. (It slips by linters since codeception gets installed in the ci)


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.14.1
- **WPGraphQL Version:** 1.14.6
- **WordPress Version:** 6.2.2
- **WooCommerce Version:** 7.8.2
