### PR TITLE
fix: remove trailing commas from function calls

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,10 +1,10 @@
 === WP GraphQL WooCommerce ===
 Contributors: kidunot89, ranaaterning, jasonbahl, saleebm
 Tags: GraphQL, WooCommerce, WPGraphQL
-Requires at least: 4.9
+Requires at least: 5.9
 Tested up to: 6.2
-Requires PHP: 7.1
-Requires WooCommerce: 4.8.0
+Requires PHP: 7.2
+Requires WooCommerce: 7.5.0
 Requires WPGraphQL: 1.14.0+
 Works with WPGraphQL-JWT-Authentication: 0.7.0+
 Stable tag: 0.14.1

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2",
         "firebase/php-jwt": "^6.1.0"
     },
     "require-dev": {
         "automattic/vipwpcs": "^2.3",
-        "axepress/wp-graphql-stubs": "^1.14",
-        "php-stubs/woocommerce-stubs": "^7.7",
+        "axepress/wp-graphql-stubs": "1.14.0",
+        "php-stubs/woocommerce-stubs": "7.5.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb3dcd97101e5ff66f9f812e417aa977",
+    "content-hash": "1fe0d1a5418403ab97ed669378c504f9",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -125,16 +125,16 @@
         },
         {
             "name": "axepress/wp-graphql-stubs",
-            "version": "v1.14.4",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AxeWP/wp-graphql-stubs.git",
-                "reference": "1c5b0cb3ce978d1e88a828c158383877ba7c223a"
+                "reference": "1455a46043f758b77a49337c9520cb79c5a0a31f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/1c5b0cb3ce978d1e88a828c158383877ba7c223a",
-                "reference": "1c5b0cb3ce978d1e88a828c158383877ba7c223a",
+                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/1455a46043f758b77a49337c9520cb79c5a0a31f",
+                "reference": "1455a46043f758b77a49337c9520cb79c5a0a31f",
                 "shasum": ""
             },
             "require": {
@@ -165,7 +165,7 @@
             ],
             "support": {
                 "issues": "https://github.com/AxeWP/wp-graphql-stubs/issues",
-                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.14.4"
+                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.14.0"
             },
             "funding": [
                 {
@@ -173,7 +173,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-06-14T01:39:23+00:00"
+            "time": "2023-03-09T01:45:16+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -252,16 +252,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v7.8.0",
+            "version": "v7.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "1e9180bbac115884bf41bf1d2ee0f72338c0a566"
+                "reference": "9a735c3a66fb3eab4bdbb9e998db00b1fbd268d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/1e9180bbac115884bf41bf1d2ee0f72338c0a566",
-                "reference": "1e9180bbac115884bf41bf1d2ee0f72338c0a566",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/9a735c3a66fb3eab4bdbb9e998db00b1fbd268d7",
+                "reference": "9a735c3a66fb3eab4bdbb9e998db00b1fbd268d7",
                 "shasum": ""
             },
             "require": {
@@ -290,9 +290,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.8.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.5.0"
             },
-            "time": "2023-06-13T20:06:40+00:00"
+            "time": "2023-03-14T14:19:48+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -385,16 +385,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.21",
+            "version": "1.10.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5"
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
-                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578f4e70d117f9a90699324c555922800ac38d8c",
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c",
                 "shasum": ""
             },
             "require": {
@@ -443,7 +443,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-21T20:07:58+00:00"
+            "time": "2023-07-06T12:11:37+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -756,7 +756,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.0"
+        "php": ">=7.2"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -37,7 +37,7 @@ class Admin {
 
 		$manager->settings_api->register_fields(
 			'woographql_settings',
-			General::get_fields(),
+			General::get_fields()
 		);
 	}
 }

--- a/includes/class-core-schema-filters.php
+++ b/includes/class-core-schema-filters.php
@@ -120,7 +120,7 @@ class Core_Schema_Filters {
 
 		add_filter(
 			'woographql_cart_connection_definitions',
-			[ __CLASS__, 'skip_cart_item_connection' ],
+			[ __CLASS__, 'skip_cart_item_connection' ]
 		);
 	}
 

--- a/includes/connection/class-product-attributes.php
+++ b/includes/connection/class-product-attributes.php
@@ -37,7 +37,7 @@ class Product_Attributes {
 					'toType'         => 'LocalProductAttribute',
 					'fromFieldName'  => 'localAttributes',
 					'connectionArgs' => [],
-				],
+				]
 			)
 		);
 

--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -243,7 +243,7 @@ class Order extends Model {
 	protected function get_viewable_order_types() {
 		return apply_filters(
 			'woographql_viewable_order_types',
-			wc_get_order_types( 'view-orders' ),
+			wc_get_order_types( 'view-orders' )
 		);
 	}
 

--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -146,7 +146,7 @@ class Customer_Type {
 					},
 				],
 			],
-			$other_fields,
+			$other_fields
 		);
 	}
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,7 @@
 	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
 	<!-- Rules: Check PHP version compatibility -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.2-"/>
 
 	<!-- Rules: WordPress Coding Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
@@ -23,7 +23,7 @@
 	<rule ref="WordPress-Extra" />
 
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/wp-graphql-woocommerce.php
+++ b/wp-graphql-woocommerce.php
@@ -10,8 +10,8 @@
  * Domain Path: /languages
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * WC requires at least: 4.8.0
- * WC tested up to: 7.5.1
+ * WC requires at least: 7.5.0
+ * WC tested up to: 7.8.2
  * WPGraphQL requires at least: 1.14.0+
  * WPGraphQL-JWT-Authentication requires at least: 0.7.0+
  *


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR removes the usage of trailing commas, which throw a fatal error in PHP 7.2 and lower.

Branch is based off of https://github.com/wp-graphql/wp-graphql-woocommerce/pull/763, which should be merged first.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Audited with [WPGraphQL Coding Standards](https://github.com/AxeWP/WPGraphQL-Coding-Standards).

**Note**: This is not caught by PHPStan since our composer file is _built_ on 7.3 for our dev-deps to work.

Where has this been tested?
---------------------------

- WooGraphQL Version: 0.14.1
- WPGraphQL Version: 1.14.6
- WordPress Version: 6.2.2
- WooCommerce Version: 7.8.2
