### PR TITLE
dev: remove deprecated usage of `AbstractConnectionResolver::get_offset()`

### DIFF
--- a/includes/data/connection/class-coupon-connection-resolver.php
+++ b/includes/data/connection/class-coupon-connection-resolver.php
@@ -120,20 +120,22 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 		];
 
 		/**
-		 * Set the graphql_cursor_offset which is used by Config::graphql_wp_query_cursor_pagination_support
-		 * to filter the WP_Query to support cursor pagination
+		 * Set the cursor args.
+		 *
+		 * @see \WPGraphQL\Data\Config::graphql_wp_query_cursor_pagination_support
 		 */
-		$cursor_offset                        = $this->get_offset();
-		$query_args['graphql_cursor_offset']  = $cursor_offset;
-		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+		$query_args['graphql_after_cursor']   = $this->get_after_offset();
+		$query_args['graphql_before_cursor']  = $this->get_before_offset();
+		$query_args['graphql_cursor_compare'] = ! empty( $last ) ? '>' : '<';
 
 		/**
 		 * If the starting offset is not 0 sticky posts will not be queried as the automatic checks in wp-query don't
 		 * trigger due to the page parameter not being set in the query_vars, fixes #732
 		 */
-		if ( 0 !== $cursor_offset ) {
+		if ( empty( $query_args['graphql_after_cursor'] ) && empty( $query_args['graphql_before_cursor'] ) ) {
 			$query_args['ignore_sticky_posts'] = true;
 		}
+
 		/**
 		 * Pass the graphql $args to the WP_Query
 		 */

--- a/includes/data/connection/class-customer-connection-resolver.php
+++ b/includes/data/connection/class-customer-connection-resolver.php
@@ -61,12 +61,13 @@ class Customer_Connection_Resolver extends AbstractConnectionResolver {
 		$query_args['number']      = $this->get_query_amount() + 1;
 
 		/**
-		 * Set the graphql_cursor_offset which is used by Config::graphql_wp_user_query_cursor_pagination_support
-		 * to filter the WP_User_Query to support cursor pagination
+		 * Set the cursor args.
+		 *
+		 * @see \WPGraphQL\Data\Config::graphql_wp_query_cursor_pagination_support
 		 */
-		$cursor_offset                        = $this->get_offset();
-		$query_args['graphql_cursor_offset']  = $cursor_offset;
-		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+		$query_args['graphql_after_cursor']   = $this->get_after_offset();
+		$query_args['graphql_before_cursor']  = $this->get_before_offset();
+		$query_args['graphql_cursor_compare'] = ! empty( $last ) ? '>' : '<';
 
 		$input_fields = [];
 		if ( ! empty( $this->args['where'] ) ) {

--- a/includes/data/connection/class-order-item-connection-resolver.php
+++ b/includes/data/connection/class-order-item-connection-resolver.php
@@ -119,7 +119,7 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 			}
 		}
 
-		$cursor = absint( $this->get_offset() );
+		$cursor = (int) $this->get_offset_for_cursor( $this->args['after'] ?? ( $this->args['before'] ?? 0 ) );
 		$first  = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
 		$last   = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 
@@ -177,36 +177,5 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 	 */
 	public function is_valid_offset( $offset ) {
 		return 'string' === gettype( $offset );
-	}
-
-	/**
-	 * Get_offset
-	 *
-	 * This returns the offset to be used in the $query_args based on the $args passed to the
-	 * GraphQL query.
-	 *
-	 * @return int|mixed
-	 */
-	public function get_offset() {
-		/**
-		 * Defaults
-		 */
-		$offset = 0;
-
-		/**
-		 * Get the $after offset
-		 */
-		if ( ! empty( $this->args['after'] ) ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-			$offset = substr( base64_decode( $this->args['after'] ), strlen( 'arrayconnection:' ) );
-		} elseif ( ! empty( $this->args['before'] ) ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-			$offset = substr( base64_decode( $this->args['before'] ), strlen( 'arrayconnection:' ) );
-		}
-
-		/**
-		 * Return the higher of the two values
-		 */
-		return $offset;
 	}
 }

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -152,12 +152,13 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 * Set the graphql_cursor_offset which is used by Config::graphql_wp_query_cursor_pagination_support
-		 * to filter the WP_Query to support cursor pagination
+		 * Set the cursor args.
+		 *
+		 * @see \WPGraphQL\Data\Config::graphql_wp_query_cursor_pagination_support
 		 */
-		$cursor_offset                        = $this->get_offset();
-		$query_args['graphql_cursor_offset']  = $cursor_offset;
-		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+		$query_args['graphql_after_cursor']   = $this->get_after_offset();
+		$query_args['graphql_before_cursor']  = $this->get_before_offset();
+		$query_args['graphql_cursor_compare'] = ! empty( $last ) ? '>' : '<';
 
 		/**
 		 * Pass the graphql $args to the WP_Query

--- a/includes/data/connection/class-shipping-method-connection-resolver.php
+++ b/includes/data/connection/class-shipping-method-connection-resolver.php
@@ -88,36 +88,4 @@ class Shipping_Method_Connection_Resolver extends AbstractConnectionResolver {
 	public function is_valid_offset( $offset ) {
 		return is_string( $offset );
 	}
-
-	/**
-	 * Get_offset
-	 *
-	 * This returns the offset to be used in the $query_args based on the $args passed to the
-	 * GraphQL query.
-	 *
-	 * @return int|mixed
-	 */
-	public function get_offset() {
-		/**
-		 * Defaults
-		 */
-		$offset = 0;
-
-		/**
-		 * Get the $after offset
-		 */
-		if ( ! empty( $this->args['after'] ) ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-			$offset = substr( base64_decode( $this->args['after'] ), strlen( 'arrayconnection:' ) );
-		} elseif ( ! empty( $this->args['before'] ) ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-			$offset = substr( base64_decode( $this->args['before'] ), strlen( 'arrayconnection:' ) );
-		}
-
-		/**
-		 * Return the higher of the two values
-		 */
-		return $offset;
-	}
-
 }

--- a/includes/data/connection/class-tax-rate-connection-resolver.php
+++ b/includes/data/connection/class-tax-rate-connection-resolver.php
@@ -73,12 +73,13 @@ class Tax_Rate_Connection_Resolver extends AbstractConnectionResolver {
 		$query_args['items_per_page'] = min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1;
 
 		/**
-		 * Set the graphql_cursor_offset which is used by Config::graphql_wp_query_cursor_pagination_support
-		 * to filter the WP_Query to support cursor pagination
+		 * Set the cursor args.
+		 *
+		 * @see \WPGraphQL\Data\Config::graphql_wp_query_cursor_pagination_support
 		 */
-		$cursor_offset                        = $this->get_offset();
-		$query_args['graphql_cursor_offset']  = $cursor_offset;
-		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+		$query_args['graphql_after_cursor']   = $this->get_after_offset();
+		$query_args['graphql_before_cursor']  = $this->get_before_offset();
+		$query_args['graphql_cursor_compare'] = ! empty( $last ) ? '>' : '<';
 
 		/**
 		 * If there's no orderby params in the inputArgs, set order based on the first/last argument


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR removes the usage of `AbstractConnectionResolver::get_offset()`, which was deprecated from WPGraphQL in v1.9.0.

Instead of `get_offset()`, we use `get_offset_for_cursor()`, and rely on the `graphql_after_cursor` and `graphql_before_cursor` query args.

Additionally, the overloaded definitions of `get_offset()` were removed from local ConnectionResolvers as their output is identical to the parent method, sans the deprecation warning.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
```
 PHP Deprecated:  Function WPGraphQL\Data\Connection\AbstractConnectionResolver::get_offset is <strong>deprecated</strong> since version 1.9.0! Use WPGraphQL\WooCommerce\Data\Connection\Product_Connection_Resolver::get_offset_for_cursor() instead.
```

Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.14.1
- **WPGraphQL Version:** 1.14.6
- **WordPress Version:** 6.2.2
- **WooCommerce Version:** 7.8.2
