### PR TITLE
fix: ProductVariation type made to inherit the Product interface.

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -66,6 +66,8 @@ wp-graphql wp-graphql-jwt-authentication \
 wp-graphql-woocommerce \
 --allow-root
 
+wp theme activate twentytwentyone --allow-root
+
 if ! wp config has GRAPHQL_JWT_AUTH_SECRET_KEY --allow-root; then
 	echo "Adding WPGraphQL-JWT-Authentication salt..."
     wp config set GRAPHQL_JWT_AUTH_SECRET_KEY 'test' --allow-root

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -72,6 +72,7 @@ modules:
       domain: '%WORDPRESS_DOMAIN%'
       adminEmail: '%ADMIN_EMAIL%'
       title: 'WooGraphQL Tests'
+      theme: 'twentytwentyone'
       plugins:
         - woocommerce/woocommerce.php
         - woocommerce-gateway-stripe/woocommerce-gateway-stripe.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     build:
       context: .
       args:
-        PHP_VERSION: ${PHP_VERSION:-7.3}
+        PHP_VERSION: ${PHP_VERSION:-8.0}
     volumes:
       - .:/var/www/html/wp-content/plugins/wp-graphql-woocommerce
       - ./codeception.dist.yml:/var/www/html/wp-content/plugins/wp-graphql-woocommerce/codeception.yml

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -74,10 +74,11 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 			return apply_filters(
 				'graphql_woocommerce_product_types',
 				[
-					'simple'   => 'SimpleProduct',
-					'variable' => 'VariableProduct',
-					'external' => 'ExternalProduct',
-					'grouped'  => 'GroupProduct',
+					'simple'    => 'SimpleProduct',
+					'variable'  => 'VariableProduct',
+					'external'  => 'ExternalProduct',
+					'grouped'   => 'GroupProduct',
+					'variation' => 'ProductVariation',
 				]
 			);
 		}

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -561,6 +561,10 @@ class Products {
 				'type'        => 'Boolean',
 				'description' => __( 'Limit result types to types supported by WooGraphQL.', 'wp-graphql-woocommerce' ),
 			],
+			'includeVariations'   => [
+				'type'        => 'Boolean',
+				'description' => __( 'Include variations in the result set.', 'wp-graphql-woocommerce' ),
+			],
 		];
 
 		if ( wc_tax_enabled() ) {
@@ -609,6 +613,10 @@ class Products {
 			'tag__in',
 			'tag__not_in',
 		];
+
+		if ( isset( $where_args['includeVariations'] ) && $where_args['includeVariations'] ) {
+			$query_args['post_type'] = [ 'product', 'product_variation' ];
+		}
 
 		$query_args = array_diff_key( $query_args, array_flip( $remove ) );
 

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -130,7 +130,7 @@ class Products {
 		$cross_sell_config = [
 			'fromFieldName' => 'crossSell',
 			'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-				$resolver = new Product_Connection_Resolver( $source, $args, $context, $info, 'product' );
+				$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 				$resolver->set_query_arg( 'post__in', $source->cross_sell_ids );
 				return $resolver->get_connection();
 			},
@@ -197,7 +197,7 @@ class Products {
 						'toType'        => 'ProductVariation',
 						'fromFieldName' => 'variations',
 						'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-							$attribute_meta_key = 'attribute_' . strtolower( preg_replace( '/([A-Z])/', '_$1', $source->taxonomyName ) );
+							$attribute_meta_key = 'attribute_' . strtolower( preg_replace( '/([A-Z])/', '_$1', $source->taxonomyName ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 							$meta_query         = [
 								'key'     => $attribute_meta_key,
 								'value'   => $source->slug,
@@ -254,12 +254,12 @@ class Products {
 			$config['resolve'] = static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 				$tax_query = [
 					[
-						'taxonomy'         => $source->taxonomyName, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						'operator'         => 'EXISTS',
-					]
+						'taxonomy' => $source->taxonomyName, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						'operator' => 'EXISTS',
+					],
 				];
 
-				$resolver  = new Product_Connection_Resolver( $source, $args, $context, $info );
+				$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 				$resolver->add_tax_query( $tax_query );
 
 				return $resolver->get_connection();
@@ -467,7 +467,7 @@ class Products {
 				'type'        => 'Boolean',
 				'description' => __( 'Limit result types to types supported by WooGraphQL.', 'wp-graphql-woocommerce' ),
 			],
-			'includeVariations'   => [
+			'includeVariations'  => [
 				'type'        => 'Boolean',
 				'description' => __( 'Include variations in the result set.', 'wp-graphql-woocommerce' ),
 			],

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -11,7 +11,7 @@ namespace WPGraphQL\WooCommerce\Connection;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
+use WPGraphQL\WooCommerce\Data\Connection\Product_Connection_Resolver;
 use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**
@@ -33,16 +33,8 @@ class Products {
 				[
 					'fromType' => 'Coupon',
 					'resolve'  => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-						add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-						remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
+						$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 						$resolver->set_query_arg( 'post__in', $source->product_ids );
-
-						// Change default ordering.
-						if ( ! in_array( 'orderby', array_keys( $resolver->get_query_args() ), true ) ) {
-							$resolver->set_query_arg( 'orderby', 'post__in' );
-						}
 
 						return $resolver->get_connection();
 					},
@@ -55,10 +47,7 @@ class Products {
 					'fromType'      => 'Coupon',
 					'fromFieldName' => 'excludedProducts',
 					'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-						add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-						remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
+						$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 						$resolver->set_query_arg( 'post__in', $source->excluded_product_ids );
 
 						// Change default ordering.
@@ -78,8 +67,7 @@ class Products {
 				[
 					'fromType'       => 'Product',
 					'fromFieldName'  => 'related',
-					'connectionArgs' => array_merge(
-						self::get_connection_args(),
+					'connectionArgs' => self::get_connection_args(
 						[
 							'shuffle' => [
 								'type'        => 'Boolean',
@@ -88,9 +76,7 @@ class Products {
 						]
 					),
 					'resolve'        => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-						add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-						remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
+						$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 
 						// Bypass randomization by default for pagination support.
 						if ( empty( $args['where']['shuffle'] ) ) {
@@ -105,11 +91,6 @@ class Products {
 						$related_ids = wc_get_related_products( $source->ID, $resolver->get_query_amount() );
 						$resolver->set_query_arg( 'post__in', $related_ids );
 
-						// Change default ordering.
-						if ( ! in_array( 'orderby', array_keys( $resolver->get_query_args() ), true ) ) {
-							$resolver->set_query_arg( 'orderby', 'post__in' );
-						}
-
 						return $resolver->get_connection();
 					},
 				]
@@ -121,16 +102,8 @@ class Products {
 					'fromType'      => 'Product',
 					'fromFieldName' => 'upsell',
 					'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-						add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-						remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
+						$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 						$resolver->set_query_arg( 'post__in', $source->upsell_ids );
-
-						// Change default ordering.
-						if ( ! in_array( 'orderby', array_keys( $resolver->get_query_args() ), true ) ) {
-							$resolver->set_query_arg( 'orderby', 'post__in' );
-						}
 
 						return $resolver->get_connection();
 					},
@@ -144,16 +117,8 @@ class Products {
 				[
 					'fromType' => 'GroupProduct',
 					'resolve'  => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-						add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-						remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
+						$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 						$resolver->set_query_arg( 'post__in', $source->grouped_ids );
-
-						// Change default ordering.
-						if ( ! in_array( 'orderby', array_keys( $resolver->get_query_args() ), true ) ) {
-							$resolver->set_query_arg( 'orderby', 'post__in' );
-						}
 
 						return $resolver->get_connection();
 					},
@@ -165,17 +130,8 @@ class Products {
 		$cross_sell_config = [
 			'fromFieldName' => 'crossSell',
 			'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-				add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-				$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-				remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
+				$resolver = new Product_Connection_Resolver( $source, $args, $context, $info, 'product' );
 				$resolver->set_query_arg( 'post__in', $source->cross_sell_ids );
-
-				// Change default ordering.
-				if ( ! in_array( 'orderby', array_keys( $resolver->get_query_args() ), true ) ) {
-					$resolver->set_query_arg( 'orderby', 'post__in' );
-				}
-
 				return $resolver->get_connection();
 			},
 		];
@@ -198,20 +154,11 @@ class Products {
 					'toType'        => 'ProductVariation',
 					'fromFieldName' => 'variations',
 					'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-						add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-						remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
+						$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 
 						$resolver->set_query_arg( 'post_parent', $source->ID );
 						$resolver->set_query_arg( 'post_type', 'product_variation' );
 						$resolver->set_query_arg( 'post__in', $source->variation_ids );
-
-						// Change default ordering.
-						if ( ! in_array( 'orderby', array_keys( $resolver->get_query_args() ), true ) ) {
-							$resolver->set_query_arg( 'orderby', 'post__in' );
-						}
-
-						$resolver = self::set_ordering_query_args( $resolver, $args );
 
 						return $resolver->get_connection();
 					},
@@ -232,13 +179,8 @@ class Products {
 						return null;
 					}
 
-					add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-					$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-					remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
+					$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 					$resolver->set_query_arg( 'p', $source->parent_id );
-
-					$resolver = self::set_ordering_query_args( $resolver, $args );
 
 					return $resolver->one_to_one()->get_connection();
 				},
@@ -255,30 +197,16 @@ class Products {
 						'toType'        => 'ProductVariation',
 						'fromFieldName' => 'variations',
 						'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-							global $wpdb;
-							add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product_variation' );
-							remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
-							// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 							$attribute_meta_key = 'attribute_' . strtolower( preg_replace( '/([A-Z])/', '_$1', $source->taxonomyName ) );
-							// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-							$variation_ids = $wpdb->get_col(
-								$wpdb->prepare(
-									"SELECT ID
-									FROM {$wpdb->prefix}posts
-									WHERE ID IN (SELECT post_id FROM {$wpdb->prefix}postmeta WHERE meta_key = %s AND meta_value = %s)
-									AND post_type = 'product_variation'",
-									$attribute_meta_key,
-									$source->slug
-								)
-							);
+							$meta_query         = [
+								'key'     => $attribute_meta_key,
+								'value'   => $source->slug,
+								'compare' => '=',
+							];
 
-							$variation_ids = ! empty( $variation_ids ) ? $variation_ids : [ '0' ];
-
-							$resolver->set_query_arg( 'post__in', $variation_ids );
-
-							$resolver = self::set_ordering_query_args( $resolver, $args );
+							$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
+							$resolver->set_query_arg( 'post_type', 'product_variation' );
+							$resolver->add_meta_query( $meta_query );
 
 							return $resolver->get_connection();
 						},
@@ -319,26 +247,20 @@ class Products {
 		$from_type = $config['fromType'];
 		if ( 'Product' === $to_type ) {
 			$config['connectionArgs'] = self::get_connection_args();
-			$config['queryClass']     = '\WC_Product_Query';
 		}
 
 		$taxonomies = self::get_product_connected_taxonomies();
 		if ( 'Product' === $to_type && in_array( $from_type, $taxonomies, true ) ) {
 			$config['resolve'] = static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-				add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-				$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-				remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
 				$tax_query = [
 					[
 						'taxonomy'         => $source->taxonomyName, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						'terms'            => [ $source->term_id ],
-						'field'            => 'term_id',
-						'include_children' => false,
-					],
+						'operator'         => 'EXISTS',
+					]
 				];
-				$resolver->set_query_arg( 'tax_query', $tax_query );
 
-				$resolver = self::set_ordering_query_args( $resolver, $args );
+				$resolver  = new Product_Connection_Resolver( $source, $args, $context, $info );
+				$resolver->add_tax_query( $tax_query );
 
 				return $resolver->get_connection();
 			};
@@ -359,33 +281,15 @@ class Products {
 				'fromType'       => 'RootQuery',
 				'toType'         => 'Product',
 				'fromFieldName'  => 'products',
-				'queryClass'     => '\WC_Product_Query',
 				'connectionArgs' => self::get_connection_args(),
 				'resolve'        => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-					add_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10, 3 );
-					$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'product' );
-					remove_filter( 'graphql_post_object_connection_args', [ self::class, 'bypass_get_args_sanitization' ], 10 );
-
-					$resolver = self::set_ordering_query_args( $resolver, $args );
+					$resolver = new Product_Connection_Resolver( $source, $args, $context, $info );
 
 					return $resolver->get_connection();
 				},
 			],
 			$args
 		);
-	}
-
-	/**
-	 * Bypass arg sanization in Post Object Connection Resolver.
-	 *
-	 * @param array                                                   $args                Sanitized GraphQL args passed to the resolver.
-	 * @param \WPGraphQL\Data\Connection\PostObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver.
-	 * @param array                                                   $all_args            array of arguments input in the field as part of the GraphQL query.
-
-	 * @return array
-	 */
-	public static function bypass_get_args_sanitization( $args, $connection_resolver, $all_args ) {
-		return $all_args;
 	}
 
 	/**
@@ -432,10 +336,12 @@ class Products {
 
 	/**
 	 * Returns array of where args.
+	 * 
+	 * @param array $extra_args  Extra connection args.
 	 *
 	 * @return array
 	 */
-	public static function get_connection_args(): array {
+	public static function get_connection_args( $extra_args = [] ): array {
 		$args = [
 			'slugIn'             => [
 				'type'        => [ 'list_of' => 'String' ],
@@ -574,7 +480,7 @@ class Products {
 			];
 		}
 
-		return array_merge( get_wc_cpt_connection_args(), $args );
+		return array_merge( get_wc_cpt_connection_args(), $args, $extra_args );
 	}
 
 	/**

--- a/includes/connection/class-variation-attributes.php
+++ b/includes/connection/class-variation-attributes.php
@@ -54,7 +54,7 @@ class Variation_Attributes {
 			[
 				'fromType'       => 'ProductVariation',
 				'toType'         => 'VariationAttribute',
-				'fromFieldName'  => 'attributes',
+				'fromFieldName'  => 'variationAttributes',
 				'connectionArgs' => [],
 				'resolve'        => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 					$resolver = new Variation_Attribute_Connection_Resolver();

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -41,7 +41,7 @@ class WC_Terms extends TermObjects {
 		// Loop through the allowed_taxonomies to register appropriate connections.
 		foreach ( $allowed_taxonomies as $tax_object ) {
 			foreach ( $wc_post_types as $post_type ) {
-				if ( 'product' === $post_type ) {
+				if ( 'product' === $post_type || 'product_variation' === $post_type ) {
 					continue;
 				}
 

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -161,7 +161,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		 * @var \WP_Post_Type
 		 */
 		$post_type_obj = get_post_type_object( 'product' );
-		    
+			
 		if ( empty( $this->args['where']['visibility'] ) && ! current_user_can( $post_type_obj->cap->read_private_posts ) ) {
 			if ( empty( $query_args['tax_query'] ) ) {
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -10,11 +10,13 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
+use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 use GraphQL\Error\InvariantViolation;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\WooCommerce\Model\Product;
 use WPGraphQL\WooCommerce\Model\Product_Variation;
 use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Product_Connection_Resolver
@@ -37,18 +39,6 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	protected $post_type;
 
 	/**
-	 * Holds default catalog visibility tax query.
-	 *
-	 * @var array
-	 */
-	public static $default_visibility = [
-		'taxonomy' => 'product_visibility',
-		'field'    => 'slug',
-		'terms'    => [ 'exclude-from-catalog', 'exclude-from-search' ],
-		'operator' => 'NOT IN',
-	];
-
-	/**
 	 * Refund_Connection_Resolver constructor.
 	 *
 	 * @param mixed                                $source    The object passed down from the previous level in the Resolve tree.
@@ -58,9 +48,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 */
 	public function __construct( $source, $args, $context, $info ) {
 		// @codingStandardsIgnoreLine.
-		$this->post_type = wc_graphql_ends_with( $info->fieldName, 'ariations' )
-			? 'product_variation'
-			: 'product';
+		$this->post_type = ['product'];
 
 		/**
 		 * Call the parent construct to setup class data
@@ -78,26 +66,6 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Given an ID, return the model for the entity or null
-	 *
-	 * @param integer $id  Node ID.
-	 *
-	 * @return \WPGraphQL\WooCommerce\Model\Product|\WPGraphQL\WooCommerce\Model\Product_Variation|null
-	 */
-	public function get_node_by_id( $id ) {
-		$post = get_post( $id );
-		if ( empty( $post ) ) {
-			return null;
-		}
-
-		if ( 'product_variation' === $post->post_type ) {
-			return new Product_Variation( $id );
-		}
-
-		return new Product( $id );
-	}
-
-	/**
 	 * Confirms the user has the privileges to query the products
 	 *
 	 * @return bool
@@ -107,31 +75,59 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * Creates query arguments array
+	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-
-		// Prepare for later use.
+		/**
+		 * Prepare for later use
+		 */
 		$last  = ! empty( $this->args['last'] ) ? $this->args['last'] : null;
 		$first = ! empty( $this->args['first'] ) ? $this->args['first'] : null;
 
-		// Set the $query_args based on various defaults and primary input $args.
+		$query_args = [];
 		/**
-		 * Get product post type.
-		 *
-		 * @var \WP_Post_Type $post_type_obj
+		 * Ignore sticky posts by default
 		 */
-		$post_type_obj = get_post_type_object( $this->post_type );
-		$query_args    = [
-			'post_type'           => $this->post_type,
-			'post_status'         => current_user_can( $post_type_obj->cap->edit_posts ) ? 'any' : 'publish',
-			'perm'                => 'readable',
-			'no_rows_found'       => true,
-			'fields'              => 'ids',
-			// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
-			'posts_per_page'      => min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1,
-			'ignore_sticky_posts' => true,
-		];
+		$query_args['ignore_sticky_posts'] = true;
+
+		/**
+		 * Don't calculate the total rows, it's not needed and can be expensive
+		 */
+		$query_args['no_found_rows'] = true;
+
+		/**
+		 * Set post_type
+		 */
+		$query_args['post_type'] = $this->post_type;
+
+		/**
+		 * Set the post_status
+		 */
+		$query_args['post_status'] = [ 'draft', 'pending', 'private', 'publish' ];
+		$query_args['perm']        = 'readable';
+
+		/**
+		 * Set posts_per_page the highest value of $first and $last, with a (filterable) max of 100
+		 */
+		$query_args['posts_per_page'] = $this->one_to_one ? 1 : min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1;
+
+		// set the graphql cursor args
+		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
+		$query_args['graphql_after_cursor']   = $this->get_after_offset();
+		$query_args['graphql_before_cursor']  = $this->get_before_offset();
+
+		/**
+		 * If the cursor offsets not empty,
+		 * ignore sticky posts on the query
+		 */
+		if ( ! empty( $this->get_after_offset() ) || ! empty( $this->get_after_offset() ) ) {
+			$query_args['ignore_sticky_posts'] = true;
+		}
+
+		/**
+		 * Pass the graphql $args to the WP_Query
+		 */
+		$query_args['graphql_args'] = $this->args;
 
 		/**
 		 * Collect the input_fields and sanitize them to prepare them for sending to the WP_Query
@@ -141,31 +137,28 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			$input_fields = $this->sanitize_input_fields( $this->args['where'] );
 		}
 
+		/**
+		 * Merge the input_fields with the default query_args
+		 */
 		if ( ! empty( $input_fields ) ) {
 			$query_args = array_merge( $query_args, $input_fields );
 		}
 
-		/**
-		 * Set the cursor args.
-		 *
-		 * @see \WPGraphQL\Data\Config::graphql_wp_query_cursor_pagination_support
-		 */
-		$query_args['graphql_after_cursor']   = $this->get_after_offset();
-		$query_args['graphql_before_cursor']  = $this->get_before_offset();
-		$query_args['graphql_cursor_compare'] = ! empty( $last ) ? '>' : '<';
 
 		/**
-		 * Pass the graphql $args to the WP_Query
+		 * If the query contains search default the results to
 		 */
-		$query_args['graphql_args'] = $this->args;
-
-		// Determine where we're at in the Graph and adjust the query context appropriately.
-
-		if ( isset( $query_args['post__in'] ) && empty( $query_args['post__in'] ) ) {
-			$query_args['post__in'] = [ '0' ];
+		if ( isset( $query_args['search'] ) && ! empty( $query_args['search'] ) ) {
+			/**
+			 * Don't order search results by title (causes funky issues with cursors)
+			 */
+			$query_args['search_orderby_title'] = false;
+			$query_args['orderby']              = 'date';
+			$query_args['order']                = isset( $last ) ? 'ASC' : 'DESC';
 		}
 
-		if ( ! current_user_can( $post_type_obj->cap->read_private_posts ) ) {
+		$post_type_obj = get_post_type_object( 'product' );		
+		if ( empty( $this->args['where']['visibility'] ) && ! current_user_can( $post_type_obj->cap->read_private_posts ) ) {
 			if ( empty( $query_args['tax_query'] ) ) {
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$query_args['tax_query'] = [];
@@ -183,7 +176,12 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			 */
 			$catalog_visibility = apply_filters(
 				'graphql_product_connection_catalog_visibility',
-				self::$default_visibility,
+				[
+					'taxonomy' => 'product_visibility',
+					'field'    => 'slug',
+					'terms'    => [ 'exclude-from-catalog', 'exclude-from-search' ],
+					'operator' => 'NOT IN',
+				],
 				$query_args,
 				$this->source,
 				$this->args,
@@ -194,62 +192,60 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			if ( ! empty( $catalog_visibility ) ) {
 				$query_args['tax_query'][] = $catalog_visibility;
 			}
+
+			if ( 1 < count( $query_args['tax_query'] ) ) {
+				$query_args['tax_query']['relation'] = 'AND';
+			}
 		}//end if
 
-		/**
-		 * If the query is a search, the source is not another Post, and the parent input $arg is not
-		 * explicitly set in the query, unset the $query_args['post_parent'] so the search
-		 * can search all posts, not just top level posts.
-		 */
-		if ( isset( $query_args['search'] ) && ! isset( $input_fields['parent'] ) ) {
-			unset( $query_args['post_parent'] );
-		}
-
-		/**
-		 * If there's no orderby params in the inputArgs, set order based on the first/last argument
-		 */
 		if ( empty( $query_args['orderby'] ) ) {
-			$query_args['order'] = ! empty( $last ) ? 'ASC' : 'DESC';
+			$query_args['orderby'] = 'date';
+			$query_args['order']   = isset( $last ) ? 'ASC' : 'DESC';
 		}
 
 		/**
-		 * Filter the $query_args to allow folks to customize queries programmatically.
-		 *
-		 * @param array       $query_args The args that will be passed to the WP_Query.
-		 * @param mixed       $source     The source that's passed down the GraphQL queries.
-		 * @param array       $args       The inputArgs on the field.
-		 * @param \WPGraphQL\AppContext  $context    The AppContext passed down the GraphQL tree.
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo passed down the GraphQL tree.
+		 * NOTE: Only IDs should be queried here as the Deferred resolution will handle
+		 * fetching the full objects, either from cache of from a follow-up query to the DB
 		 */
-		$query_args = apply_filters( 'graphql_product_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
+		$query_args['fields'] = 'ids';
 
-		return $query_args;
+		/**
+		 * Filter the $query args to allow folks to customize queries programmatically
+		 *
+		 * @param array                                $query_args The args that will be passed to the WP_Query
+		 * @param mixed                                $source     The source that's passed down the GraphQL queries
+		 * @param array                                $args       The inputArgs on the field
+		 * @param \WPGraphQL\AppContext                $context The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the GraphQL tree
+		 */
+		return apply_filters( 'graphql_product_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**
-	 * Executes query
+	 * {@inheritDoc}
 	 *
-	 * @return \WP_Query
-	 *
-	 * @throws \GraphQL\Error\InvariantViolation  Filter currently not supported for WP_Query.
+	 * @return \WC_Product_Query
 	 */
 	public function get_query() {
+		\codecept_debug( $this->query_args );
+		// Run query and remove hook.
 		$query = new \WP_Query( $this->query_args );
-
-		if ( isset( $query->query_vars['suppress_filters'] ) && true === $query->query_vars['suppress_filters'] ) {
-			throw new InvariantViolation( __( 'WP_Query has been modified by a plugin or theme to suppress_filters, which will cause issues with WPGraphQL Execution. If you need to suppress filters for a specific reason within GraphQL, consider registering a custom field to the WPGraphQL Schema with a custom resolver.', 'wp-graphql-woocommerce' ) );
-		}
 
 		return $query;
 	}
 
 	/**
-	 * Return an array of items from the query
-	 *
-	 * @return array
+	 * {@inheritDoc}
 	 */
-	public function get_ids() {
-		return ! empty( $this->query->posts ) ? $this->query->posts : [];
+	public function get_ids_from_query() {
+		$ids = $this->query->get_posts();
+
+		// If we're going backwards, we need to reverse the array.
+		if ( ! empty( $this->args['last'] ) ) {
+			$ids = array_reverse( $ids );
+		}
+
+		return $ids;
 	}
 
 	/**
@@ -281,18 +277,20 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function sanitize_input_fields( array $where_args ) {
-		$args = $this->sanitize_common_inputs( $where_args );
+		$query_args = Utils::map_input(
+			$this->sanitize_common_inputs( $where_args ),
+			[
+				'slugIn'          => 'post_name__in',
+				'minPrice'        => 'min_price',
+				'maxPrice'        => 'max_price',
+				'stockStatus'     => 'stock_status',
+				'status'          => 'post_status',
+				'search'          => 's',
+			]
+		);
 
-		if ( ! empty( $where_args['slugIn'] ) ) {
-			$args['post_name__in'] = $where_args['slugIn'];
-		}
-
-		if ( ! empty( $where_args['status'] ) ) {
-			$args['post_status'] = $where_args['status'];
-		}
-
-		if ( ! empty( $where_args['search'] ) ) {
-			$args['s'] = $where_args['search'];
+		if ( isset( $where_args['includeVariations'] ) && $where_args['includeVariations'] ) {
+			$query_args['post_type'] = [ 'product', 'product_variation' ];
 		}
 
 		$tax_query     = [];
@@ -329,7 +327,28 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 				// Set tax query config.
 				switch ( $field ) {
 					case 'type':
+						if ( 'variation' === $where_args[ $field ] ) {
+							$query_args['post_type'] = ['product_variation'];
+							break;
+						}
 					case 'typeIn':
+						if ( is_array( $where_args[ $field ] ) && in_array( 'variation', $where_args[ $field ], true ) ) {
+							$query_args['post_type'] = array_merge( $this->post_type, ['product_variation'] );
+						}
+						$tax_query[] = [
+							'relation' => 'OR',
+							[
+								'taxonomy' => 'product_type',
+								'field'    => 'slug',
+								'terms'    => $where_args[ $field ],
+							],
+							[
+								'taxonomy' => 'product_type',
+								'field'    => 'id',
+								'operator' => 'NOT EXISTS',
+							],
+						];
+						break;
 					case 'typeNotIn':
 					case 'category':
 					case 'categoryIn':
@@ -361,10 +380,6 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			}//end if
 		}//end foreach
 
-		if ( 1 < count( $tax_query ) ) {
-			$tax_query['relation'] = 'AND';
-		}
-
 		// Filter by attribute and term.
 		if ( ! empty( $where_args['attribute'] ) && ! empty( $where_args['attributeTerm'] ) ) {
 			if ( in_array( $where_args['attribute'], \wc_get_attribute_taxonomy_names(), true ) ) {
@@ -378,11 +393,11 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 
 		if ( empty( $where_args['type'] ) && empty( $where_args['typeIn'] ) && ! empty( $where_args['supportedTypesOnly'] )
 			&& true === $where_args['supportedTypesOnly'] ) {
-				$supported_types = array_keys( WP_GraphQL_WooCommerce::get_enabled_product_types() );
-				$terms           = ! empty( $where_args['typeNotIn'] )
-					? array_diff( $supported_types, $where_args['typeNotIn'] )
-					: $supported_types;
-			$tax_query[]         = [
+			$supported_types = array_keys( WP_GraphQL_WooCommerce::get_enabled_product_types() );
+			$terms           = ! empty( $where_args['typeNotIn'] )
+				? array_diff( $supported_types, $where_args['typeNotIn'] )
+				: $supported_types;
+			$tax_query[]     = [
 				'taxonomy' => 'product_type',
 				'field'    => 'slug',
 				'terms'    => $terms,
@@ -414,7 +429,6 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		}//end if
 
 		// Handle visibility.
-		$post_type_obj = get_post_type_object( $this->post_type );
 		if ( ! empty( $where_args['visibility'] ) ) {
 			switch ( $where_args['visibility'] ) {
 				case 'search':
@@ -453,43 +467,61 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		}//end if
 
 		// Process "taxonomyFilter".
+		$tax_filter_query = [];
 		if ( ! empty( $where_args['taxonomyFilter'] ) ) {
-			foreach ( $where_args['taxonomyFilter'] as $filter ) {
-				// Holds sub tax query parameters.
-				$sub_tax_query = [];
+			$taxonomy_query = $where_args['taxonomyFilter'];
+			$relation       = ! empty( $taxonomy_query['relation'] ) ? $taxonomy_query['relation'] : 'AND';
 
-				// Process parameters.
-				foreach ( $filter as $relation => $filter_args ) {
-					foreach ( $filter_args as $filter_arg ) {
-						$sub_tax_query[] = [
-							'taxonomy' => $filter_arg['taxonomy'],
-							'field'    => ! empty( $filter_arg['ids'] ) ? 'term_id' : 'slug',
-							'terms'    => ! empty( $filter_arg['ids'] )
-								? $filter_arg['ids']
-								: $filter_arg['terms'],
-							'operator' => ! empty( $filter_arg['operator'] )
-								? $filter_arg['operator']
-								: 'IN',
-						];
+			if ( ! empty( $taxonomy_query['filters'] ) ) {
+				$tax_groups = [];
+				foreach ( $taxonomy_query['filters'] as $filter ) {
+					$common = [
+						'taxonomy' => $filter['taxonomy'],
+						'operator' => ! empty( $filter['operator'] ) ? $filter['operator'] : 'IN',
+					];
+
+					if ( ! empty( $filter['ids'] ) ) {
+						$tax_groups[] = array_merge(
+							$common,
+							[
+								'field' => 'ID',
+								'terms' => $filter['ids'],
+							]
+						);
 					}
+
+					if ( ! empty( $filter['terms'] ) ) {
+						$tax_groups[] = array_merge(
+							$common,
+							[
+								'field' => 'slug',
+								'terms' => $filter['terms'],
+							]
+						);
+					}
+				}//end foreach
+
+				if ( ! empty( $tax_groups ) ) {
+					array_push( $tax_filter_query, ...$tax_groups );
 				}
 
-				// Set sub tax query relation.
-				if ( 1 > count( $sub_tax_query ) && ! empty( $relation ) ) {
-					$sub_tax_query['relation'] = strtoupper( $relation );
+				if ( 1 < count( $tax_filter_query ) ) {
+					$tax_filter_query['relation'] = $relation;
 				}
-
-				$tax_query[] = $sub_tax_query;
-			}//end foreach
+			}//end if
 		}//end if
 
-		if ( ! empty( $tax_query ) && 1 < count( $tax_query ) ) {
+		if ( ! empty( $tax_filter_query ) ) {
+			$tax_query[] = $tax_filter_query;
+		}
+
+		if ( 1 < count( $tax_query ) ) {
 			$tax_query['relation'] = 'AND';
 		}
 
 		if ( ! empty( $tax_query ) ) {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-			$args['tax_query'] = $tax_query;
+			$query_args['tax_query'] = $tax_query;
 		}
 
 		$meta_query = [];
@@ -502,24 +534,12 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		}
 
 		if ( ! empty( $where_args['minPrice'] ) || ! empty( $where_args['maxPrice'] ) ) {
-			$current_min_price = isset( $where_args['minPrice'] )
-				? floatval( $where_args['minPrice'] )
-				: 0;
-			$current_max_price = isset( $where_args['maxPrice'] )
-				? floatval( $where_args['maxPrice'] )
-				: PHP_INT_MAX;
+			$price_meta_args = [
+				'min_price' => isset( $where_args['minPrice'] ) ? floatval( $where_args['minPrice'] ) : 0,
+				'max_price' => isset( $where_args['maxPrice'] ) ? floatval( $where_args['maxPrice'] ) : PHP_INT_MAX
+			];
 
-			$meta_query[] = apply_filters(
-				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-				'woocommerce_get_min_max_price_meta_query',
-				[
-					'key'     => '_price',
-					'value'   => [ $current_min_price, $current_max_price ],
-					'compare' => 'BETWEEN',
-					'type'    => 'DECIMAL(10,' . wc_get_price_decimals() . ')',
-				],
-				$args
-			);
+			$meta_query[] = wc_get_min_max_price_meta_query( $price_meta_args );
 		}
 
 		if ( isset( $where_args['stockStatus'] ) ) {
@@ -532,15 +552,15 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 
 		if ( ! empty( $meta_query ) ) {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			$args['meta_query'] = $meta_query;
+			$query_args['meta_query'] = $meta_query;
 		}
 
 		if ( isset( $where_args['onSale'] ) && is_bool( $where_args['onSale'] ) ) {
-			$on_sale_key = false !== $where_args['onSale'] ? 'post__in' : 'post__not_in';
+			$on_sale_key = $where_args['onSale'] ? 'post__in' : 'post__not_in';
 			$on_sale_ids = \wc_get_product_ids_on_sale();
 
-			$on_sale_ids          = empty( $on_sale_ids ) ? [ 0 ] : $on_sale_ids;
-			$args[ $on_sale_key ] = $on_sale_ids;
+			$on_sale_ids                = empty( $on_sale_ids ) ? [ 0 ] : $on_sale_ids;
+			$query_args[ $on_sale_key ] = $on_sale_ids;
 		}
 
 		/**
@@ -556,18 +576,22 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		 * @param \GraphQL\Type\Definition\ResolveInfo $info       The ResolveInfo object
 		 * @param mixed|string|array      $post_type  The post type for the query
 		 */
-		$args = apply_filters(
+		$query_args = apply_filters_deprecated(
 			'graphql_map_input_fields_to_product_query',
-			$args,
-			$where_args,
-			$this->source,
-			$this->args,
-			$this->context,
-			$this->info,
-			$this->post_type
+			[
+				$query_args,
+				$where_args,
+				$this->source,
+				$this->args,
+				$this->context,
+				$this->info,
+				$this->post_type,
+			],
+			'0.9.0',
+			'graphql_map_input_fields_to_wp_query'
 		);
 
-		return $args;
+		return $query_args;
 	}
 
 	/**
@@ -578,6 +602,25 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	 * @return bool
 	 */
 	public function is_valid_offset( $offset ) {
-		return $this->is_valid_post_offset( $offset );
+		return (bool) wc_get_product( $offset );
+	}
+
+
+	public function add_meta_query( $value ) {
+		if ( ! empty( $this->query_args['meta_query'] ) ) {
+			$this->query_args['meta_query'] = $value;
+		} else {
+			$this->query_args['meta_query'][] = $value;
+			$this->query_args['meta_query']['relation'] = 'AND';
+		}
+	}
+
+	public function add_tax_query( $value ) {
+		if ( ! empty( $this->query_args['tax_query'] ) ) {
+			$this->query_args['tax_query'] = $value;
+		} else {
+			$this->query_args['tax_query'][] = $value;
+			$this->query_args['tax_query']['relation'] = 'AND';
+		}
 	}
 }

--- a/includes/data/connection/trait-wc-cpt-loader-common.php
+++ b/includes/data/connection/trait-wc-cpt-loader-common.php
@@ -8,6 +8,8 @@
 
 namespace WPGraphQL\WooCommerce\Data\Connection;
 
+use WPGraphQL\Utils\Utils;
+
 /**
  * Trait WC_CPT_Loader_Common
  *
@@ -41,30 +43,17 @@ trait WC_CPT_Loader_Common {
 	 * @return array
 	 */
 	public function sanitize_common_inputs( array $input ) {
-		$args = [];
-		if ( ! empty( $input['include'] ) ) {
-			$args['post__in'] = $input['include'];
-		}
-
-		if ( ! empty( $input['exclude'] ) ) {
-			$args['post__not_in'] = $input['exclude'];
-		}
-
-		if ( ! empty( $input['parent'] ) ) {
-			$args['post_parent'] = $input['parent'];
-		}
-
-		if ( ! empty( $input['parentIn'] ) ) {
-			$args['post_parent__in'] = $input['parentIn'];
-		}
-
-		if ( ! empty( $input['parentNotIn'] ) ) {
-			$args['post_parent__not_in'] = $input['parentNotIn'];
-		}
-
-		if ( ! empty( $input['search'] ) ) {
-			$args['s'] = $input['search'];
-		}
+		$args = Utils::map_input(
+			$input,
+			[
+				'include'     => 'post__in',
+				'exclude'     => 'post__not_in',
+				'parent'      => 'post_parent',
+				'parentIn'    => 'post_parent__in',
+				'parentNotIn' => 'post_parent__not_in',
+				'search'      => 's',
+			]
+		);
 
 		/**
 		 * Map the orderby inputArgs to the WP_Query

--- a/includes/model/class-product-variation.php
+++ b/includes/model/class-product-variation.php
@@ -191,7 +191,7 @@ class Product_Variation extends WC_Post {
 					return ! empty( $this->wc_data->get_height() ) ? $this->wc_data->get_height() : null;
 				},
 				'menuOrder'         => function () {
-					return ! empty( $this->wc_data->get_menu_order() ) ? $this->wc_data->get_menu_order() : null;
+					return $this->wc_data->get_menu_order();
 				},
 				'purchaseNote'      => function () {
 					return ! empty( $this->wc_data->get_purchase_note() ) ? $this->wc_data->get_purchase_note() : null;

--- a/includes/type/object/class-product-variation-type.php
+++ b/includes/type/object/class-product-variation-type.php
@@ -31,6 +31,7 @@ class Product_Variation_Type {
 					'NodeWithFeaturedImage',
 					'ContentNode',
 					'UniformResourceIdentifiable',
+					'Product'
 				],
 				'fields'      => [
 					'id'                => [

--- a/includes/type/object/class-product-variation-type.php
+++ b/includes/type/object/class-product-variation-type.php
@@ -31,7 +31,7 @@ class Product_Variation_Type {
 					'NodeWithFeaturedImage',
 					'ContentNode',
 					'UniformResourceIdentifiable',
-					'Product'
+					'Product',
 				],
 				'fields'      => [
 					'id'                => [

--- a/tests/_support/Factory/ProductFactory.php
+++ b/tests/_support/Factory/ProductFactory.php
@@ -198,7 +198,7 @@ class ProductFactory extends \WP_UnitTest_Factory_For_Thing {
 						'show_ui'      => false,
 						'query_var'    => true,
 						'rewrite'      => false,
-					]
+					],
 				)
 			);
 

--- a/tests/_support/Factory/ProductVariationFactory.php
+++ b/tests/_support/Factory/ProductVariationFactory.php
@@ -125,8 +125,8 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 
 		$variations = [];
 		foreach ( $variation_data as $data ) {
-			$args      = array_merge( $data, $args );
-			$variation = $this->create_and_get( $args, [ 'variation_class' => '\WC_Product_Variation' ] );
+			$variation_args = array_merge( $data, $args );
+			$variation      = $this->create_and_get( $variation_args, [ 'variation_class' => '\WC_Product_Variation' ] );
 
 			$variations[] = $variation->get_id();
 		}

--- a/tests/_support/Helper/GraphQLE2E.php
+++ b/tests/_support/Helper/GraphQLE2E.php
@@ -746,6 +746,8 @@ class GraphQLE2E extends \Codeception\Module {
 	 * @return void
 	 */
 	public function _setupStore() {
+		$wpdb = $this->getModule( 'WPDb' );
+		$wpdb->useTheme('twentytwentyone');
 		// Turn on tax calculations and store shipping countries. Important!
 		update_option( 'woocommerce_ship_to_countries', 'all' );
 		update_option( 'woocommerce_prices_include_tax', 'no' );

--- a/tests/acceptance/CustomerProceedsToCheckoutCept.php
+++ b/tests/acceptance/CustomerProceedsToCheckoutCept.php
@@ -83,7 +83,7 @@ $cart_url = $success['data']['updateSession']['customer']['cartUrl'];
 
 $I->wantTo( 'Go cart page and confirm empty and session not seen' );
 $I->amOnPage( '/cart' );
-$I->see( 'Your cart is currently empty!' );
+$I->seeElement('.wc-empty-cart-message');
 
 $I->wantTo( 'Authenticate with cart url and confirm page redirect' );
 $I->stopFollowingRedirects();

--- a/tests/acceptance/CustomerProceedsToCheckoutCept.php
+++ b/tests/acceptance/CustomerProceedsToCheckoutCept.php
@@ -83,7 +83,7 @@ $cart_url = $success['data']['updateSession']['customer']['cartUrl'];
 
 $I->wantTo( 'Go cart page and confirm empty and session not seen' );
 $I->amOnPage( '/cart' );
-$I->see( 'Your cart is currently empty.' );
+$I->see( 'Your cart is currently empty!' );
 
 $I->wantTo( 'Authenticate with cart url and confirm page redirect' );
 $I->stopFollowingRedirects();

--- a/tests/functional/ProtectedRouterCest.php
+++ b/tests/functional/ProtectedRouterCest.php
@@ -84,7 +84,7 @@ class ProtectedRouterCest {
 
 		$I->wantTo( 'Go checkout page and confirm session not seen' );
 		$I->amOnPage( '/checkout' );
-		$I->see( 'Your cart is currently empty.' );
+		$I->seeElement('.wc-empty-cart-message');
 
 		$I->wantTo( 'Authenticate with nonced url and confirm page redirect to checkout page' );
 		$I->stopFollowingRedirects();
@@ -99,8 +99,7 @@ class ProtectedRouterCest {
 
 		$I->wantTo( 'Confirm session has been loaded.' );
 		$I->see( 'Checkout' );
-		$I->see( 'Apply Coupon' );
-		$I->see( 'T-Shirt' );
+		$I->see( 't-shirt' );
 	}
 
 
@@ -172,7 +171,7 @@ class ProtectedRouterCest {
 
 		$I->wantTo( 'Go checkout page and confirm session not seen' );
 		$I->amOnPage( '/checkout' );
-		$I->see( 'Your cart is currently empty.' );
+		$I->seeElement('.wc-empty-cart-message');
 
 		$I->wantTo( 'Attempt to authenticate with expired url and confirm page redirect to checkout page' );
 		$I->stopFollowingRedirects();
@@ -210,7 +209,7 @@ class ProtectedRouterCest {
 
 		$I->wantTo( 'Go checkout page and confirm session not seen' );
 		$I->amOnPage( '/checkout' );
-		$I->see( 'Your cart is currently empty.' );
+		$I->seeElement('.wc-empty-cart-message');
 
 		$I->wantTo( 'Attempt to authenticate with nonced url and confirm page redirect to checkout page' );
 		$I->stopFollowingRedirects();

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -261,7 +261,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$this->assertQuerySuccessful( $response, $expected );
 
 		// Clear cache
-		$this->getModule( '\Helper\Wpunit' )->clear_loader_cache( 'wc_post' );
+		$this->clearLoaderCache( 'wc_post' );
 
 		/**
 		 * Assertion Two

--- a/tests/wpunit/ProductVariationQueriesTest.php
+++ b/tests/wpunit/ProductVariationQueriesTest.php
@@ -1,28 +1,98 @@
 <?php
 
-use GraphQLRelay\Relay;
+use WPGraphQL\Type\WPEnumType;
 
-class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
-	private $shop_manager;
-	private $customer;
-	private $products;
+class ProductVariationQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
 
-	public function setUp(): void {
-		parent::setUp();
+	public function expectedProductVariationData( $id ) {
+		$data = new WC_Product_Variation( $id );
 
-		$this->shop_manager   = $this->factory->user->create( [ 'role' => 'shop_manager' ] );
-		$this->customer       = $this->factory->user->create( [ 'role' => 'customer' ] );
-		$this->product_helper = $this->getModule( '\Helper\Wpunit' )->product();
-		$this->helper         = $this->getModule( '\Helper\Wpunit' )->product_variation();
-		$this->products       = $this->helper->create( $this->product_helper->create_variable() );
-
-		\WPGraphQL::clear_schema();
+		return [
+			$this->expectedField( 'productVariation.id', $this->toRelayId( 'product_variation', $id ) ),
+			$this->expectedField( 'productVariation.databaseId', $data->get_id() ),
+			$this->expectedField( 'productVariation.name', $data->get_name() ),
+			$this->expectedField( 'productVariation.date', $data->get_date_created()->__toString() ),
+			$this->expectedField(
+				'productVariation.modified',
+				! empty( $data->get_date_created() )
+					? $data->get_date_created()->__toString()
+					: self::IS_NULL
+			),
+			$this->expectedField( 'productVariation.description', ! empty( $data->get_description() ) ? $data->get_description() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.sku', $data->get_sku() ),
+			$this->expectedField( 'productVariation.price', ! empty( $data->get_price() ) ? \wc_graphql_price( $data->get_price() ) : self::IS_NULL ),
+			$this->expectedField( 'productVariation.regularPrice', ! empty( $data->get_regular_price() ) ? \wc_graphql_price( $data->get_regular_price() ) : self::IS_NULL ),
+			$this->expectedField( 'productVariation.salePrice', ! empty( $data->get_sale_price() ) ? \wc_graphql_price( $data->get_sale_price() ) : self::IS_NULL ),
+			$this->expectedField(
+				'productVariation.dateOnSaleFrom',
+				! empty( $data->get_date_on_sale_from() )
+					? $data->get_date_on_sale_from()
+					: self::IS_NULL
+			),
+			$this->expectedField(
+				'productVariation.dateOnSaleTo',
+				! empty( $data->get_date_on_sale_to() )
+					? $data->get_date_on_sale_to()
+					: self::IS_NULL
+			),
+			$this->expectedField( 'productVariation.onSale', $data->is_on_sale() ),
+			$this->expectedField( 'productVariation.status', $data->get_status() ),
+			$this->expectedField( 'productVariation.purchasable', ! empty( $data->is_purchasable() ) ? $data->is_purchasable() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.virtual', $data->is_virtual() ),
+			$this->expectedField( 'productVariation.downloadable', $data->is_downloadable() ),
+			$this->expectedField( 'productVariation.downloadLimit', ! empty( $data->get_download_limit() ) ? $data->get_download_limit() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.downloadExpiry', ! empty( $data->get_download_expiry() ) ? $data->get_download_expiry() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.taxStatus', strtoupper( $data->get_tax_status() ) ),
+			$this->expectedField(
+				'productVariation.taxClass',
+				! empty( $data->get_tax_class() )
+					? WPEnumType::get_safe_name( $data->get_tax_class() )
+					: 'STANDARD'
+			),
+			$this->expectedField(
+				'productVariation.manageStock',
+				! empty( $data->get_manage_stock() )
+					? WPEnumType::get_safe_name( $data->get_manage_stock() )
+					: self::IS_NULL
+			),
+			$this->expectedField( 'productVariation.stockQuantity', ! empty( $data->get_stock_quantity() ) ? $data->get_stock_quantity() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.stockStatus', ProductHelper::get_stock_status_enum( $data->get_stock_status() ) ),
+			$this->expectedField(
+				'productVariation.backorders',
+				! empty( $data->get_backorders() )
+					? WPEnumType::get_safe_name( $data->get_backorders() )
+					: self::IS_NULL
+			),
+			$this->expectedField( 'productVariation.backordersAllowed', $data->backorders_allowed() ),
+			$this->expectedField( 'productVariation.weight', ! empty( $data->get_weight() ) ? $data->get_weight() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.length', ! empty( $data->get_length() ) ? $data->get_length() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.width', ! empty( $data->get_width() ) ? $data->get_width() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.height', ! empty( $data->get_height() ) ? $data->get_height() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.menuOrder', $data->get_menu_order() ),
+			$this->expectedField( 'productVariation.purchaseNote', ! empty( $data->get_purchase_note() ) ? $data->get_purchase_note() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.shippingClass', ! empty( $data->get_shipping_class() ) ? $data->get_shipping_class() : self::IS_NULL ),
+			$this->expectedField(
+				'productVariation.catalogVisibility',
+				! empty( $data->get_catalog_visibility() )
+					? WPEnumType::get_safe_name( $data->get_catalog_visibility() )
+					: self::IS_NULL
+			),
+			$this->expectedField( 'productVariation.hasAttributes', ! empty( $data->has_attributes() ) ? $data->has_attributes() : self::IS_NULL ),
+			$this->expectedField( 'productVariation.type', WPEnumType::get_safe_name( $data->get_type() ) ),
+			$this->expectedField( 'productVariation.parent.node.id', $this->toRelayId( 'product', $data->get_parent_id() ) ),
+		];
 	}
 
 	// tests
 	public function testVariationQuery() {
-		$variation_id = $this->products['variations'][0];
-		$id           = $this->helper->to_relay_id( $variation_id );
+		// Create product variations.
+		$products     = $this->factory->product_variation->createSome(
+			$this->factory->product->createVariable()
+		);
+		$variation_id = $products['variations'][0];
+		$id           = $this->toRelayId( 'product_variation', $variation_id );
+
+		// Create query.
 		$query        = '
             query ($id: ID, $idType: ProductVariationIdTypeEnum) {
                 productVariation(id: $id, idType: $idType) {
@@ -78,20 +148,12 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'id'     => $id,
 			'idType' => 'ID',
 		];
-		$actual    = graphql(
-			[
-				'query'     => $query,
-				'variables' => $variables,
-			]
-		);
-		$expected  = [ 'data' => [ 'productVariation' => $this->helper->print_query( $variation_id ) ] ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = $this->expectedProductVariationData( $variation_id );
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
+		$this->assertQuerySuccessful( $response, $expected );
 
-		$this->assertEquals( $expected, $actual );
-
-		$this->getModule( '\Helper\Wpunit' )->clear_loader_cache( 'wc_post' );
+		$this->clearLoaderCache( 'wc_post' );
 
 		/**
 		 * Assertion Two
@@ -103,24 +165,22 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'idType' => 'DATABASE_ID',
 
 		];
-		$actual   = graphql(
-			[
-				'query'     => $query,
-				'variables' => $variables,
-			]
-		);
-		$expected = [ 'data' => [ 'productVariation' => $this->helper->print_query( $variation_id ) ] ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = $this->expectedProductVariationData( $variation_id );
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 
 	public function testVariationsQueryAndWhereArgs() {
-		$id         = $this->product_helper->to_relay_id( $this->products['product'] );
-		$product    = wc_get_product( $this->products['product'] );
-		$variations = $this->products['variations'];
+		// Create product variations.
+		$products     = $this->factory->product_variation->createSome(
+			$this->factory->product->createVariable()
+		);
+		$variation_id = $products['variations'][0];
+		$id           = $this->toRelayId( 'product', $products['product'] );
+		$product      = wc_get_product( $products['product'] );
+		$variations   = $products['variations'];
+		$prices       = $product->get_variation_prices( true );
 
 		$query = '
             query (
@@ -155,46 +215,31 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 		 *
 		 * Test query with no arguments
 		 */
-		wp_set_current_user( $this->shop_manager );
+		$this->loginAsShopManager();
 		$variables = [ 'id' => $id ];
-		$actual    = graphql(
-			[
-				'query'     => $query,
-				'variables' => $variables,
-			]
-		);
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedField( 'product.variations.nodes.#.id', $this->toRelayId( 'product_variation', $variations[0] ) ),
+			$this->expectedField( 'product.variations.nodes.#.id', $this->toRelayId( 'product_variation', $variations[1] ) ),
+			$this->expectedField( 'product.variations.nodes.#.id', $this->toRelayId( 'product_variation', $variations[2] ) ),
+			$this->expectedField(
+				'product.price',
+				\wc_graphql_price( current( $prices['price'] ) )
+					. ' - '
+					. \wc_graphql_price( end( $prices['price'] ) )
+			),
+			$this->expectedField(
+				'product.regularPrice',
+				\wc_graphql_price( current( $prices['regular_price'] ) )
+					. ' - '
+					. \wc_graphql_price( end( $prices['regular_price'] ) )
+			),
+			$this->expectedField( 'product.salePrice', self::IS_NULL )
+		];
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
+		$this->assertQuerySuccessful( $response, $expected );
 
-		// Get product data.
-		$product_data = $actual['data']['product'];
-
-		// Assert variations.
-		foreach ( $variations as $vid ) {
-			$this->assertTrue(
-				in_array(
-					[ 'id' => $this->helper->to_relay_id( $vid ) ],
-					$product_data['variations']['nodes'],
-					true
-				),
-				$this->helper->to_relay_id( $vid ) . ' not a variation of ' . $product->get_name()
-			);
-		}
-
-		// Assert prices.
-		$prices         = $this->product_helper->field( $this->products['product'], 'variation_prices', [ true ] );
-		$expected_price = \wc_graphql_price( current( $prices['price'] ) )
-			. ' - '
-			. \wc_graphql_price( end( $prices['price'] ) );
-		$this->assertTrue( $expected_price === $product_data['price'] );
-
-		$expected_price = \wc_graphql_price( current( $prices['regular_price'] ) )
-			. ' - '
-			. \wc_graphql_price( end( $prices['regular_price'] ) );
-		$this->assertTrue( $expected_price === $product_data['regularPrice'] );
-
-		$this->assertTrue( null === $product_data['salePrice'] );
+		$this->clearLoaderCache( 'wc_post' );
 
 		/**
 		 * Assertion Two
@@ -205,39 +250,26 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 			'id'       => $id,
 			'minPrice' => 15,
 		];
-		$actual    = graphql(
-			[
-				'query'     => $query,
-				'variables' => $variables,
-			]
-		);
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->not()->expectedField( 'product.variations.nodes.#.id', $this->toRelayId( 'product_variation', $variations[0] ) ),
+			$this->expectedField( 'product.variations.nodes.#.id', $this->toRelayId( 'product_variation', $variations[1] ) ),
+			$this->expectedField( 'product.variations.nodes.#.id', $this->toRelayId( 'product_variation', $variations[2] ) ),
+		];
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
-
-		// Get product data.
-		$product_data = $actual['data']['product'];
-
-		// Assert variations.
-		$filter = function( $id ) {
-			$variation = new WC_Product_Variation( $id );
-			return 15.00 <= floatval( $variation->get_price() );
-		};
-
-		foreach ( array_filter( $variations, $filter ) as $vid ) {
-			$this->assertTrue(
-				in_array(
-					[ 'id' => $this->helper->to_relay_id( $vid ) ],
-					$product_data['variations']['nodes'],
-					true
-				),
-				$this->helper->to_relay_id( $vid ) . ' not a variation of ' . $product->get_name()
-			);
-		}
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 
 	public function testProductVariationToMediaItemConnections() {
-		$id    = $this->helper->to_relay_id( $this->products['variations'][1] );
+		// Create product variations.
+		$products     = $this->factory->product_variation->createSome(
+			$this->factory->product->createVariable()
+		);
+		$variation_id = $products['variations'][1];
+		$id           = $this->toRelayId( 'product_variation', $variation_id );
+		$product      = wc_get_product( $variation_id );
+
+		// Create query.
 		$query = '
 			query ($id: ID!) {
 				productVariation(id: $id) {
@@ -250,35 +282,26 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 		';
 
 		$variables = [ 'id' => $id ];
-		$actual    = graphql(
-			[
-				'query'     => $query,
-				'variables' => $variables,
-			]
-		);
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
-			'data' => [
-				'productVariation' => [
-					'id'    => $id,
-					'image' => [
-						'id' => Relay::toGlobalId(
-							'post',
-							$this->helper->field( $this->products['variations'][1], 'image_id' )
-						),
-					],
-				],
-			],
+			$this->expectedField( 'productVariation.id', $id ),
+			$this->expectedField( 'productVariation.image.id', $this->toRelayId( 'post', $product->get_image_id() ) ),
 		];
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
-
-		$this->assertEquals( $expected, $actual );
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 
 	public function testProductVariationDownloads() {
-		$id = $this->helper->to_relay_id( $this->products['variations'][0] );
+		// Create product variations.
+		$products     = $products     = $this->factory->product_variation->createSome(
+			$this->factory->product->createVariable()
+		);
+		$variation_id = $products['variations'][0];
+		$id           = $this->toRelayId( 'product_variation', $variation_id );
+		$product      = wc_get_product( $variation_id );
+		$downloads    = (array) array_values( $product->get_downloads() );
 
+		// Create query.
 		$query = '
 			query ($id: ID!) {
 				productVariation(id: $id) {
@@ -298,24 +321,103 @@ class ProductVariationQueriesTest extends \Codeception\TestCase\WPTestCase {
 		';
 
 		$variables = [ 'id' => $id ];
-		$actual    = graphql(
-			[
-				'query'     => $query,
-				'variables' => $variables,
-			]
-		);
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
-			'data' => [
-				'productVariation' => [
-					'id'        => $id,
-					'downloads' => $this->helper->print_downloads( $this->products['variations'][0] ),
-				],
-			],
+			$this->expectedField( 'productVariation.id', $id ),
+			$this->expectedNode(
+				'productVariation.downloads',
+				[
+					$this->expectedField( 'name', $downloads[0]->get_name() ),
+					$this->expectedField( 'downloadId', $downloads[0]->get_id() ),
+					$this->expectedField( 'filePathType', $downloads[0]->get_type_of_file_path() ),
+					$this->expectedField( 'fileType', $downloads[0]->get_file_type() ),
+					$this->expectedField( 'fileExt', $downloads[0]->get_file_extension() ),
+					$this->expectedField( 'allowedFileType', $downloads[0]->is_allowed_filetype() ),
+					$this->expectedField( 'fileExists', $downloads[0]->file_exists() ),
+					$this->expectedField( 'file', $downloads[0]->get_file() ),
+				]
+			)
 		];
 
-		// use --debug flag to view.
-		codecept_debug( $actual );
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 
-		$this->assertEquals( $expected, $actual );
+	public function testProductsQueriesWithVariations() {
+		// Create noise products.
+		$product_id   = $this->factory->product->createVariable(
+			[
+				'attribute_data' => [ $this->factory->product->createAttribute( 'print', [ 'polka-dot', 'stripe', 'flames' ] ) ],
+			],
+		);
+		$variation_id = $this->factory->product_variation->create(
+			[
+				'parent_id'     => $product_id,
+				'attributes'    => [
+					'pattern' => 'polka-dot',
+				],
+				'image_id'      => null,
+				'regular_price' => 10,
+			]
+		);
+
+
+		$other_variation_id = $this->factory->product_variation->create(
+			[
+				'parent_id'     => $product_id,
+				'attributes'    => [
+					'pattern' => 'stripe',
+				],
+				'image_id'      => null,
+				'regular_price' => 10,
+			]
+		);
+
+		$query = '
+			query ( $type: ProductTypesEnum, $typeIn: [ProductTypesEnum], $includeVariations: Boolean ) {
+				products( where: { type: $type, typeIn: $typeIn includeVariations: $includeVariations } ) {
+					nodes {
+						id
+					}
+				}
+			}
+		';
+
+		/**
+		 * Assert default results without "type", or "typeIn" excludes product variations.
+		 */
+		$response = $this->graphql( compact( 'query' ) );
+		$expected = [
+			$this->expectedField( 'products.nodes.0.id', $this->toRelayId( 'product', $product_id ) ),
+			$this->not()->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product_variation', $variation_id ) ),
+			$this->not()->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product_variation', $other_variation_id ) ),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		/**
+		 * Assert result with "type" set to "VARIATION" only return variations.
+		 */
+		$variables = [ 'type' => 'VARIATION' ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->not()->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product', $product_id ) ),
+			$this->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product_variation', $variation_id ) ),
+			$this->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product_variation', $other_variation_id ) ),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		/**
+		 * Assert result with "typeIn" set to "VARIATION" & "VARIATION" products and variations are returned.
+		 */
+		$variables = [ 'includeVariations' => true ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product', $product_id ) ),
+			$this->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product_variation', $variation_id ) ),
+			$this->expectedField( 'products.nodes.#.id', $this->toRelayId( 'product_variation', $other_variation_id ) ),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
 	}
 }

--- a/tests/wpunit/VariationAttributeQueriesTest.php
+++ b/tests/wpunit/VariationAttributeQueriesTest.php
@@ -86,7 +86,7 @@ class VariationAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCas
             query fromVariationQuery( $id: ID! ) {
                 productVariation( id: $id ) {
                     id
-                    attributes {
+                    variationAttributes {
                         nodes {
                             id
                             attributeId
@@ -107,7 +107,7 @@ class VariationAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCas
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
 			$this->expectedField( 'productVariation.id', $this->toRelayId( 'product_variation', $variation_id ) ),
-			$this->expectedObject( 'productVariation.attributes', $this->expectedAttributes( $variation_id ) ),
+			$this->expectedObject( 'productVariation.variationAttributes', $this->expectedAttributes( $variation_id ) ),
 		];
 
 		$this->assertQuerySuccessful( $response, $expected );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Add support for querying variations alongside products.
- `ProductVariation.attributes` renamed to `ProductVariation.variationAttributes` to prevent collision with the `Product.attributes` field.
- **ProductConnectionResolver** class no longer deprecated.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
