### PR TITLE
chore: use fully-qualified class names for PHPDoc types

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,10 +1,10 @@
 === WP GraphQL WooCommerce ===
 Contributors: kidunot89, ranaaterning, jasonbahl, saleebm
 Tags: GraphQL, WooCommerce, WPGraphQL
-Requires at least: 4.9
+Requires at least: 5.9
 Tested up to: 6.2
-Requires PHP: 7.1
-Requires WooCommerce: 4.8.0
+Requires PHP: 7.2
+Requires WooCommerce: 7.5.0
 Requires WPGraphQL: 1.14.0+
 Works with WPGraphQL-JWT-Authentication: 0.7.0+
 Stable tag: 0.14.1

--- a/access-functions.php
+++ b/access-functions.php
@@ -6,9 +6,6 @@
  * @since 0.0.1
  */
 
-use WPGraphQL\WooCommerce\Utils\QL_Session_Handler;
-use WPGraphQL\WooCommerce\Utils\Transfer_Session_Handler;
-
 if ( ! function_exists( 'wc_graphql_starts_with' ) ) {
 	/**
 	 * Checks if source string starts with the target string

--- a/access-functions.php
+++ b/access-functions.php
@@ -287,7 +287,7 @@ if ( ! function_exists( 'woographql_get_session_uid' ) ) :
 		/**
 		 * Session Handler
 		 *
-		 * @var QL_Session_Handler|Transfer_Session_Handler $session
+		 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler|\WPGraphQL\WooCommerce\Utils\Transfer_Session_Handler $session
 		 */
 		$session = WC()->session;
 		return $session->get_customer_id();
@@ -304,7 +304,7 @@ if ( ! function_exists( 'woographql_get_session_token' ) ) :
 		/**
 		 * Session Handler
 		 *
-		 * @var QL_Session_Handler|Transfer_Session_Handler $session
+		 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler|\WPGraphQL\WooCommerce\Utils\Transfer_Session_Handler $session
 		 */
 		$session = WC()->session;
 		return $session->get_client_session_id();

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2",
         "firebase/php-jwt": "^6.1.0"
     },
     "require-dev": {
         "automattic/vipwpcs": "^2.3",
-        "axepress/wp-graphql-stubs": "^1.14",
-        "php-stubs/woocommerce-stubs": "^7.7",
+        "axepress/wp-graphql-stubs": "1.14.0",
+        "php-stubs/woocommerce-stubs": "7.5.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb3dcd97101e5ff66f9f812e417aa977",
+    "content-hash": "1fe0d1a5418403ab97ed669378c504f9",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -125,16 +125,16 @@
         },
         {
             "name": "axepress/wp-graphql-stubs",
-            "version": "v1.14.4",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AxeWP/wp-graphql-stubs.git",
-                "reference": "1c5b0cb3ce978d1e88a828c158383877ba7c223a"
+                "reference": "1455a46043f758b77a49337c9520cb79c5a0a31f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/1c5b0cb3ce978d1e88a828c158383877ba7c223a",
-                "reference": "1c5b0cb3ce978d1e88a828c158383877ba7c223a",
+                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/1455a46043f758b77a49337c9520cb79c5a0a31f",
+                "reference": "1455a46043f758b77a49337c9520cb79c5a0a31f",
                 "shasum": ""
             },
             "require": {
@@ -165,7 +165,7 @@
             ],
             "support": {
                 "issues": "https://github.com/AxeWP/wp-graphql-stubs/issues",
-                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.14.4"
+                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.14.0"
             },
             "funding": [
                 {
@@ -173,7 +173,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-06-14T01:39:23+00:00"
+            "time": "2023-03-09T01:45:16+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -252,16 +252,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v7.8.0",
+            "version": "v7.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "1e9180bbac115884bf41bf1d2ee0f72338c0a566"
+                "reference": "9a735c3a66fb3eab4bdbb9e998db00b1fbd268d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/1e9180bbac115884bf41bf1d2ee0f72338c0a566",
-                "reference": "1e9180bbac115884bf41bf1d2ee0f72338c0a566",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/9a735c3a66fb3eab4bdbb9e998db00b1fbd268d7",
+                "reference": "9a735c3a66fb3eab4bdbb9e998db00b1fbd268d7",
                 "shasum": ""
             },
             "require": {
@@ -290,9 +290,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.8.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.5.0"
             },
-            "time": "2023-06-13T20:06:40+00:00"
+            "time": "2023-03-14T14:19:48+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -385,16 +385,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.21",
+            "version": "1.10.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5"
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
-                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578f4e70d117f9a90699324c555922800ac38d8c",
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c",
                 "shasum": ""
             },
             "require": {
@@ -443,7 +443,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-21T20:07:58+00:00"
+            "time": "2023-07-06T12:11:37+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -756,7 +756,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.0"
+        "php": ">=7.2"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -26,7 +26,7 @@ class Admin {
 	/**
 	 * Registers the WooGraphQL Settings tab.
 	 *
-	 * @param Settings $manager  Settings Manager.
+	 * @param \WPGraphQL\Admin\Settings\Settings $manager  Settings Manager.
 	 * @return void
 	 */
 	public function register_settings( Settings $manager ) {

--- a/includes/class-core-schema-filters.php
+++ b/includes/class-core-schema-filters.php
@@ -9,10 +9,10 @@
 namespace WPGraphQL\WooCommerce;
 
 use GraphQL\Error\UserError;
-use WPGraphQL\WooCommerce\Data\Loader\WC_Customer_Loader;
-use WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader;
-use WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader;
 use WPGraphQL\WooCommerce\Data\Factory;
+use WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader;
+use WPGraphQL\WooCommerce\Data\Loader\WC_Customer_Loader;
+use WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader;
 use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce as WooGraphQL;
 
 /**

--- a/includes/class-core-schema-filters.php
+++ b/includes/class-core-schema-filters.php
@@ -360,7 +360,7 @@ class Core_Schema_Filters {
 	 * @param \WPGraphQL\Type\WPObjectType|null $type   Type be resolve to.
 	 * @param mixed                             $value  Object for which the type is being resolve config.
 	 *
-	 * @throws UserError Invalid product type received.
+	 * @throws \GraphQL\Error\UserError Invalid product type received.
 	 *
 	 * @return \WPGraphQL\Type\WPObjectType|null
 	 */

--- a/includes/class-jwt-auth-schema-filters.php
+++ b/includes/class-jwt-auth-schema-filters.php
@@ -11,8 +11,6 @@ namespace WPGraphQL\WooCommerce;
 
 use GraphQL\Error\UserError;
 use WPGraphQL\WooCommerce\Model\Customer;
-use WPGraphQL\WooCommerce\Utils\QL_Session_Handler;
-use WPGraphQL\WooCommerce\Utils\Transfer_Session_Handler;
 
 /**
  * Class JWT_Auth_Schema_Filters

--- a/includes/class-jwt-auth-schema-filters.php
+++ b/includes/class-jwt-auth-schema-filters.php
@@ -142,7 +142,7 @@ class JWT_Auth_Schema_Filters {
 						/**
 						 * Session Handler.
 						 *
-						 * @var QL_Session_Handler $session
+						 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session
 						 */
 						$session = \WC()->session;
 

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -21,14 +21,14 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 		/**
 		 * Stores the instance of the WP_GraphQL_WooCommerce class
 		 *
-		 * @var null|WP_GraphQL_WooCommerce The one true WP_GraphQL_WooCommerce
+		 * @var null|\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce The one true WP_GraphQL_WooCommerce
 		 */
 		private static $instance = null;
 
 		/**
 		 * Returns a WP_GraphQL_WooCommerce Instance.
 		 *
-		 * @return WP_GraphQL_WooCommerce
+		 * @return \WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce
 		 */
 		public static function instance() {
 			if ( is_null( self::$instance ) ) {
@@ -40,7 +40,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 			/**
 			 * Fire off init action
 			 *
-			 * @param WP_GraphQL_WooCommerce $instance The instance of the WP_GraphQL_WooCommerce class
+			 * @param \WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce $instance The instance of the WP_GraphQL_WooCommerce class
 			 */
 			do_action( 'graphql_woocommerce_init', self::$instance );
 

--- a/includes/connection/class-coupons.php
+++ b/includes/connection/class-coupons.php
@@ -9,9 +9,6 @@
 
 namespace WPGraphQL\WooCommerce\Connection;
 
-use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 
 /**

--- a/includes/connection/class-coupons.php
+++ b/includes/connection/class-coupons.php
@@ -101,13 +101,13 @@ class Coupons {
 	 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 	 * from a GraphQL Query to the WP_Query
 	 *
-	 * @param array              $query_args The mapped query arguments.
-	 * @param array              $where_args       Query "where" args.
-	 * @param mixed              $source     The query results for a query calling this.
-	 * @param array              $args   All of the arguments for the query (not just the "where" args).
-	 * @param AppContext         $context    The AppContext object.
-	 * @param ResolveInfo        $info       The ResolveInfo object.
-	 * @param mixed|string|array $post_type  The post type for the query.
+	 * @param array                                $query_args The mapped query arguments.
+	 * @param array                                $where_args       Query "where" args.
+	 * @param mixed                                $source     The query results for a query calling this.
+	 * @param array                                $args   All of the arguments for the query (not just the "where" args).
+	 * @param \WPGraphQL\AppContext                $context    The AppContext object.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object.
+	 * @param mixed|string|array                   $post_type  The post type for the query.
 	 *
 	 * @return array Query arguments.
 	 */
@@ -141,8 +141,8 @@ class Coupons {
 		 * @param array       $where_args Query "where" args
 		 * @param mixed       $source     The query results for a query calling this
 		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext  $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
 		 */
 		$query_args = apply_filters(
 			'graphql_map_input_fields_to_coupon_query',

--- a/includes/connection/class-customers.php
+++ b/includes/connection/class-customers.php
@@ -126,12 +126,12 @@ class Customers {
 	 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 	 * from a GraphQL Query to the WP_Query
 	 *
-	 * @param array       $query_args  The mapped query arguments.
-	 * @param array       $where_args  Query "where" args.
-	 * @param mixed       $source      The query results for a query calling this.
-	 * @param array       $args        All of the arguments for the query (not just the "where" args).
-	 * @param AppContext  $context     The AppContext object.
-	 * @param ResolveInfo $info        The ResolveInfo object.
+	 * @param array                                $query_args  The mapped query arguments.
+	 * @param array                                $where_args  Query "where" args.
+	 * @param mixed                                $source      The query results for a query calling this.
+	 * @param array                                $args        All of the arguments for the query (not just the "where" args).
+	 * @param \WPGraphQL\AppContext                $context     The AppContext object.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info        The ResolveInfo object.
 	 *
 	 * @return array Query arguments.
 	 */
@@ -173,12 +173,12 @@ class Customers {
 		 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 		 * from a GraphQL Query to the WP_Query
 		 *
-		 * @param array       $args       The mapped query arguments
-		 * @param array       $where_args Query "where" args
-		 * @param mixed       $source     The query results for a query calling this
-		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param array                                $args       The mapped query arguments
+		 * @param array                                $where_args Query "where" args
+		 * @param mixed                                $source     The query results for a query calling this
+		 * @param array                                $all_args   All of the arguments for the query (not just the "where" args)
+		 * @param \WPGraphQL\AppContext                $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
 		 */
 		$query_args = apply_filters(
 			'graphql_map_input_fields_to_customer_query',
@@ -197,8 +197,8 @@ class Customers {
 	 * Temporary function until necessary functionality
 	 * has been added to the UserConnectionResolver
 	 *
-	 * @param array                      $connection  Resolved connection.
-	 * @param AbstractConnectionResolver $resolver  Resolver class.
+	 * @param array                                                 $connection  Resolved connection.
+	 * @param \WPGraphQL\Data\Connection\AbstractConnectionResolver $resolver  Resolver class.
 	 *
 	 * @return array
 	 */

--- a/includes/connection/class-customers.php
+++ b/includes/connection/class-customers.php
@@ -11,7 +11,6 @@ namespace WPGraphQL\WooCommerce\Connection;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\Data\Connection\UserConnectionResolver;
 use WPGraphQL\WooCommerce\Model\Customer;
 

--- a/includes/connection/class-orders.php
+++ b/includes/connection/class-orders.php
@@ -99,8 +99,8 @@ class Orders {
 	/**
 	 * Returns order connection filter by customer.
 	 *
-	 * @param Order_Connection_Resolver $resolver  Connection resolver.
-	 * @param \WC_Customer              $customer  Customer object of querying user.
+	 * @param \WPGraphQL\WooCommerce\Data\Connection\Order_Connection_Resolver $resolver  Connection resolver.
+	 * @param \WC_Customer                                                     $customer  Customer object of querying user.
 	 *
 	 * @return array
 	 */
@@ -129,8 +129,8 @@ class Orders {
 	/**
 	 * Returns refund connection filter by customer.
 	 *
-	 * @param Order_Connection_Resolver $resolver  Connection resolver.
-	 * @param \WC_Customer              $customer  Customer object of querying user.
+	 * @param \WPGraphQL\WooCommerce\Data\Connection\Order_Connection_Resolver $resolver  Connection resolver.
+	 * @param \WC_Customer                                                     $customer  Customer object of querying user.
 	 *
 	 * @return array
 	 */

--- a/includes/connection/class-orders.php
+++ b/includes/connection/class-orders.php
@@ -9,10 +9,8 @@
 
 namespace WPGraphQL\WooCommerce\Connection;
 
-use Automattic\WooCommerce\Utilities\OrderUtil;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\WooCommerce\Data\Connection\Order_Connection_Resolver;
 
 /**

--- a/includes/connection/class-posts.php
+++ b/includes/connection/class-posts.php
@@ -11,8 +11,8 @@ namespace WPGraphQL\WooCommerce\Connection;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Type\Connection\PostObjects;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
+use WPGraphQL\Type\Connection\PostObjects;
 
 /**
  * Class - Posts

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -11,8 +11,8 @@ namespace WPGraphQL\WooCommerce\Connection;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
+use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**
  * Class - Products

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -379,9 +379,9 @@ class Products {
 	/**
 	 * Bypass arg sanization in Post Object Connection Resolver.
 	 *
-	 * @param array                        $args                Sanitized GraphQL args passed to the resolver.
-	 * @param PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-	 * @param array                        $all_args            array of arguments input in the field as part of the GraphQL query.
+	 * @param array                                                   $args                Sanitized GraphQL args passed to the resolver.
+	 * @param \WPGraphQL\Data\Connection\PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
+	 * @param array                                                   $all_args            array of arguments input in the field as part of the GraphQL query.
 
 	 * @return array
 	 */
@@ -392,10 +392,10 @@ class Products {
 	/**
 	 * Undocumented function
 	 *
-	 * @param PostObjectConnectionResolver $resolver  Connection resolver instance.
-	 * @param array                        $args      Connection provided args.
+	 * @param \WPGraphQL\Data\Connection\PostObjectConnectionResolver $resolver  Connection resolver instance.
+	 * @param array                                                   $args      Connection provided args.
 	 *
-	 * @return PostObjectConnectionResolver
+	 * @return \WPGraphQL\Data\Connection\PostObjectConnectionResolver
 	 */
 	public static function set_ordering_query_args( $resolver, $args ) {
 		$backward = isset( $args['last'] ) ? true : false;
@@ -578,13 +578,13 @@ class Products {
 	 * This allows plugins/themes to hook in and alter what $args should be allowed to be passed
 	 * from a GraphQL Query to the WP_Query
 	 *
-	 * @param array              $query_args The mapped query arguments.
-	 * @param array              $args       Query "where" args.
-	 * @param mixed              $source     The query results for a query calling this.
-	 * @param array              $all_args   All of the arguments for the query (not just the "where" args).
-	 * @param AppContext         $context    The AppContext object.
-	 * @param ResolveInfo        $info       The ResolveInfo object.
-	 * @param mixed|string|array $post_type  The post type for the query.
+	 * @param array                                $query_args The mapped query arguments.
+	 * @param array                                $args       Query "where" args.
+	 * @param mixed                                $source     The query results for a query calling this.
+	 * @param array                                $all_args   All of the arguments for the query (not just the "where" args).
+	 * @param \WPGraphQL\AppContext                $context    The AppContext object.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object.
+	 * @param mixed|string|array                   $post_type  The post type for the query.
 	 *
 	 * @return array Query arguments.
 	 */
@@ -882,8 +882,8 @@ class Products {
 		 * @param array       $where_args Query "where" args
 		 * @param mixed       $source     The query results for a query calling this
 		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext  $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
 		 * @param mixed|string|array      $post_type  The post type for the query
 		 */
 		$query_args = apply_filters_deprecated(

--- a/includes/connection/class-variation-attributes.php
+++ b/includes/connection/class-variation-attributes.php
@@ -12,8 +12,8 @@ namespace WPGraphQL\WooCommerce\Connection;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 use WPGraphQL\WooCommerce\Data\Connection\Variation_Attribute_Connection_Resolver;
+use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**
  * Class Product_Attributes

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -10,13 +10,12 @@
 
 namespace WPGraphQL\WooCommerce\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Error\UserError;
-use WPGraphQL\AppContext;
-use WPGraphQL\Type\Connection\TermObjects;
-use WPGraphQL\Data\DataSource;
-use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
+use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
+use WPGraphQL\Type\Connection\TermObjects;
 use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**

--- a/includes/data/class-db-hooks.php
+++ b/includes/data/class-db-hooks.php
@@ -8,7 +8,6 @@
 
 namespace WPGraphQL\WooCommerce\Data;
 
-use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 
 /**

--- a/includes/data/class-factory.php
+++ b/includes/data/class-factory.php
@@ -32,7 +32,7 @@ class Factory {
 	/**
 	 * Returns the current woocommerce customer object tied to the current session.
 	 *
-	 * @return Customer
+	 * @return \WPGraphQL\WooCommerce\Model\Customer
 	 * @access public
 	 */
 	public static function resolve_session_customer() {
@@ -42,10 +42,10 @@ class Factory {
 	/**
 	 * Returns the Customer store object for the provided user ID
 	 *
-	 * @param int        $id      - user ID of the customer being retrieved.
-	 * @param AppContext $context - AppContext object.
+	 * @param int                   $id      - user ID of the customer being retrieved.
+	 * @param \WPGraphQL\AppContext $context - AppContext object.
 	 *
-	 * @return null|Deferred object
+	 * @return null|\GraphQL\Deferred object
 	 * @access public
 	 */
 	public static function resolve_customer( $id, AppContext $context ) {
@@ -59,10 +59,10 @@ class Factory {
 	/**
 	 * Returns the WooCommerce CRUD object for the post ID
 	 *
-	 * @param int        $id      - post ID of the crud object being retrieved.
-	 * @param AppContext $context - AppContext object.
+	 * @param int                   $id      - post ID of the crud object being retrieved.
+	 * @param \WPGraphQL\AppContext $context - AppContext object.
 	 *
-	 * @return null|Deferred object
+	 * @return null|\GraphQL\Deferred object
 	 * @access public
 	 */
 	public static function resolve_crud_object( $id, AppContext $context ) {
@@ -78,9 +78,9 @@ class Factory {
 	 *
 	 * @param \WC_Order_Item $item - order item crud object instance.
 	 *
-	 * @return Order_Item
+	 * @return \WPGraphQL\WooCommerce\Model\Order_Item
 	 * @access public
-	 * @throws UserError Invalid object.
+	 * @throws \GraphQL\Error\UserError Invalid object.
 	 */
 	public static function resolve_order_item( $item ) {
 		/**
@@ -96,10 +96,10 @@ class Factory {
 	/**
 	 * Returns the tax rate Model for the tax rate ID.
 	 *
-	 * @param int        $id - Tax rate ID.
-	 * @param AppContext $context - AppContext object.
+	 * @param int                   $id - Tax rate ID.
+	 * @param \WPGraphQL\AppContext $context - AppContext object.
 	 *
-	 * @return null|Deferred object
+	 * @return null|\GraphQL\Deferred object
 	 */
 	public static function resolve_tax_rate( $id, AppContext $context ) {
 		if ( 0 === absint( $id ) ) {
@@ -114,9 +114,9 @@ class Factory {
 	 *
 	 * @param int $id - Shipping method ID.
 	 *
-	 * @return Shipping_Method
+	 * @return \WPGraphQL\WooCommerce\Model\Shipping_Method
 	 * @access public
-	 * @throws UserError Invalid object.
+	 * @throws \GraphQL\Error\UserError Invalid object.
 	 */
 	public static function resolve_shipping_method( $id ) {
 		$wc_shipping = \WC_Shipping::instance();
@@ -145,10 +145,10 @@ class Factory {
 	/**
 	 * Resolves a cart item by key.
 	 *
-	 * @param string     $key      Cart item key.
-	 * @param AppContext $context  AppContext object.
+	 * @param string                $key      Cart item key.
+	 * @param \WPGraphQL\AppContext $context  AppContext object.
 	 *
-	 * @return null|Deferred object
+	 * @return null|\GraphQL\Deferred object
 	 */
 	public static function resolve_cart_item( $key, AppContext $context ) {
 		if ( empty( $key ) ) {
@@ -161,10 +161,10 @@ class Factory {
 	/**
 	 * Resolves a downloadable item by ID.
 	 *
-	 * @param int        $id       Downloadable item ID.
-	 * @param AppContext $context  AppContext object.
+	 * @param int                   $id       Downloadable item ID.
+	 * @param \WPGraphQL\AppContext $context  AppContext object.
 	 *
-	 * @return null|Deferred object
+	 * @return null|\GraphQL\Deferred object
 	 */
 	public static function resolve_downloadable_item( $id, AppContext $context ) {
 		if ( 0 === absint( $id ) ) {
@@ -177,10 +177,10 @@ class Factory {
 	/**
 	 * Resolves Relay node for some WooGraphQL types.
 	 *
-	 * @param mixed      $node     Node object.
-	 * @param int        $id       Object unique ID.
-	 * @param string     $type     Node type.
-	 * @param AppContext $context  AppContext instance.
+	 * @param mixed                 $node     Node object.
+	 * @param int                   $id       Object unique ID.
+	 * @param string                $type     Node type.
+	 * @param \WPGraphQL\AppContext $context  AppContext instance.
 	 *
 	 * @return mixed
 	 */

--- a/includes/data/class-factory.php
+++ b/includes/data/class-factory.php
@@ -10,20 +10,17 @@
 
 namespace WPGraphQL\WooCommerce\Data;
 
-use GraphQL\Deferred;
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use function WC;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Model\Coupon;
+use WPGraphQL\WooCommerce\Model\Customer;
 use WPGraphQL\WooCommerce\Model\Order;
-use WPGraphQL\WooCommerce\Model\Refund;
 use WPGraphQL\WooCommerce\Model\Order_Item;
 use WPGraphQL\WooCommerce\Model\Product;
 use WPGraphQL\WooCommerce\Model\Product_Variation;
-use WPGraphQL\WooCommerce\Model\Customer;
-use WPGraphQL\WooCommerce\Model\Tax_Rate;
 use WPGraphQL\WooCommerce\Model\Shipping_Method;
+use WPGraphQL\WooCommerce\Model\Tax_Rate;
+use function WC;
 
 /**
  * Class Factory

--- a/includes/data/connection/class-cart-item-connection-resolver.php
+++ b/includes/data/connection/class-cart-item-connection-resolver.php
@@ -10,13 +10,7 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use GraphQLRelay\Connection\ArrayConnection;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
-use WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader;
-use WPGraphQL\WooCommerce\Data\Factory;
 
 /**
  * Class Cart_Item_Connection_Resolver

--- a/includes/data/connection/class-cart-item-connection-resolver.php
+++ b/includes/data/connection/class-cart-item-connection-resolver.php
@@ -21,7 +21,7 @@ use WPGraphQL\WooCommerce\Data\Factory;
 /**
  * Class Cart_Item_Connection_Resolver
  *
- * @property WC_Db_Loader $loader
+ * @property \WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader $loader
  *
  * @package WPGraphQL\WooCommerce\Data\Connection
  */
@@ -74,8 +74,8 @@ class Cart_Item_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query.
 		 * @param mixed       $source     The source that's passed down the GraphQL queries.
 		 * @param array       $args       The inputArgs on the field.
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree.
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
+		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
 		 */
 		$query_args = apply_filters( 'graphql_cart_item_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 

--- a/includes/data/connection/class-coupon-connection-resolver.php
+++ b/includes/data/connection/class-coupon-connection-resolver.php
@@ -11,12 +11,7 @@
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
 use GraphQL\Error\InvariantViolation;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
-use WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader;
-use WPGraphQL\WooCommerce\Model\Order;
-use WPGraphQL\WooCommerce\Model\Coupon;
 
 /**
  * Class Coupon_Connection_Resolver

--- a/includes/data/connection/class-coupon-connection-resolver.php
+++ b/includes/data/connection/class-coupon-connection-resolver.php
@@ -23,7 +23,7 @@ use WPGraphQL\WooCommerce\Model\Coupon;
  *
  * @deprecated v0.10.0
  *
- * @property WC_CPT_Loader $loader
+ * @property \WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader $loader
  *
  * @package WPGraphQL\WooCommerce\Data\Connection
  */
@@ -43,10 +43,10 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 	/**
 	 * Refund_Connection_Resolver constructor.
 	 *
-	 * @param mixed       $source    The object passed down from the previous level in the Resolve tree.
-	 * @param array       $args      The input arguments for the query.
-	 * @param AppContext  $context   The context of the request.
-	 * @param ResolveInfo $info      The resolve info passed down the Resolve tree.
+	 * @param mixed                                $source    The object passed down from the previous level in the Resolve tree.
+	 * @param array                                $args      The input arguments for the query.
+	 * @param \WPGraphQL\AppContext                $context   The context of the request.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info      The resolve info passed down the Resolve tree.
 	 */
 	public function __construct( $source, $args, $context, $info ) {
 		/**
@@ -73,7 +73,7 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 	 *
 	 * @param integer $id Node ID.
 	 *
-	 * @return mixed|Coupon|null
+	 * @return mixed|\WPGraphQL\WooCommerce\Model\Coupon|null
 	 */
 	public function get_node_by_id( $id ) {
 		return $this->get_cpt_model_by_id( $id );
@@ -164,8 +164,8 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query
 		 * @param mixed       $source     The source that's passed down the GraphQL queries
 		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
 		 */
 		$query_args = apply_filters( 'graphql_coupon_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 
@@ -175,7 +175,7 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 	/**
 	 * Executes query
 	 *
-	 * @throws InvariantViolation Filtering suppressed.
+	 * @throws \GraphQL\Error\InvariantViolation Filtering suppressed.
 	 *
 	 * @return \WP_Query
 	 */
@@ -237,8 +237,8 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $where_args Query "where" args
 		 * @param mixed       $source     The query results for a query calling this
 		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext  $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
 		 * @param mixed|string|array      $post_type  The post type for the query
 		 */
 		$args = apply_filters(

--- a/includes/data/connection/class-customer-connection-resolver.php
+++ b/includes/data/connection/class-customer-connection-resolver.php
@@ -10,7 +10,6 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\WooCommerce\Model\Coupon;
 

--- a/includes/data/connection/class-downloadable-item-connection-resolver.php
+++ b/includes/data/connection/class-downloadable-item-connection-resolver.php
@@ -22,7 +22,7 @@ use WPGraphQL\WooCommerce\Model\Customer;
 /**
  * Class Downloadable_Item_Connection_Resolver
  *
- * @property WC_Db_Loader $loader
+ * @property \WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader $loader
  *
  * @package WPGraphQL\WooCommerce\Data\Connection
  */
@@ -101,8 +101,8 @@ class Downloadable_Item_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query.
 		 * @param mixed       $source     The source that's passed down the GraphQL queries.
 		 * @param array       $args       The inputArgs on the field.
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree.
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
+		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
 		 */
 		$query_args = apply_filters( 'graphql_downloadable_item_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 

--- a/includes/data/connection/class-downloadable-item-connection-resolver.php
+++ b/includes/data/connection/class-downloadable-item-connection-resolver.php
@@ -10,13 +10,7 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use GraphQLRelay\Connection\ArrayConnection;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
-use WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader;
-use WPGraphQL\WooCommerce\Data\Factory;
 use WPGraphQL\WooCommerce\Model\Customer;
 
 /**

--- a/includes/data/connection/class-order-connection-resolver.php
+++ b/includes/data/connection/class-order-connection-resolver.php
@@ -44,11 +44,11 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 	/**
 	 * Refund_Connection_Resolver constructor.
 	 *
-	 * @param mixed       $source    The object passed down from the previous level in the Resolve tree.
-	 * @param array       $args      The input arguments for the query.
-	 * @param AppContext  $context   The context of the request.
-	 * @param ResolveInfo $info      The resolve info passed down the Resolve tree.
-	 * @param string      $post_type The post type for the connection resolver.
+	 * @param mixed                                $source    The object passed down from the previous level in the Resolve tree.
+	 * @param array                                $args      The input arguments for the query.
+	 * @param \WPGraphQL\AppContext                $context   The context of the request.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info      The resolve info passed down the Resolve tree.
+	 * @param string                               $post_type The post type for the connection resolver.
 	 */
 	public function __construct( $source, $args, $context, $info, $post_type = 'shop_order' ) {
 		/**
@@ -81,7 +81,7 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 	 *
 	 * @param integer $id  Node ID.
 	 *
-	 * @return mixed|Order|null
+	 * @return mixed|\WPGraphQL\WooCommerce\Model\Order|null
 	 */
 	public function get_node_by_id( $id ) {
 		return $this->get_cpt_model_by_id( $id );
@@ -190,8 +190,8 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query
 		 * @param mixed       $source     The source that's passed down the GraphQL queries
 		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
 		 */
 		$query_args = apply_filters( 'graphql_order_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 
@@ -201,7 +201,7 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 	/**
 	 * Executes query
 	 *
-	 * @throws InvariantViolation  Filter currently not supported for WC_Order_Query.
+	 * @throws \GraphQL\Error\InvariantViolation  Filter currently not supported for WC_Order_Query.
 	 *
 	 * @return \WC_Order_Query
 	 */
@@ -325,8 +325,8 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $where_args Query "where" args
 		 * @param mixed       $source     The query results for a query calling this
 		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext  $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
 		 * @param mixed|string|array      $post_type  The post type for the query
 		 */
 		$args = apply_filters(

--- a/includes/data/connection/class-order-connection-resolver.php
+++ b/includes/data/connection/class-order-connection-resolver.php
@@ -11,12 +11,7 @@
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
 use GraphQL\Error\InvariantViolation;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
-use WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader;
-use WPGraphQL\WooCommerce\Model\Customer;
-use WPGraphQL\WooCommerce\Model\Order;
 
 /**
  * Class Order_Connection_Resolver

--- a/includes/data/connection/class-order-item-connection-resolver.php
+++ b/includes/data/connection/class-order-item-connection-resolver.php
@@ -10,13 +10,7 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use GraphQLRelay\Connection\ArrayConnection;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
-use WPGraphQL\WooCommerce\Data\Factory;
-use WPGraphQL\WooCommerce\Model\Customer;
 
 /**
  * Class Order_Item_Connection_Resolver

--- a/includes/data/connection/class-order-item-connection-resolver.php
+++ b/includes/data/connection/class-order-item-connection-resolver.php
@@ -55,8 +55,8 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query.
 		 * @param mixed       $source     The source that's passed down the GraphQL queries.
 		 * @param array       $args       The inputArgs on the field.
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree.
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
+		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
 		 */
 		$query_args = apply_filters( 'graphql_order_item_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 
@@ -90,8 +90,8 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 				 * @param string      $item_type  Order item type.
 				 * @param mixed       $source     The source that's passed down the GraphQL queries.
 				 * @param array       $args       The inputArgs on the field.
-				 * @param AppContext  $context    The AppContext passed down the GraphQL tree.
-				 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
+				 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree.
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
 				 */
 				$type = apply_filters(
 					'graphql_order_item_connection_item_type',

--- a/includes/data/connection/class-payment-gateway-connection-resolver.php
+++ b/includes/data/connection/class-payment-gateway-connection-resolver.php
@@ -22,12 +22,12 @@ class Payment_Gateway_Connection_Resolver {
 	/**
 	 * Creates connection
 	 *
-	 * @param mixed       $source     - Connection source Model instance.
-	 * @param array       $args       - Connection arguments.
-	 * @param AppContext  $context    - AppContext object.
-	 * @param ResolveInfo $info       - ResolveInfo object.
+	 * @param mixed                                $source     - Connection source Model instance.
+	 * @param array                                $args       - Connection arguments.
+	 * @param \WPGraphQL\AppContext                $context    - AppContext object.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info       - ResolveInfo object.
 	 *
-	 * @throws UserError User not authorized.
+	 * @throws \GraphQL\Error\UserError User not authorized.
 	 * @return array|null
 	 */
 	public function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {

--- a/includes/data/connection/class-product-attribute-connection-resolver.php
+++ b/includes/data/connection/class-product-attribute-connection-resolver.php
@@ -25,14 +25,14 @@ class Product_Attribute_Connection_Resolver {
 	/**
 	 * Builds Product attribute items
 	 *
-	 * @param array       $attributes  Array of WC_Product_Attributes instances.
-	 * @param Product     $source      Parent product model.
-	 * @param array       $args        Connection arguments.
-	 * @param AppContext  $context     AppContext object.
-	 * @param ResolveInfo $info        ResolveInfo object.
-	 * @param string      $type     Attribute type.
+	 * @param array                                $attributes  Array of WC_Product_Attributes instances.
+	 * @param \WPGraphQL\WooCommerce\Model\Product $source      Parent product model.
+	 * @param array                                $args        Connection arguments.
+	 * @param \WPGraphQL\AppContext                $context     AppContext object.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info        ResolveInfo object.
+	 * @param string                               $type     Attribute type.
 	 *
-	 * @throws UserError  Invalid product attribute enumeration value.
+	 * @throws \GraphQL\Error\UserError  Invalid product attribute enumeration value.
 	 * @return array
 	 */
 	private function get_items( $attributes, $source, $args, $context, $info, $type = null ) {
@@ -80,11 +80,11 @@ class Product_Attribute_Connection_Resolver {
 	/**
 	 * Creates connection
 	 *
-	 * @param mixed       $source   Connection source Model instance.
-	 * @param array       $args     Connection arguments.
-	 * @param AppContext  $context  AppContext object.
-	 * @param ResolveInfo $info     ResolveInfo object.
-	 * @param string      $type     Attribute type.
+	 * @param mixed                                $source   Connection source Model instance.
+	 * @param array                                $args     Connection arguments.
+	 * @param \WPGraphQL\AppContext                $context  AppContext object.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     ResolveInfo object.
+	 * @param string                               $type     Attribute type.
 	 *
 	 * @return array|null
 	 */

--- a/includes/data/connection/class-product-attribute-connection-resolver.php
+++ b/includes/data/connection/class-product-attribute-connection-resolver.php
@@ -14,7 +14,6 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Model\Product;
 
 const GLOBAL_ID_DELIMITER = ':';
 

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -27,7 +27,7 @@ use WPGraphQL\WooCommerce\Model\Product_Variation;
  *
  * @deprecated v0.10.0
  *
- * @property WC_CPT_Loader $loader
+ * @property \WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader $loader
  */
 class Product_Connection_Resolver extends AbstractConnectionResolver {
 	/**
@@ -57,10 +57,10 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	/**
 	 * Refund_Connection_Resolver constructor.
 	 *
-	 * @param mixed       $source    The object passed down from the previous level in the Resolve tree.
-	 * @param array       $args      The input arguments for the query.
-	 * @param AppContext  $context   The context of the request.
-	 * @param ResolveInfo $info      The resolve info passed down the Resolve tree.
+	 * @param mixed                                $source    The object passed down from the previous level in the Resolve tree.
+	 * @param array                                $args      The input arguments for the query.
+	 * @param \WPGraphQL\AppContext                $context   The context of the request.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info      The resolve info passed down the Resolve tree.
 	 */
 	public function __construct( $source, $args, $context, $info ) {
 		// @codingStandardsIgnoreLine.
@@ -88,7 +88,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 *
 	 * @param integer $id  Node ID.
 	 *
-	 * @return Product|Product_Variation|null
+	 * @return \WPGraphQL\WooCommerce\Model\Product|\WPGraphQL\WooCommerce\Model\Product_Variation|null
 	 */
 	public function get_node_by_id( $id ) {
 		$post = get_post( $id );
@@ -183,8 +183,8 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			 * @param array       $query_args          The args that will be passed to the WP_Query.
 			 * @param mixed       $source              The source that's passed down the GraphQL queries.
 			 * @param array       $args                The inputArgs on the field.
-			 * @param AppContext  $context             The AppContext passed down the GraphQL tree.
-			 * @param ResolveInfo $info                The ResolveInfo passed down the GraphQL tree.
+			 * @param \WPGraphQL\AppContext  $context             The AppContext passed down the GraphQL tree.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info                The ResolveInfo passed down the GraphQL tree.
 			 */
 			$catalog_visibility = apply_filters(
 				'graphql_product_connection_catalog_visibility',
@@ -223,8 +223,8 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query.
 		 * @param mixed       $source     The source that's passed down the GraphQL queries.
 		 * @param array       $args       The inputArgs on the field.
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree.
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
+		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
 		 */
 		$query_args = apply_filters( 'graphql_product_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 
@@ -236,7 +236,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 *
 	 * @return \WP_Query
 	 *
-	 * @throws InvariantViolation  Filter currently not supported for WP_Query.
+	 * @throws \GraphQL\Error\InvariantViolation  Filter currently not supported for WP_Query.
 	 */
 	public function get_query() {
 		$query = new \WP_Query( $this->query_args );
@@ -557,8 +557,8 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $where_args Query "where" args
 		 * @param mixed       $source     The query results for a query calling this
 		 * @param array       $all_args   All of the arguments for the query (not just the "where" args)
-		 * @param AppContext  $context    The AppContext object
-		 * @param ResolveInfo $info       The ResolveInfo object
+		 * @param \WPGraphQL\AppContext  $context    The AppContext object
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
 		 * @param mixed|string|array      $post_type  The post type for the query
 		 */
 		$args = apply_filters(

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -12,15 +12,9 @@ namespace WPGraphQL\WooCommerce\Data\Connection;
 
 use GraphQL\Error\InvariantViolation;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\Model\Term;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
-use WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader;
-use WPGraphQL\WooCommerce\Model\Coupon;
-use WPGraphQL\WooCommerce\Model\Customer;
 use WPGraphQL\WooCommerce\Model\Product;
 use WPGraphQL\WooCommerce\Model\Product_Variation;
+use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**
  * Class Product_Connection_Resolver

--- a/includes/data/connection/class-shipping-method-connection-resolver.php
+++ b/includes/data/connection/class-shipping-method-connection-resolver.php
@@ -10,9 +10,6 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
-use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 
 /**

--- a/includes/data/connection/class-tax-rate-connection-resolver.php
+++ b/includes/data/connection/class-tax-rate-connection-resolver.php
@@ -20,7 +20,7 @@ use WPGraphQL\WooCommerce\Model\Tax_Rate;
 /**
  * Class Tax_Rate_Connection_Resolver
  *
- * @property WC_Db_Loader $loader
+ * @property \WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader $loader
  *
  * @package WPGraphQL\WooCommerce\Data\Connection
  */
@@ -96,8 +96,8 @@ class Tax_Rate_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query
 		 * @param mixed       $source     The source that's passed down the GraphQL queries
 		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
 		 */
 		$query_args = apply_filters( 'graphql_tax_rate_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 

--- a/includes/data/connection/class-tax-rate-connection-resolver.php
+++ b/includes/data/connection/class-tax-rate-connection-resolver.php
@@ -11,11 +11,6 @@
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Factory;
-use WPGraphQL\WooCommerce\Data\Loader\WC_Db_Loader;
-use WPGraphQL\WooCommerce\Model\Tax_Rate;
 
 /**
  * Class Tax_Rate_Connection_Resolver

--- a/includes/data/connection/class-variation-attribute-connection-resolver.php
+++ b/includes/data/connection/class-variation-attribute-connection-resolver.php
@@ -113,10 +113,10 @@ class Variation_Attribute_Connection_Resolver {
 	/**
 	 * Creates connection
 	 *
-	 * @param mixed       $source     - Connection source Model instance.
-	 * @param array       $args       - Connection arguments.
-	 * @param AppContext  $context    - AppContext object.
-	 * @param ResolveInfo $info       - ResolveInfo object.
+	 * @param mixed                                $source     - Connection source Model instance.
+	 * @param array                                $args       - Connection arguments.
+	 * @param \WPGraphQL\AppContext                $context    - AppContext object.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info       - ResolveInfo object.
 	 *
 	 * @return array|null
 	 */

--- a/includes/data/connection/trait-wc-cpt-loader-common.php
+++ b/includes/data/connection/trait-wc-cpt-loader-common.php
@@ -8,8 +8,6 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
-use WPGraphQL\WooCommerce\Data\Factory;
-
 /**
  * Trait WC_CPT_Loader_Common
  *

--- a/includes/data/connection/trait-wc-db-loader-common.php
+++ b/includes/data/connection/trait-wc-db-loader-common.php
@@ -8,8 +8,6 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
-use WPGraphQL\WooCommerce\Data\Factory;
-
 /**
  * Trait WC_Db_Loader_Common
  */

--- a/includes/data/cursor/class-cot-cursor.php
+++ b/includes/data/cursor/class-cot-cursor.php
@@ -37,7 +37,7 @@ class COT_Cursor extends AbstractCursor {
 	/**
 	 * The query instance to use when building the SQL statement.
 	 *
-	 * @var OrdersTableQuery
+	 * @var \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery
 	 */
 	public $query;
 
@@ -58,16 +58,16 @@ class COT_Cursor extends AbstractCursor {
 	/**
 	 * Meta query parser.
 	 *
-	 * @var OrdersTableMetaQuery|null
+	 * @var \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableMetaQuery|null
 	 */
 	private $meta_query;
 
 	/**
 	 * COT_Cursor constructor.
 	 *
-	 * @param array            $query_vars  The query vars to use when building the SQL statement.
-	 * @param OrdersTableQuery $query       The query to use when building the SQL statement.
-	 * @param string|null      $cursor      Whether to generate the before or after cursor. Default "after".
+	 * @param array                                                               $query_vars  The query vars to use when building the SQL statement.
+	 * @param \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery $query       The query to use when building the SQL statement.
+	 * @param string|null                                                         $cursor      Whether to generate the before or after cursor. Default "after".
 	 */
 	public function __construct( $query_vars, $query, $cursor = 'after' ) {
 

--- a/includes/data/cursor/class-cot-cursor.php
+++ b/includes/data/cursor/class-cot-cursor.php
@@ -11,10 +11,9 @@
 
 namespace WPGraphQL\WooCommerce\Data\Cursor;
 
-use WPGraphQL\Data\Cursor\AbstractCursor;
-use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
-use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableMetaQuery;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableMetaQuery;
+use WPGraphQL\Data\Cursor\AbstractCursor;
 
 /**
  * Class COT_Cursor

--- a/includes/data/loader/class-wc-cpt-loader.php
+++ b/includes/data/loader/class-wc-cpt-loader.php
@@ -14,13 +14,11 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 use GraphQL\Deferred;
 use GraphQL\Error\UserError;
 use WPGraphQL\Data\Loader\AbstractDataLoader;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
-use WPGraphQL\WooCommerce\Data\Factory;
 use WPGraphQL\WooCommerce\Model\Coupon;
+use WPGraphQL\WooCommerce\Model\Order;
 use WPGraphQL\WooCommerce\Model\Product;
 use WPGraphQL\WooCommerce\Model\Product_Variation;
-use WPGraphQL\WooCommerce\Model\Order;
-use WPGraphQL\WooCommerce\Model\Refund;
+use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**
  * Class WC_CPT_Loader

--- a/includes/data/loader/class-wc-cpt-loader.php
+++ b/includes/data/loader/class-wc-cpt-loader.php
@@ -41,7 +41,7 @@ class WC_CPT_Loader extends AbstractDataLoader {
 	 * @param boolean $fatal      Throw if no model found.
 	 *
 	 * @return mixed
-	 * @throws UserError - throws if no corresponding Model is registered to the post-type.
+	 * @throws \GraphQL\Error\UserError - throws if no corresponding Model is registered to the post-type.
 	 */
 	public static function resolve_model( $post_type, $id, $fatal = true ) {
 		switch ( $post_type ) {
@@ -78,7 +78,7 @@ class WC_CPT_Loader extends AbstractDataLoader {
 	 * @param array $keys - array of IDs.
 	 *
 	 * @return array
-	 * @throws UserError - throws if no corresponding Data store exists with the ID.
+	 * @throws \GraphQL\Error\UserError - throws if no corresponding Data store exists with the ID.
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/includes/data/loader/class-wc-db-loader.php
+++ b/includes/data/loader/class-wc-db-loader.php
@@ -10,9 +10,7 @@
 
 namespace WPGraphQL\WooCommerce\Data\Loader;
 
-use GraphQL\Deferred;
 use GraphQL\Error\UserError;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Loader\AbstractDataLoader;
 use WPGraphQL\WooCommerce\Data\Factory;
 use WPGraphQL\WooCommerce\Model\Shipping_Method;

--- a/includes/data/loader/class-wc-db-loader.php
+++ b/includes/data/loader/class-wc-db-loader.php
@@ -39,8 +39,8 @@ class WC_Db_Loader extends AbstractDataLoader {
 	/**
 	 * WC_Db_Loader constructor
 	 *
-	 * @param AppContext $context      AppContext instance.
-	 * @param string     $loader_type  Type of loader be initialized.
+	 * @param \WPGraphQL\AppContext $context      AppContext instance.
+	 * @param string                $loader_type  Type of loader be initialized.
 	 */
 	public function __construct( $context, $loader_type ) {
 		$this->loader_type = $loader_type;
@@ -132,7 +132,7 @@ class WC_Db_Loader extends AbstractDataLoader {
 	 *
 	 * @param int $id - Tax rate IDs.
 	 *
-	 * @return Tax_Rate|null
+	 * @return \WPGraphQL\WooCommerce\Model\Tax_Rate|null
 	 */
 	public function load_tax_rate_from_id( $id ) {
 		global $wpdb;
@@ -185,9 +185,9 @@ class WC_Db_Loader extends AbstractDataLoader {
 	 *
 	 * @param int $id - Shipping method ID.
 	 *
-	 * @return Shipping_Method
+	 * @return \WPGraphQL\WooCommerce\Model\Shipping_Method
 	 * @access public
-	 * @throws UserError Invalid object.
+	 * @throws \GraphQL\Error\UserError Invalid object.
 	 */
 	public function load_shipping_method_from_id( $id ) {
 		$wc_shipping = \WC_Shipping::instance();

--- a/includes/data/mutation/class-cart-mutation.php
+++ b/includes/data/mutation/class-cart-mutation.php
@@ -9,8 +9,6 @@
 namespace WPGraphQL\WooCommerce\Data\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Factory;
 
 /**

--- a/includes/data/mutation/class-cart-mutation.php
+++ b/includes/data/mutation/class-cart-mutation.php
@@ -40,11 +40,11 @@ class Cart_Mutation {
 	/**
 	 * Returns a cart item.
 	 *
-	 * @param array       $input   Input data describing cart item.
-	 * @param AppContext  $context AppContext instance.
-	 * @param ResolveInfo $info    Query info.
+	 * @param array                                $input   Input data describing cart item.
+	 * @param \WPGraphQL\AppContext                $context AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info    Query info.
 	 *
-	 * @throws UserError Missing/Invalid input.
+	 * @throws \GraphQL\Error\UserError Missing/Invalid input.
 	 *
 	 * @return array
 	 */
@@ -76,7 +76,7 @@ class Cart_Mutation {
 	 *
 	 * @return array
 	 *
-	 * @throws UserError  Invalid cart attribute provided.
+	 * @throws \GraphQL\Error\UserError  Invalid cart attribute provided.
 	 */
 	private static function prepare_attributes( $product_id, array $variation_data = [] ) {
 		$product = wc_get_product( $product_id );
@@ -122,13 +122,13 @@ class Cart_Mutation {
 	/**
 	 * Returns an array of cart items.
 	 *
-	 * @param array       $input    Input data describing cart items.
-	 * @param AppContext  $context  AppContext instance.
-	 * @param ResolveInfo $info     Query info.
-	 * @param string      $mutation Mutation type.
+	 * @param array                                $input    Input data describing cart items.
+	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     Query info.
+	 * @param string                               $mutation Mutation type.
 	 *
 	 * @return array
-	 * @throws UserError Cart item not found message.
+	 * @throws \GraphQL\Error\UserError Cart item not found message.
 	 */
 	public static function retrieve_cart_items( $input, $context, $info, $mutation = '' ) {
 		$items = null;
@@ -157,9 +157,9 @@ class Cart_Mutation {
 	/**
 	 * Return array of data to be when defining a cart fee.
 	 *
-	 * @param array       $input   input data describing cart item.
-	 * @param AppContext  $context AppContext instance.
-	 * @param ResolveInfo $info    query info.
+	 * @param array                                $input   input data describing cart item.
+	 * @param \WPGraphQL\AppContext                $context AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info    query info.
 	 *
 	 * @return array
 	 */
@@ -263,7 +263,7 @@ class Cart_Mutation {
 	 *
 	 * @param array $posted_shipping_methods  Chosen shipping methods.
 	 *
-	 * @throws UserError  Invalid shipping method.
+	 * @throws \GraphQL\Error\UserError  Invalid shipping method.
 	 *
 	 * @return array<string,string>
 	 */
@@ -312,7 +312,7 @@ class Cart_Mutation {
 	/**
 	 * Checks for errors thrown by the QL_Session_Handler during session token validation.
 	 *
-	 * @throws UserError If GRAPHQL_DEBUG is set to true and errors found.
+	 * @throws \GraphQL\Error\UserError If GRAPHQL_DEBUG is set to true and errors found.
 	 *
 	 * @return void
 	 */

--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -9,8 +9,6 @@
 namespace WPGraphQL\WooCommerce\Data\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WP_Error;
 
 use function WC;

--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -61,9 +61,9 @@ class Checkout_Mutation {
 	/**
 	 * Returns order data for use when user checking out.
 	 *
-	 * @param array       $input    Input data describing order.
-	 * @param AppContext  $context  AppContext instance.
-	 * @param ResolveInfo $info     ResolveInfo instance.
+	 * @param array                                $input    Input data describing order.
+	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     ResolveInfo instance.
 	 *
 	 * @return array
 	 */
@@ -258,7 +258,7 @@ class Checkout_Mutation {
 	 *
 	 * @param array $data Checkout data.
 	 *
-	 * @throws UserError When not able to create customer.
+	 * @throws \GraphQL\Error\UserError When not able to create customer.
 	 *
 	 * @return void
 	 */
@@ -372,7 +372,7 @@ class Checkout_Mutation {
 	 *
 	 * @param array $data  Checkout data.
 	 *
-	 * @throws UserError Invalid input.
+	 * @throws \GraphQL\Error\UserError Invalid input.
 	 *
 	 * @return void
 	 */
@@ -452,7 +452,7 @@ class Checkout_Mutation {
 	 *
 	 * @param array $data  An array of posted data.
 	 *
-	 * @throws UserError Invalid input.
+	 * @throws \GraphQL\Error\UserError Invalid input.
 	 *
 	 * @return void
 	 */
@@ -513,7 +513,7 @@ class Checkout_Mutation {
 	 * @param int    $order_id       Order ID.
 	 * @param string $payment_method Payment method.
 	 *
-	 * @throws UserError When payment method is invalid.
+	 * @throws \GraphQL\Error\UserError When payment method is invalid.
 	 *
 	 * @return array Processed payment results.
 	 */
@@ -566,13 +566,13 @@ class Checkout_Mutation {
 	/**
 	 * Process the checkout.
 	 *
-	 * @param array       $data     Order data.
-	 * @param array       $input    Input data describing order.
-	 * @param AppContext  $context  AppContext instance.
-	 * @param ResolveInfo $info     ResolveInfo instance.
-	 * @param array       $results  Order status.
+	 * @param array                                $data     Order data.
+	 * @param array                                $input    Input data describing order.
+	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     ResolveInfo instance.
+	 * @param array                                $results  Order status.
 	 *
-	 * @throws UserError When validation fails.
+	 * @throws \GraphQL\Error\UserError When validation fails.
 	 *
 	 * @return int Order ID.
 	 */
@@ -636,8 +636,8 @@ class Checkout_Mutation {
 			 * @param String|null $transaction_id  Order payment transaction ID.
 			 * @param array       $data            Order data.
 			 * @param array       $input           Order raw input data.
-			 * @param AppContext  $context         Request's AppContext instance.
-			 * @param ResolveInfo $info            Request's ResolveInfo instance.
+			 * @param \WPGraphQL\AppContext  $context         Request's AppContext instance.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info            Request's ResolveInfo instance.
 			 */
 			$valid = apply_filters(
 				'graphql_checkout_prepaid_order_validation',
@@ -721,11 +721,11 @@ class Checkout_Mutation {
 	/**
 	 * Add or update meta data not set in WC_Checkout::create_order().
 	 *
-	 * @param int         $order_id   Order ID.
-	 * @param array       $meta_data  Order meta data.
-	 * @param array       $input      Order properties.
-	 * @param AppContext  $context    AppContext instance.
-	 * @param ResolveInfo $info       ResolveInfo instance.
+	 * @param int                                  $order_id   Order ID.
+	 * @param array                                $meta_data  Order meta data.
+	 * @param array                                $input      Order properties.
+	 * @param \WPGraphQL\AppContext                $context    AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info       ResolveInfo instance.
 	 *
 	 * @throws \Exception Order cannot be retrieved.
 	 *
@@ -749,8 +749,8 @@ class Checkout_Mutation {
 		 * @param \WC_Order   $order      WC_Order instance.
 		 * @param array       $meta_data  Order meta data.
 		 * @param array       $props      Order props array.
-		 * @param AppContext  $context    Request AppContext instance.
-		 * @param ResolveInfo $info       Request ResolveInfo instance.
+		 * @param \WPGraphQL\AppContext  $context    Request AppContext instance.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info       Request ResolveInfo instance.
 		 */
 		do_action( 'graphql_woocommerce_before_checkout_meta_save', $order, $meta_data, $input, $context, $info );
 

--- a/includes/data/mutation/class-coupon-mutation.php
+++ b/includes/data/mutation/class-coupon-mutation.php
@@ -8,9 +8,6 @@
 
 namespace WPGraphQL\WooCommerce\Data\Mutation;
 
-use GraphQL\Error\UserError;
-use WPGraphQL\WooCommerce\Data\Factory;
-
 /**
  * Class - Coupon_Mutation
  */

--- a/includes/data/mutation/class-customer-mutation.php
+++ b/includes/data/mutation/class-customer-mutation.php
@@ -8,11 +8,6 @@
 
 namespace WPGraphQL\WooCommerce\Data\Mutation;
 
-use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\Types;
-
 /**
  * Class Customer_Mutation
  */

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -20,11 +20,11 @@ class Order_Mutation {
 	/**
 	 * Filterable authentication function.
 	 *
-	 * @param array        $input     Input data describing order.
-	 * @param AppContext   $context   AppContext instance.
-	 * @param ResolveInfo  $info      ResolveInfo instance.
-	 * @param string       $mutation  Mutation being executed.
-	 * @param integer|null $order_id  Order ID.
+	 * @param array                                $input     Input data describing order.
+	 * @param \WPGraphQL\AppContext                $context   AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info      ResolveInfo instance.
+	 * @param string                               $mutation  Mutation being executed.
+	 * @param integer|null                         $order_id  Order ID.
 	 *
 	 * @return boolean
 	 */
@@ -53,13 +53,13 @@ class Order_Mutation {
 	/**
 	 * Create an order.
 	 *
-	 * @param array       $input    Input data describing order.
-	 * @param AppContext  $context  AppContext instance.
-	 * @param ResolveInfo $info     ResolveInfo instance.
+	 * @param array                                $input    Input data describing order.
+	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     ResolveInfo instance.
 	 *
 	 * @return integer
 	 *
-	 * @throws UserError  Error creating order.
+	 * @throws \GraphQL\Error\UserError  Error creating order.
 	 */
 	public static function create_order( $input, $context, $info ) {
 		$order_keys = [
@@ -82,8 +82,8 @@ class Order_Mutation {
 		 * Action called before order is created.
 		 *
 		 * @param array       $input   Input data describing order.
-		 * @param AppContext  $context Request AppContext instance.
-		 * @param ResolveInfo $info    Request ResolveInfo instance.
+		 * @param \WPGraphQL\AppContext  $context Request AppContext instance.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info    Request ResolveInfo instance.
 		 */
 		do_action( 'graphql_woocommerce_before_order_create', $input, $context, $info );
 
@@ -97,8 +97,8 @@ class Order_Mutation {
 		 *
 		 * @param \WC_Order    $order   WC_Order instance.
 		 * @param array       $input   Input data describing order.
-		 * @param AppContext  $context Request AppContext instance.
-		 * @param ResolveInfo $info    Request ResolveInfo instance.
+		 * @param \WPGraphQL\AppContext  $context Request AppContext instance.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info    Request ResolveInfo instance.
 		 */
 		do_action( 'graphql_woocommerce_after_order_create', $order, $input, $context, $info );
 
@@ -108,10 +108,10 @@ class Order_Mutation {
 	/**
 	 * Add items to order.
 	 *
-	 * @param array       $input     Input data describing order.
-	 * @param int         $order_id  Order object.
-	 * @param AppContext  $context   AppContext instance.
-	 * @param ResolveInfo $info      ResolveInfo instance.
+	 * @param array                                $input     Input data describing order.
+	 * @param int                                  $order_id  Order object.
+	 * @param \WPGraphQL\AppContext                $context   AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info      ResolveInfo instance.
 	 *
 	 * @return void
 	 */
@@ -132,8 +132,8 @@ class Order_Mutation {
 				 *
 				 * @param array       $items     Item data being added.
 				 * @param integer     $order_id  ID of target order.
-				 * @param AppContext  $context   Request AppContext instance.
-				 * @param ResolveInfo $info      Request ResolveInfo instance.
+				 * @param \WPGraphQL\AppContext  $context   Request AppContext instance.
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info      Request ResolveInfo instance.
 				 */
 				do_action( "graphql_woocommerce_before_{$type}s_added_to_order", $items, $order_id, $context, $info );
 
@@ -158,8 +158,8 @@ class Order_Mutation {
 				 *
 				 * @param array       $items     Item data being added.
 				 * @param integer     $order_id  ID of target order.
-				 * @param AppContext  $context   Request AppContext instance.
-				 * @param ResolveInfo $info      Request ResolveInfo instance.
+				 * @param \WPGraphQL\AppContext  $context   Request AppContext instance.
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info      Request ResolveInfo instance.
 				 */
 				do_action( "graphql_woocommerce_after_{$type}s_added_to_order", $items, $order_id, $context, $info );
 			}//end if
@@ -169,11 +169,11 @@ class Order_Mutation {
 	/**
 	 * Return array of item mapped with the provided $item_keys and extracts $meta_data
 	 *
-	 * @param integer     $item_id    Order item ID.
-	 * @param array       $input      Item input data.
-	 * @param array       $item_keys  Item key map.
-	 * @param AppContext  $context    AppContext instance.
-	 * @param ResolveInfo $info       ResolveInfo instance.
+	 * @param integer                              $item_id    Order item ID.
+	 * @param array                                $input      Item input data.
+	 * @param array                                $item_keys  Item key map.
+	 * @param \WPGraphQL\AppContext                $context    AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info       ResolveInfo instance.
 	 *
 	 * @throws \Exception  Failed to retrieve order item | Failed to retrieve connected product.
 	 *
@@ -276,7 +276,7 @@ class Order_Mutation {
 	 * @param array $data  Line item data.
 	 *
 	 * @return integer
-	 * @throws UserError When SKU or ID is not valid.
+	 * @throws \GraphQL\Error\UserError When SKU or ID is not valid.
 	 */
 	protected static function get_product_id( $data ) {
 		if ( ! empty( $data['sku'] ) ) {
@@ -295,12 +295,12 @@ class Order_Mutation {
 	/**
 	 * Create/Update order item meta data.
 	 *
-	 * @param int         $item_id    Order item ID.
-	 * @param array       $meta_data  Array of meta data.
-	 * @param AppContext  $context    AppContext instance.
-	 * @param ResolveInfo $info       ResolveInfo instance.
+	 * @param int                                  $item_id    Order item ID.
+	 * @param array                                $meta_data  Array of meta data.
+	 * @param \WPGraphQL\AppContext                $context    AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info       ResolveInfo instance.
 	 *
-	 * @throws UserError|\Exception  Invalid item input | Failed to retrieve order item.
+	 * @throws \GraphQL\Error\UserError|\Exception  Invalid item input | Failed to retrieve order item.
 	 *
 	 * @return void
 	 */
@@ -323,10 +323,10 @@ class Order_Mutation {
 	/**
 	 * Add meta data not set in self::create_order().
 	 *
-	 * @param int         $order_id  Order ID.
-	 * @param array       $input     Order properties.
-	 * @param AppContext  $context   AppContext instance.
-	 * @param ResolveInfo $info      ResolveInfo instance.
+	 * @param int                                  $order_id  Order ID.
+	 * @param array                                $input     Order properties.
+	 * @param \WPGraphQL\AppContext                $context   AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info      ResolveInfo instance.
 	 *
 	 * @throws \Exception  Failed to retrieve order.
 	 *
@@ -372,8 +372,8 @@ class Order_Mutation {
 		 *
 		 * @param \WC_Order   $order   WC_Order instance.
 		 * @param array       $props   Order props array.
-		 * @param AppContext  $context Request AppContext instance.
-		 * @param ResolveInfo $info    Request ResolveInfo instance.
+		 * @param \WPGraphQL\AppContext  $context Request AppContext instance.
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info    Request ResolveInfo instance.
 		 */
 		do_action( 'graphql_woocommerce_before_order_meta_save', $order, $input, $context, $info );
 
@@ -470,11 +470,11 @@ class Order_Mutation {
 	/**
 	 * Purge object when creating.
 	 *
-	 * @param null|\WC_Order|Order $order         Object data.
-	 * @param boolean              $force_delete  Delete or put in trash.
+	 * @param null|\WC_Order|\WPGraphQL\WooCommerce\Model\Order $order         Object data.
+	 * @param boolean                                           $force_delete  Delete or put in trash.
 	 *
 	 * @return bool
-	 * @throws UserError  Failed to delete order.
+	 * @throws \GraphQL\Error\UserError  Failed to delete order.
 	 */
 	public static function purge( $order, $force_delete = true ) {
 		if ( ! empty( $order ) ) {

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -9,9 +9,6 @@
 namespace WPGraphQL\WooCommerce\Data\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Model\Order;
 
 /**
  * Class - Order_Mutation

--- a/includes/model/class-customer.php
+++ b/includes/model/class-customer.php
@@ -11,8 +11,8 @@
 namespace WPGraphQL\WooCommerce\Model;
 
 use GraphQLRelay\Relay;
-use WPGraphQL\Model\Model;
 use WC_Customer;
+use WPGraphQL\Model\Model;
 
 /**
  * Class Customer

--- a/includes/model/class-customer.php
+++ b/includes/model/class-customer.php
@@ -47,7 +47,7 @@ class Customer extends Model {
 	/**
 	 * Customer constructor
 	 *
-	 * @param WC_Customer|int|string $id - User ID.
+	 * @param \WC_Customer|int|string $id - User ID.
 	 */
 	public function __construct( $id = 'session' ) {
 		$this->data                = 'session' === $id ? \WC()->customer : new WC_Customer( absint( $id ) );

--- a/includes/model/class-order-item.php
+++ b/includes/model/class-order-item.php
@@ -10,8 +10,8 @@
 
 namespace WPGraphQL\WooCommerce\Model;
 
-use WPGraphQL\Model\Model;
 use GraphQLRelay\Relay;
+use WPGraphQL\Model\Model;
 
 /**
  * Class Order_Item

--- a/includes/model/class-order-item.php
+++ b/includes/model/class-order-item.php
@@ -76,15 +76,15 @@ class Order_Item extends Model {
 	/**
 	 * Stores parent order model.
 	 *
-	 * @var Order
+	 * @var \WPGraphQL\WooCommerce\Model\Order
 	 */
 	protected $order;
 
 	/**
 	 * Order_Item constructor
 	 *
-	 * @param \WC_Order_Item $item          Order item crud object.
-	 * @param null|Order     $cached_order  Preloaded parent order model.
+	 * @param \WC_Order_Item                          $item          Order item crud object.
+	 * @param null|\WPGraphQL\WooCommerce\Model\Order $cached_order  Preloaded parent order model.
 	 */
 	public function __construct( $item, $cached_order = null ) {
 		$this->data                = $item;

--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -10,7 +10,6 @@
 
 namespace WPGraphQL\WooCommerce\Model;
 
-use Automattic\WooCommerce\Utilities\OrderUtil;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\Model\Model;

--- a/includes/model/class-product-variation.php
+++ b/includes/model/class-product-variation.php
@@ -11,7 +11,6 @@
 namespace WPGraphQL\WooCommerce\Model;
 
 use GraphQLRelay\Relay;
-use WC_Product_Variation;
 
 /**
  * Class Product_Variation

--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -111,7 +111,7 @@ class Product extends WC_Post {
 	/**
 	 * Stores product factory.
 	 *
-	 * @var WC_Product_Factory|null
+	 * @var \WC_Product_Factory|null
 	 */
 	protected static $product_factory = null;
 

--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -11,11 +11,6 @@
 namespace WPGraphQL\WooCommerce\Model;
 
 use GraphQLRelay\Relay;
-use WC_Product_Factory;
-use WC_Product_External;
-use WC_Product_Grouped;
-use WC_Product_Variable;
-use WC_Product_Simple;
 
 /**
  * Class Product

--- a/includes/model/class-wc-post.php
+++ b/includes/model/class-wc-post.php
@@ -12,7 +12,6 @@ namespace WPGraphQL\WooCommerce\Model;
 
 use GraphQL\Error\UserError;
 use WPGraphQL\Model\Post;
-use WP_Post_Type;
 
 /**
  * Class WC_Post

--- a/includes/model/class-wc-post.php
+++ b/includes/model/class-wc-post.php
@@ -115,7 +115,7 @@ abstract class WC_Post extends Post {
 	/**
 	 * Wrapper function for deleting
 	 *
-	 * @throws UserError Not authorized.
+	 * @throws \GraphQL\Error\UserError Not authorized.
 	 *
 	 * @param boolean $force_delete Should the data be deleted permanently.
 	 * @return boolean

--- a/includes/mutation/class-cart-add-item.php
+++ b/includes/mutation/class-cart-add-item.php
@@ -100,7 +100,7 @@ class Cart_Add_Item {
 			// Add item to cart and get item key.
 			try {
 				$cart_item_key = \WC()->cart->add_to_cart( ...$cart_item_args );
-			} catch ( \Exception $e ) {
+			} catch ( \Throwable $e ) {
 				// Repackage any errors.
 				throw new UserError( $e->getMessage() );
 			}

--- a/includes/mutation/class-cart-add-items.php
+++ b/includes/mutation/class-cart-add-items.php
@@ -133,7 +133,7 @@ class Cart_Add_Items {
 						$reason    = __( 'Failed to add cart item. Please check input.', 'wp-graphql-woocommerce' );
 						$failure[] = compact( 'cart_item_data', 'reason' );
 					}
-				} catch ( \Exception $e ) {
+				} catch ( \Throwable $e ) {
 					// Get thrown error message.
 					$reason = $e->getMessage();
 

--- a/includes/mutation/class-cart-apply-coupon.php
+++ b/includes/mutation/class-cart-apply-coupon.php
@@ -12,7 +12,6 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use WPGraphQL\WooCommerce\Data\Mutation\Cart_Mutation;
-use WC_Coupon;
 
 /**
  * Class - Cart_Apply_Coupon

--- a/includes/mutation/class-cart-empty.php
+++ b/includes/mutation/class-cart-empty.php
@@ -76,8 +76,8 @@ class Cart_Empty {
 			 *
 			 * @param object      $cloned_cart Cloned cart.
 			 * @param array       $input       Input info.
-			 * @param AppContext  $context     Context passed.
-			 * @param ResolveInfo $info        Resolver info passed.
+			 * @param \WPGraphQL\AppContext  $context     Context passed.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info        Resolver info passed.
 			 */
 			do_action( 'graphql_woocommerce_before_empty_cart', $cloned_cart, $input, $context, $info );
 
@@ -90,8 +90,8 @@ class Cart_Empty {
 			 *
 			 * @param object      $cloned_cart Cloned cart.
 			 * @param array       $input       Input info.
-			 * @param AppContext  $context     Context passed.
-			 * @param ResolveInfo $info        Resolver info passed.
+			 * @param \WPGraphQL\AppContext  $context     Context passed.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info        Resolver info passed.
 			 */
 			do_action( 'graphql_woocommerce_after_empty_cart', $cloned_cart, $input, $context, $info );
 

--- a/includes/mutation/class-cart-fill.php
+++ b/includes/mutation/class-cart-fill.php
@@ -186,7 +186,7 @@ class Cart_Fill {
 						$reason               = __( 'Failed to add cart item. Please check input.', 'wp-graphql-woocommerce' );
 						$invalid_cart_items[] = compact( 'cart_item_data', 'reason' );
 					}
-				} catch ( \Exception $e ) {
+				} catch ( \Throwable $e ) {
 					// Get thrown error message.
 					$reason = $e->getMessage();
 

--- a/includes/mutation/class-cart-update-item-quantities.php
+++ b/includes/mutation/class-cart-update-item-quantities.php
@@ -10,11 +10,11 @@
 
 namespace WPGraphQL\WooCommerce\Mutation;
 
+use Exception;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Cart_Mutation;
-use Exception;
 
 /**
  * Class - Cart_Update_Item_Quantities
@@ -152,7 +152,7 @@ class Cart_Update_Item_Quantities {
 						)
 					);
 				}
-			} catch ( Exception $e ) {
+			} catch ( \Throwable $e ) {
 				throw new UserError( $e->getMessage() );
 			}//end try
 

--- a/includes/mutation/class-checkout.php
+++ b/includes/mutation/class-checkout.php
@@ -141,8 +141,8 @@ class Checkout {
 				 *
 				 * @param array       $args    Order data.
 				 * @param array       $input   Raw input data .
-				 * @param AppContext  $context Request AppContext instance.
-				 * @param ResolveInfo $info    Request ResolveInfo instance.
+				 * @param \WPGraphQL\AppContext  $context Request AppContext instance.
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info    Request ResolveInfo instance.
 				 */
 				do_action( 'graphql_woocommerce_before_checkout', $args, $input, $context, $info );
 
@@ -159,8 +159,8 @@ class Checkout {
 				 *
 				 * @param \WC_Order   $order   WC_Order instance.
 				 * @param array       $input   Input data describing order.
-				 * @param AppContext  $context Request AppContext instance.
-				 * @param ResolveInfo $info    Request ResolveInfo instance.
+				 * @param \WPGraphQL\AppContext  $context Request AppContext instance.
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info    Request ResolveInfo instance.
 				 */
 				do_action( 'graphql_woocommerce_after_checkout', $order, $input, $context, $info );
 

--- a/includes/mutation/class-checkout.php
+++ b/includes/mutation/class-checkout.php
@@ -15,9 +15,8 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Checkout_Mutation;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
-use WPGraphQL\WooCommerce\Model\Order;
 use WPGraphQL\WooCommerce\Model\Customer;
-use Exception;
+use WPGraphQL\WooCommerce\Model\Order;
 
 /**
  * Class Checkout
@@ -165,7 +164,7 @@ class Checkout {
 				do_action( 'graphql_woocommerce_after_checkout', $order, $input, $context, $info );
 
 				return array_merge( [ 'id' => $order_id ], $results );
-			} catch ( Exception $e ) {
+			} catch ( \Throwable $e ) {
 				// Delete order if it was created.
 				if ( is_object( $order ) ) {
 					Order_Mutation::purge( $order );

--- a/includes/mutation/class-coupon-create.php
+++ b/includes/mutation/class-coupon-create.php
@@ -153,12 +153,12 @@ class Coupon_Create {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param array       $input    Mutation input.
-	 * @param AppContext  $context  AppContext instance.
-	 * @param ResolveInfo $info     ResolveInfo instance. Can be
+	 * @param array                                $input    Mutation input.
+	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     ResolveInfo instance. Can be
 	 * use to get info about the current node in the GraphQL tree.
 	 *
-	 * @throws UserError Invalid ID provided | Lack of capabilities.
+	 * @throws \GraphQL\Error\UserError Invalid ID provided | Lack of capabilities.
 	 *
 	 * @return array
 	 */

--- a/includes/mutation/class-coupon-delete.php
+++ b/includes/mutation/class-coupon-delete.php
@@ -77,12 +77,12 @@ class Coupon_Delete {
 	/**
 	 * Defines the mutation data modification closure.
 	 *
-	 * @param array       $input    Mutation input.
-	 * @param AppContext  $context  AppContext instance.
-	 * @param ResolveInfo $info     ResolveInfo instance. Can be
+	 * @param array                                $input    Mutation input.
+	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     ResolveInfo instance. Can be
 	 * use to get info about the current node in the GraphQL tree.
 	 *
-	 * @throws UserError Invalid ID provided | Lack of capabilities.
+	 * @throws \GraphQL\Error\UserError Invalid ID provided | Lack of capabilities.
 	 *
 	 * @return array
 	 */

--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -10,13 +10,13 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use WC_Customer;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\UserMutation;
-use WPGraphQL\WooCommerce\Data\Mutation\Customer_Mutation;
-use WPGraphQL\WooCommerce\Model\Customer;
 use WPGraphQL\Model\User;
 use WPGraphQL\Mutation\UserRegister;
-use WC_Customer;
+use WPGraphQL\WooCommerce\Data\Mutation\Customer_Mutation;
+use WPGraphQL\WooCommerce\Model\Customer;
 
 /**
  * Class - Customer_Register

--- a/includes/mutation/class-customer-update.php
+++ b/includes/mutation/class-customer-update.php
@@ -10,12 +10,12 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use WC_Customer;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Mutation\Customer_Mutation;
-use WPGraphQL\WooCommerce\Model\Customer;
 use WPGraphQL\Mutation\UserCreate;
 use WPGraphQL\Mutation\UserUpdate;
-use WC_Customer;
+use WPGraphQL\WooCommerce\Data\Mutation\Customer_Mutation;
+use WPGraphQL\WooCommerce\Model\Customer;
 
 /**
  * Class - Customer_Update

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -12,11 +12,10 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
+use WC_Order_Factory;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
-use WC_Order_Factory;
-use Exception;
 
 /**
  * Class Order_Create
@@ -202,7 +201,7 @@ class Order_Create {
 				do_action( 'graphql_woocommerce_after_order_create', $order, $input, $context, $info );
 
 				return [ 'id' => $order->get_id() ];
-			} catch ( Exception $e ) {
+			} catch ( \Throwable $e ) {
 				// Delete order if it was created.
 				if ( is_object( $order ) ) {
 					Order_Mutation::purge( $order );

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -196,8 +196,8 @@ class Order_Create {
 				 *
 				 * @param \WC_Order    $order   WC_Order instance.
 				 * @param array       $input   Input data describing order.
-				 * @param AppContext  $context Request AppContext instance.
-				 * @param ResolveInfo $info    Request ResolveInfo instance.
+				 * @param \WPGraphQL\AppContext  $context Request AppContext instance.
+				 * @param \GraphQL\Type\Definition\ResolveInfo $info    Request ResolveInfo instance.
 				 */
 				do_action( 'graphql_woocommerce_after_order_create', $order, $input, $context, $info );
 

--- a/includes/mutation/class-order-delete-items.php
+++ b/includes/mutation/class-order-delete-items.php
@@ -141,10 +141,10 @@ class Order_Delete_Items {
 			 * Action called before order is deleted.
 			 *
 			 * @param array           $item_ids  Order item IDs of items being deleted.
-			 * @param \WC_Order|Order $order     Order model instance.
+			 * @param \WC_Order|\WPGraphQL\WooCommerce\Model\Order $order     Order model instance.
 			 * @param array           $input     Input data describing order.
-			 * @param AppContext      $context   Request AppContext instance.
-			 * @param ResolveInfo     $info      Request ResolveInfo instance.
+			 * @param \WPGraphQL\AppContext      $context   Request AppContext instance.
+			 * @param \GraphQL\Type\Definition\ResolveInfo     $info      Request ResolveInfo instance.
 			 */
 			do_action( 'graphql_woocommerce_before_order_items_delete', $ids, $working_order, $input, $context, $info );
 
@@ -159,10 +159,10 @@ class Order_Delete_Items {
 			 * Action called before order is deleted.
 			 *
 			 * @param array           $item_ids  Order item IDs of items being deleted.
-			 * @param \WC_Order|Order $order     Order model instance.
+			 * @param \WC_Order|\WPGraphQL\WooCommerce\Model\Order $order     Order model instance.
 			 * @param array           $input     Input data describing order
-			 * @param AppContext      $context   Request AppContext instance.
-			 * @param ResolveInfo     $info      Request ResolveInfo instance.
+			 * @param \WPGraphQL\AppContext      $context   Request AppContext instance.
+			 * @param \GraphQL\Type\Definition\ResolveInfo     $info      Request ResolveInfo instance.
 			 */
 			do_action( 'graphql_woocommerce_after_order_delete', $ids, $working_order, $input, $context, $info );
 

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -13,10 +13,10 @@ namespace WPGraphQL\WooCommerce\Mutation;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WC_Order_Factory;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
-use WC_Order_Factory;
 
 /**
  * Class Order_Delete

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -130,10 +130,10 @@ class Order_Delete {
 			/**
 			 * Action called before order is deleted.
 			 *
-			 * @param \WC_Order|Order $order   Order model instance.
+			 * @param \WC_Order|\WPGraphQL\WooCommerce\Model\Order $order   Order model instance.
 			 * @param array           $input   Input data describing order.
-			 * @param AppContext      $context Request AppContext instance.
-			 * @param ResolveInfo     $info    Request ResolveInfo instance.
+			 * @param \WPGraphQL\AppContext      $context Request AppContext instance.
+			 * @param \GraphQL\Type\Definition\ResolveInfo     $info    Request ResolveInfo instance.
 			 */
 			do_action( 'graphql_woocommerce_before_order_delete', $order, $input, $context, $info );
 
@@ -159,10 +159,10 @@ class Order_Delete {
 			/**
 			 * Action called before order is deleted.
 			 *
-			 * @param \WC_Order|Order $order   Order model instance.
+			 * @param \WC_Order|\WPGraphQL\WooCommerce\Model\Order $order   Order model instance.
 			 * @param array           $input   Input data describing order
-			 * @param AppContext      $context Request AppContext instance.
-			 * @param ResolveInfo     $info    Request ResolveInfo instance.
+			 * @param \WPGraphQL\AppContext      $context Request AppContext instance.
+			 * @param \GraphQL\Type\Definition\ResolveInfo     $info    Request ResolveInfo instance.
 			 */
 			do_action( 'graphql_woocommerce_after_order_delete', $order, $input, $context, $info );
 

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -13,10 +13,10 @@ namespace WPGraphQL\WooCommerce\Mutation;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
+use WC_Order_Factory;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
-use WC_Order_Factory;
 
 /**
  * Class Order_Update

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -111,8 +111,8 @@ class Order_Update {
 			 *
 			 * @param int         $order_id  Order ID.
 			 * @param array       $input     Input data describing order
-			 * @param AppContext  $context   Request AppContext instance.
-			 * @param ResolveInfo $info      Request ResolveInfo instance.
+			 * @param \WPGraphQL\AppContext  $context   Request AppContext instance.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info      Request ResolveInfo instance.
 			 */
 			do_action( 'graphql_woocommerce_before_order_update', $order_id, $input, $context, $info );
 
@@ -161,8 +161,8 @@ class Order_Update {
 			 *
 			 * @param \WC_Order    $order   WC_Order instance.
 			 * @param array       $input   Input data describing order
-			 * @param AppContext  $context Request AppContext instance.
-			 * @param ResolveInfo $info    Request ResolveInfo instance.
+			 * @param \WPGraphQL\AppContext  $context Request AppContext instance.
+			 * @param \GraphQL\Type\Definition\ResolveInfo $info    Request ResolveInfo instance.
 			 */
 			do_action( 'graphql_woocommerce_after_order_update', $order, $input, $context, $info );
 

--- a/includes/mutation/class-payment-method-delete.php
+++ b/includes/mutation/class-payment-method-delete.php
@@ -12,12 +12,8 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
-use WPGraphQL\Model\Comment;
-use WPGraphQL\Mutation\CommentCreate;
 use WC_Payment_Tokens;
+use WPGraphQL\AppContext;
 
 /**
  * Class Payment_Method_Delete

--- a/includes/mutation/class-payment-method-set-default.php
+++ b/includes/mutation/class-payment-method-set-default.php
@@ -12,12 +12,8 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
-use WPGraphQL\Model\Comment;
-use WPGraphQL\Mutation\CommentCreate;
 use WC_Payment_Tokens;
+use WPGraphQL\AppContext;
 
 /**
  * Class Payment_Method_Set_Default

--- a/includes/mutation/class-review-update.php
+++ b/includes/mutation/class-review-update.php
@@ -14,7 +14,6 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Mutation\CommentUpdate;
 
 /**

--- a/includes/mutation/class-review-write.php
+++ b/includes/mutation/class-review-write.php
@@ -12,9 +12,7 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\Model\Comment;
 use WPGraphQL\Mutation\CommentCreate;
 

--- a/includes/mutation/class-update-session.php
+++ b/includes/mutation/class-update-session.php
@@ -15,7 +15,6 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Cart_Mutation;
 use WPGraphQL\WooCommerce\Model\Customer;
-use WPGraphQL\WooCommerce\Utils\QL_Session_Handler;
 
 /**
  * Class - Update_Session

--- a/includes/mutation/class-update-session.php
+++ b/includes/mutation/class-update-session.php
@@ -65,7 +65,7 @@ class Update_Session {
 					/**
 					 * Session handler.
 					 *
-					 * @var QL_Session_Handler $session
+					 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session
 					 */
 					$session      = \WC()->session;
 					$session_data = $session->get_session_data();
@@ -108,7 +108,7 @@ class Update_Session {
 			/**
 			 * Session handler.
 			 *
-			 * @var QL_Session_Handler $session
+			 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session
 			 */
 			$session = \WC()->session;
 

--- a/includes/type/interface/class-payment-token.php
+++ b/includes/type/interface/class-payment-token.php
@@ -8,8 +8,8 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPInterface;
 
-use GraphQLRelay\Relay;
 use GraphQL\Error\UserError;
+use GraphQLRelay\Relay;
 
 /**
  * Class Payment_Token

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -14,7 +14,6 @@ use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Factory;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**
  * Class - Product

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -10,12 +10,11 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Connection\Variation_Attribute_Connection_Resolver;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\WooCommerce\Data\Connection\Cart_Item_Connection_Resolver;
+use WPGraphQL\WooCommerce\Data\Connection\Variation_Attribute_Connection_Resolver;
 use WPGraphQL\WooCommerce\Data\Factory;
 
 /**

--- a/includes/type/object/class-coupon-type.php
+++ b/includes/type/object/class-coupon-type.php
@@ -10,11 +10,6 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
-use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Factory;
-
 /**
  * Class Coupon_Type
  */

--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -292,7 +292,7 @@ class Customer_Type {
 						/**
 						 * Session handler.
 						 *
-						 * @var QL_Session_Handler $session
+						 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session
 						 */
 						$session = \WC()->session;
 
@@ -317,7 +317,7 @@ class Customer_Type {
 						/**
 						 * Session handler
 						 *
-						 * @var QL_Session_Handler $session
+						 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session
 						 */
 						$session = \WC()->session;
 

--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -12,11 +12,9 @@ namespace WPGraphQL\WooCommerce\Type\WPObject;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Factory;
 use WPGraphQL\WooCommerce\Data\Connection\Downloadable_Item_Connection_Resolver;
-use WPGraphQL\WooCommerce\Utils\QL_Session_Handler;
+use WPGraphQL\WooCommerce\Data\Factory;
 
 /**
  * Class Customer_Type

--- a/includes/type/object/class-downloadable-item-type.php
+++ b/includes/type/object/class-downloadable-item-type.php
@@ -11,9 +11,9 @@
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
 use GraphQLRelay\Relay;
+use WC_Product_Download;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Factory;
-use WC_Product_Download;
 
 /**
  * Class Downloadable_Item_Type

--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -10,8 +10,6 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
-
 /**
  * Class Meta_Data_Type
  */

--- a/includes/type/object/class-order-item-type.php
+++ b/includes/type/object/class-order-item-type.php
@@ -11,8 +11,8 @@
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Factory;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
+use WPGraphQL\WooCommerce\Data\Factory;
 
 /**
  * Class Order_Item_Type

--- a/includes/type/object/class-order-type.php
+++ b/includes/type/object/class-order-type.php
@@ -425,10 +425,10 @@ class Order_Type {
 	/**
 	 * Order Item connection resolver callback
 	 *
-	 * @param \WPGraphQL\WooCommerce\Model\Order $source   Source order.
-	 * @param array                              $args     Connection args.
-	 * @param AppContext                         $context  AppContext instance.
-	 * @param ResolveInfo                        $info     ResolveInfo instance.
+	 * @param \WPGraphQL\WooCommerce\Model\Order   $source   Source order.
+	 * @param array                                $args     Connection args.
+	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info     ResolveInfo instance.
 	 *
 	 * @return array
 	 */

--- a/includes/type/object/class-order-type.php
+++ b/includes/type/object/class-order-type.php
@@ -10,13 +10,11 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Factory;
-use WPGraphQL\WooCommerce\Data\Connection\Order_Item_Connection_Resolver;
 use WPGraphQL\WooCommerce\Data\Connection\Downloadable_Item_Connection_Resolver;
+use WPGraphQL\WooCommerce\Data\Connection\Order_Item_Connection_Resolver;
+use WPGraphQL\WooCommerce\Data\Factory;
 
 /**
  * Class Order_Type

--- a/includes/type/object/class-product-types.php
+++ b/includes/type/object/class-product-types.php
@@ -10,14 +10,9 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce as WooGraphQL;
-use WPGraphQL\WooCommerce\Data\Factory;
 use WPGraphQL\WooCommerce\Model\Product as Model;
 use WPGraphQL\WooCommerce\Type\WPInterface\Product;
+use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce as WooGraphQL;
 
 
 /**

--- a/includes/type/object/class-product-variation-type.php
+++ b/includes/type/object/class-product-variation-type.php
@@ -10,10 +10,7 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Factory;
 
 /**
  * Class Product_Variation_Type

--- a/includes/type/object/class-refund-type.php
+++ b/includes/type/object/class-refund-type.php
@@ -10,11 +10,7 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
-use WPGraphQL\WooCommerce\Data\Factory;
 
 /**
  * Class Refund_Type

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -13,8 +13,8 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce as WooGraphQL;
 use WPGraphQL\WooCommerce\Data\Factory;
+use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce as WooGraphQL;
 
 /**
  * Class - Root_Query

--- a/includes/type/object/class-shipping-method-type.php
+++ b/includes/type/object/class-shipping-method-type.php
@@ -10,10 +10,6 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
-use GraphQLRelay\Relay;
-use WPGraphQL\WooCommerce\Data\Factory;
-
 /**
  * Class Shipping_Method_Type
  */

--- a/includes/type/object/class-tax-rate-type.php
+++ b/includes/type/object/class-tax-rate-type.php
@@ -10,11 +10,6 @@
 
 namespace WPGraphQL\WooCommerce\Type\WPObject;
 
-use GraphQL\Error\UserError;
-use GraphQLRelay\Relay;
-use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Data\Factory;
-
 /**
  * Class Tax_Rate_Type
  */

--- a/includes/utils/class-protected-router.php
+++ b/includes/utils/class-protected-router.php
@@ -18,7 +18,7 @@ class Protected_Router {
 	/**
 	 * Stores the instance of the Protected_Router class
 	 *
-	 * @var null|Protected_Router
+	 * @var null|\WPGraphQL\WooCommerce\Utils\Protected_Router
 	 */
 	private static $instance = null;
 
@@ -67,7 +67,7 @@ class Protected_Router {
 	/**
 	 * Returns the Protected_Router singleton instance.
 	 *
-	 * @return Protected_Router
+	 * @return \WPGraphQL\WooCommerce\Utils\Protected_Router
 	 */
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {
@@ -375,7 +375,7 @@ class Protected_Router {
 		/**
 		 * Session object
 		 *
-		 * @var Transfer_Session_Handler $session
+		 * @var \WPGraphQL\WooCommerce\Utils\Transfer_Session_Handler $session
 		 */
 		$session = \WC()->session;
 

--- a/includes/utils/class-ql-session-handler.php
+++ b/includes/utils/class-ql-session-handler.php
@@ -8,10 +8,9 @@
 
 namespace WPGraphQL\WooCommerce\Utils;
 
+use WC_Session_Handler;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
-use GraphQL\Error\UserError;
-use WC_Session_Handler;
 
 /**
  * Class - QL_Session_Handler
@@ -234,7 +233,7 @@ class QL_Session_Handler extends WC_Session_Handler {
 			if ( empty( $token->data ) || empty( $token->data->customer_id ) ) {
 				throw new \Exception( __( 'Customer ID not found in the token', 'wp-graphql-woocommerce' ) );
 			}
-		} catch ( \Exception $error ) {
+		} catch ( \Throwable $error ) {
 			return new \WP_Error( 'invalid_token', $error->getMessage() );
 		}//end try
 

--- a/includes/utils/class-ql-session-handler.php
+++ b/includes/utils/class-ql-session-handler.php
@@ -121,7 +121,7 @@ class QL_Session_Handler extends WC_Session_Handler {
 	/**
 	 * Setup token and customer ID.
 	 *
-	 * @throws UserError Invalid token.
+	 * @throws \GraphQL\Error\UserError Invalid token.
 	 *
 	 * @return void
 	 */

--- a/includes/utils/class-session-transaction-manager.php
+++ b/includes/utils/class-session-transaction-manager.php
@@ -8,9 +8,7 @@
 
 namespace WPGraphQL\WooCommerce\Utils;
 
-use Firebase\JWT\JWT;
 use GraphQL\Error\UserError;
-use WC_Session_Handler;
 
 /**
  * Class - Session_Transaction_Manager

--- a/includes/utils/class-session-transaction-manager.php
+++ b/includes/utils/class-session-transaction-manager.php
@@ -27,7 +27,7 @@ class Session_Transaction_Manager {
 	/**
 	 * Instance of parent session handler
 	 *
-	 * @var QL_Session_Handler
+	 * @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler
 	 */
 	private $session_handler = null;
 
@@ -35,7 +35,7 @@ class Session_Transaction_Manager {
 	/**
 	 * Singleton instance of class.
 	 *
-	 * @var Session_Transaction_Manager
+	 * @var \WPGraphQL\WooCommerce\Utils\Session_Transaction_Manager
 	 */
 	private static $instance = null;
 
@@ -43,9 +43,9 @@ class Session_Transaction_Manager {
 	 * Singleton retriever and cleaner.
 	 * Should not be called anywhere but in the session handler init function.
 	 *
-	 * @param QL_Session_Handler $session_handler  WooCommerce Session Handler instance.
+	 * @param \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session_handler  WooCommerce Session Handler instance.
 	 *
-	 * @return Session_Transaction_Manager
+	 * @return \WPGraphQL\WooCommerce\Utils\Session_Transaction_Manager
 	 */
 	public static function get( &$session_handler ) {
 		if ( is_null( self::$instance ) ) {
@@ -59,7 +59,7 @@ class Session_Transaction_Manager {
 	/**
 	 * Session_Transaction_Manager constructor
 	 *
-	 * @param QL_Session_Handler $session_handler  Reference back to session handler.
+	 * @param \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session_handler  Reference back to session handler.
 	 */
 	public function __construct( &$session_handler ) {
 		$this->session_handler = $session_handler;
@@ -207,7 +207,7 @@ class Session_Transaction_Manager {
 	/**
 	 * Pop transaction ID off the top of the queue, ending the transaction.
 	 *
-	 * @throws UserError If transaction ID is not on the top of the queue.
+	 * @throws \GraphQL\Error\UserError If transaction ID is not on the top of the queue.
 	 *
 	 * @return void
 	 */

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,7 @@
 	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
 	<!-- Rules: Check PHP version compatibility -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.2-"/>
 
 	<!-- Rules: WordPress Coding Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
@@ -23,7 +23,7 @@
 	<rule ref="WordPress-Extra" />
 
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/wp-graphql-woocommerce.php
+++ b/wp-graphql-woocommerce.php
@@ -10,8 +10,8 @@
  * Domain Path: /languages
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * WC requires at least: 4.8.0
- * WC tested up to: 7.5.1
+ * WC requires at least: 7.5.0
+ * WC tested up to: 7.8.2
  * WPGraphQL requires at least: 1.14.0+
  * WPGraphQL-JWT-Authentication requires at least: 0.7.0+
  *


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes all existing PHPDoc types to use full-qualified class-names. 

PHPDoc does not infer a class from the `use` statements, so using FQCN is required to ensure that devs can properly extend this plugin (and get the correct type hints/ stan checks)

Branch is based off of https://github.com/wp-graphql/wp-graphql-woocommerce/pull/763, which should be merged first.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Audited with [WPGraphQL Coding Standards](https://github.com/AxeWP/WPGraphQL-Coding-Standards).


Where has this been tested?
---------------------------

- WooGraphQL Version: 0.14.1
- WPGraphQL Version: 1.14.6
- WordPress Version: 6.2.2
- WooCommerce Version: 7.8.2
