### PR TITLE
fix: VariationAttribute now sourcing value as Term slug for global attributes

### DIFF
--- a/includes/data/connection/class-variation-attribute-connection-resolver.php
+++ b/includes/data/connection/class-variation-attribute-connection-resolver.php
@@ -101,7 +101,7 @@ class Variation_Attribute_Connection_Resolver {
 					'id'          => $id,
 					'attributeId' => $term->term_id,
 					'name'        => $term->taxonomy,
-					'value'       => $term->name,
+					'value'       => $term->slug,
 				];
 			}
 		}//end foreach


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
`VariationAttribute` type is now getting the `value` field from the term slug for global attributes for proper comparison with the `ProductAttribute` type `value` field.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
