### PR TITLE
fix: Cart_Mutation:prepare_attributes made public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH "$PATH:~/.composer/vendor/bin"
 # Install wp-browser globally
 RUN composer global require --optimize-autoloader \
 	wp-cli/wp-cli-bundle:* \
-    lucatume/wp-browser \
+    lucatume/wp-browser:^3.1 \
     codeception/module-asserts:* \
     codeception/module-cli:*  \
     codeception/module-db:*  \

--- a/bin/_lib.sh
+++ b/bin/_lib.sh
@@ -64,7 +64,6 @@ install_local_test_library() {
 	composer install
 	composer require --dev \
 		lucatume/wp-browser:^3.1 \
-		codeception/codeception:^4.2 \
 		symfony/finder:* \
 		codeception/lib-asserts:^1.0 \
 		codeception/module-asserts:^1.3.1 \
@@ -97,7 +96,6 @@ remove_local_test_library() {
 	# Remove testing library dependencies.
 	composer remove --dev wp-graphql/wp-graphql-testcase \
 		codeception/module-asserts \
-		codeception/codeception \
 		codeception/lib-asserts \
 		symfony/finder \
 		codeception/module-rest \

--- a/composer.lock
+++ b/composer.lock
@@ -907,16 +907,16 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
                 "shasum": ""
             },
             "require": {
@@ -925,7 +925,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -966,7 +966,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -982,7 +982,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",

--- a/includes/data/mutation/class-cart-mutation.php
+++ b/includes/data/mutation/class-cart-mutation.php
@@ -76,7 +76,7 @@ class Cart_Mutation {
 	 *
 	 * @throws \GraphQL\Error\UserError  Invalid cart attribute provided.
 	 */
-	private static function prepare_attributes( $product_id, array $variation_data = [] ) {
+	public static function prepare_attributes( $product_id, array $variation_data = [] ) {
 		$product = wc_get_product( $product_id );
 
 		// Bail if bad product ID.


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Makes the `prepare_attributes` of the **Cart_Mutation** class a public function so it can be used in WooGraphQL Pro and other mutations utilizing the cart functionality.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
