### PR TITLE
fix: cleanup useless variables and ternaries

### DIFF
--- a/includes/admin/class-general.php
+++ b/includes/admin/class-general.php
@@ -76,7 +76,7 @@ class General extends Section {
 					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'wp-graphql-woocommerce' ) : '' ),
 				'type'     => 'checkbox',
 				'value'    => defined( 'NO_QL_SESSION_HANDLER' ) ? 'on' : woographql_setting( 'disable_ql_session_handler', 'off' ),
-				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ) ? true : false,
+				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
 			],
 			[
 				'name'    => 'enable_unsupported_product_type',
@@ -101,7 +101,7 @@ class General extends Section {
 					]
 				),
 				'value'             => $enable_auth_urls_hardcoded ? $all_urls_checked : woographql_setting( 'enable_authorizing_url_fields', [] ),
-				'disabled'          => $enable_auth_urls_hardcoded ? true : false,
+				'disabled'          => $enable_auth_urls_hardcoded,
 				'sanitize_callback' => static function( $value ) {
 					if ( empty( $value ) ) {
 						return [];

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -398,7 +398,7 @@ class Products {
 	 * @return \WPGraphQL\Data\Connection\PostObjectConnectionResolver
 	 */
 	public static function set_ordering_query_args( $resolver, $args ) {
-		$backward = isset( $args['last'] ) ? true : false;
+		$backward = isset( $args['last'] );
 
 		if ( ! empty( $args['where']['orderby'] ) ) {
 			$default_fields = [

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -40,7 +40,7 @@ class WC_Terms extends TermObjects {
 		$wc_post_types      = WP_GraphQL_WooCommerce::get_post_types();
 
 		// Loop through the allowed_taxonomies to register appropriate connections.
-		foreach ( $allowed_taxonomies as $taxonomy => $tax_object ) {
+		foreach ( $allowed_taxonomies as $tax_object ) {
 			foreach ( $wc_post_types as $post_type ) {
 				if ( 'product' === $post_type ) {
 					continue;

--- a/includes/data/connection/class-cart-item-connection-resolver.php
+++ b/includes/data/connection/class-cart-item-connection-resolver.php
@@ -103,9 +103,7 @@ class Cart_Item_Connection_Resolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_ids_from_query() {
-		$ids = ! empty( $this->query ) ? $this->query : [];
-
-		return $ids;
+		return ! empty( $this->query ) ? $this->query : [];
 	}
 
 	/**

--- a/includes/data/connection/class-downloadable-item-connection-resolver.php
+++ b/includes/data/connection/class-downloadable-item-connection-resolver.php
@@ -140,9 +140,7 @@ class Downloadable_Item_Connection_Resolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_ids_from_query() {
-		$ids = ! empty( $this->query ) ? $this->query : [];
-
-		return $ids;
+		return ! empty( $this->query ) ? $this->query : [];
 	}
 
 	/**

--- a/includes/data/connection/class-order-item-connection-resolver.php
+++ b/includes/data/connection/class-order-item-connection-resolver.php
@@ -99,7 +99,7 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 		}//end switch
 
 		$items = [];
-		foreach ( $this->source->get_items( $type ) as $id => $item ) {
+		foreach ( $this->source->get_items( $type ) as $item ) {
 			$items[] = $item;
 		}
 

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -262,8 +262,7 @@ class Order_Mutation {
 				 * @param array  $item_keys  Order item keys.
 				 * @param string $type       Order item type slug.
 				 */
-				$item_keys = apply_filters( 'woographql_get_order_item_keys', [], $type );
-				return $item_keys;
+				return apply_filters( 'woographql_get_order_item_keys', [], $type );
 		}//end switch
 	}
 

--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -299,7 +299,7 @@ class Order extends Model {
 		}
 
 		// If customer ID matches current user, return true.
-		return absint( $customer_id ) === absint( $this->current_user->ID ) ? true : false;
+		return absint( $customer_id ) === absint( $this->current_user->ID );
 	}
 
 	/**
@@ -327,7 +327,7 @@ class Order extends Model {
 		}
 
 		// If customer email matches current user, return true.
-		return $customer_email === $session_customer->get_billing_email() ? true : false;
+		return $customer_email === $session_customer->get_billing_email();
 	}
 
 	/**
@@ -336,7 +336,7 @@ class Order extends Model {
 	 * @return bool
 	 */
 	public function is_private() {
-		return wc_is_order_status( 'wc-' . $this->data->get_status() ) ? false : true;
+		return ! wc_is_order_status( 'wc-' . $this->data->get_status() );
 	}
 
 	/**

--- a/includes/mutation/class-cart-add-fee.php
+++ b/includes/mutation/class-cart-add-fee.php
@@ -42,7 +42,7 @@ class Cart_Add_Fee {
 	 * @return array
 	 */
 	public static function get_input_fields() {
-		$input_fields = [
+		return [
 			'name'     => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => __( 'Unique name for the fee.', 'wp-graphql-woocommerce' ),
@@ -60,8 +60,6 @@ class Cart_Add_Fee {
 				'description' => __( 'The tax class for the fee if taxable.', 'wp-graphql-woocommerce' ),
 			],
 		];
-
-		return $input_fields;
 	}
 
 	/**

--- a/includes/mutation/class-cart-add-item.php
+++ b/includes/mutation/class-cart-add-item.php
@@ -76,9 +76,7 @@ class Cart_Add_Item {
 			'cartItem' => [
 				'type'    => 'CartItem',
 				'resolve' => static function ( $payload ) {
-					$item = \WC()->cart->get_cart_item( $payload['key'] );
-
-					return $item;
+					return \WC()->cart->get_cart_item( $payload['key'] );
 				},
 			],
 			'cart'     => Cart_Mutation::get_cart_field( true ),

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -44,7 +44,7 @@ class Order_Create {
 	 * @return array
 	 */
 	public static function get_input_fields() {
-		$input_fields = [
+		return [
 			'parentId'           => [
 				'type'        => 'Int',
 				'description' => __( 'Parent order ID.', 'wp-graphql-woocommerce' ),
@@ -110,8 +110,6 @@ class Order_Create {
 				'description' => __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'wp-graphql-woocommerce' ),
 			],
 		];
-
-		return $input_fields;
 	}
 
 	/**

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -150,8 +150,8 @@ class Order_Update {
 			// Actions for after the order is saved.
 			if ( true === $input['isPaid'] ) {
 				$order->payment_complete(
-					! empty( $input['transactionId'] ) ?
-						$input['transactionId']
+					! empty( $input['transactionId'] )
+						? $input['transactionId']
 						: ''
 				);
 			}

--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -237,13 +237,12 @@ class Customer_Type {
 					'description' => __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' ),
 					'resolve'     => static function( $source ) {
 						if ( get_current_user_id() === $source->ID ) {
-							$tokens = array_filter(
+							return array_filter(
 								array_values( \WC_Payment_Tokens::get_customer_tokens( $source->ID ) ),
 								static function ( $token ) {
 									return 'CC' === $token->get_type();
 								}
 							);
-							return $tokens;
 						}
 
 						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
@@ -254,13 +253,12 @@ class Customer_Type {
 					'description' => __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' ),
 					'resolve'     => static function( $source ) {
 						if ( get_current_user_id() === $source->ID ) {
-							$tokens = array_filter(
+							return array_filter(
 								array_values( \WC_Payment_Tokens::get_customer_tokens( $source->ID ) ),
 								static function ( $token ) {
 									return 'eCheck' === $token->get_type();
 								}
 							);
-							return $tokens;
 						}
 
 						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );

--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -85,7 +85,7 @@ class Meta_Data_Type {
 			],
 			'resolve'     => static function( $source, array $args ) {
 				// Set unique flag.
-				$single = ! empty( $args['multiple'] ) ? false : true;
+				$single = empty( $args['multiple'] );
 
 				// Check "key" argument and format meta_data objects.
 				if ( ! empty( $args['key'] ) && $source->meta_exists( $args['key'] ) ) {

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -586,9 +586,7 @@ class Root_Query {
 							throw new UserError( sprintf( __( 'No product exists with the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $product_id ) );
 						}
 
-						$product = Factory::resolve_crud_object( $product_id, $context );
-
-						return $product;
+						return Factory::resolve_crud_object( $product_id, $context );
 					},
 				]
 			);

--- a/includes/utils/class-transfer-session-handler.php
+++ b/includes/utils/class-transfer-session-handler.php
@@ -107,8 +107,6 @@ class Transfer_Session_Handler extends \WC_Session_Handler {
 			return $client_session_id;
 		}
 
-		$client_session_id = '';
-
-		return $client_session_id;
+		return '';
 	}
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR cleans up various useless variables and unnecessary ternaries from the codebase.

Branch is based off of https://github.com/wp-graphql/wp-graphql-woocommerce/pull/763, which should be merged first.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Several unused variables remain in the codebase, where its unclear at a glance if their lack of use is intentional or a bug. They will be picked up by [WPGraphQL Coding Standards](https://github.com/AxeWP/WPGraphQL-Coding-Standards) and can be evaluated/removed/refactored separately.


Where has this been tested?
---------------------------

- **WooGraphQL Version**: 0.14.1
- **WPGraphQL Version**: 1.14.6
- **WordPress Version**: 6.2.2
- **WooCommerce Version**: 7.8.2
