### PR TITLE
feat: "found" field added to the Products Connection types

### DIFF
--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -281,8 +281,11 @@ class Products {
 	public static function get_connection_fields(): array {
 		return [
 			'found' => [
-				'type'        => 'Number',
+				'type'        => 'Integer',
 				'description' => __( 'Total products founds', 'wp-graphql-woocommerce' ),
+				'resolve'     => static function ( $source ) {
+					return ! empty( $source['pageInfo']['found'] ) ? $source['pageInfo']['found'] : null;
+				},
 			],
 		];
 	}

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -87,11 +87,6 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		$query_args['ignore_sticky_posts'] = true;
 
 		/**
-		 * Don't calculate the total rows, it's not needed and can be expensive
-		 */
-		$query_args['no_found_rows'] = true;
-
-		/**
 		 * Set post_type
 		 */
 		$query_args['post_type'] = $this->post_type;
@@ -117,9 +112,11 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		/**
 		 * If the cursor offsets not empty,
 		 * ignore sticky posts on the query
+		 * and don't count the total number of posts
 		 */
-		if ( ! empty( $this->get_after_offset() ) || ! empty( $this->get_after_offset() ) ) {
+		if ( ! empty( $this->get_after_offset() ) || ! empty( $this->get_before_offset() ) ) {
 			$query_args['ignore_sticky_posts'] = true;
+			$query_args['no_found_rows']       = true;
 		}
 
 		/**
@@ -656,5 +653,15 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		}
 
 		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_page_info() {
+		$page_info          = parent::get_page_info();
+		$page_info['found'] = $this->query->found_posts;
+
+		return $page_info;
 	}
 }

--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -396,6 +396,9 @@ class Product extends WC_Post {
 					'soldIndividually'  => function () {
 						return $this->wc_data->is_sold_individually();
 					},
+					'lowStockAmount'    => function () {
+						return ! empty( $this->wc_data->get_low_stock_amount() ) ? $this->wc_data->get_low_stock_amount() : null;
+					},
 					'weight'            => function () {
 						return ! empty( $this->wc_data->get_weight() ) ? $this->wc_data->get_weight() : null;
 					},

--- a/includes/type/interface/class-inventoried-product.php
+++ b/includes/type/interface/class-inventoried-product.php
@@ -51,6 +51,10 @@ class Inventoried_Product {
 				'type'        => 'ManageStockEnum',
 				'description' => __( 'If product manage stock', 'wp-graphql-woocommerce' ),
 			],
+			'lowStockAmount'    => [
+				'type'        => 'Int',
+				'description' => __( 'Low stock amount', 'wp-graphql-woocommerce' ),
+			],
 			'stockQuantity'     => [
 				'type'        => 'Int',
 				'description' => __( 'Number of items available for sale', 'wp-graphql-woocommerce' ),

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -29,7 +29,7 @@ class Root_Query {
 		register_graphql_fields(
 			'RootQuery',
 			[
-				'cart'                 => [
+				'cart'             => [
 					'type'        => 'Cart',
 					'args'        => [
 						'recalculateTotals' => [
@@ -52,7 +52,7 @@ class Root_Query {
 						return $cart;
 					},
 				],
-				'cartItem'             => [
+				'cartItem'         => [
 					'type'        => 'CartItem',
 					'args'        => [
 						'key' => [
@@ -69,7 +69,7 @@ class Root_Query {
 						return $item;
 					},
 				],
-				'cartFee'              => [
+				'cartFee'          => [
 					'type'        => 'CartFee',
 					'args'        => [
 						'id' => [
@@ -88,7 +88,7 @@ class Root_Query {
 						return $fees[ $fee_id ];
 					},
 				],
-				'coupon'               => [
+				'coupon'           => [
 					'type'        => 'Coupon',
 					'description' => __( 'A coupon object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -146,7 +146,7 @@ class Root_Query {
 						return Factory::resolve_crud_object( $coupon_id, $context );
 					},
 				],
-				'customer'             => [
+				'customer'         => [
 					'type'        => 'Customer',
 					'description' => __( 'A customer object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -194,7 +194,7 @@ class Root_Query {
 						return Factory::resolve_session_customer();
 					},
 				],
-				'order'                => [
+				'order'            => [
 					'type'        => 'Order',
 					'description' => __( 'A order object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -272,7 +272,7 @@ class Root_Query {
 						return Factory::resolve_crud_object( $order_id, $context );
 					},
 				],
-				'productVariation'     => [
+				'productVariation' => [
 					'type'        => 'ProductVariation',
 					'description' => __( 'A product variation object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -318,7 +318,7 @@ class Root_Query {
 						return Factory::resolve_crud_object( $variation_id, $context );
 					},
 				],
-				'refund'               => [
+				'refund'           => [
 					'type'        => 'Refund',
 					'description' => __( 'A refund object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -399,7 +399,7 @@ class Root_Query {
 						return Factory::resolve_crud_object( $refund_id, $context );
 					},
 				],
-				'shippingMethod'       => [
+				'shippingMethod'   => [
 					'type'        => 'ShippingMethod',
 					'description' => __( 'A shipping method object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -434,7 +434,7 @@ class Root_Query {
 						return Factory::resolve_shipping_method( $method_id );
 					},
 				],
-				'taxRate'              => [
+				'taxRate'          => [
 					'type'        => 'TaxRate',
 					'description' => __( 'A tax rate object', 'wp-graphql-woocommerce' ),
 					'args'        => [
@@ -469,7 +469,17 @@ class Root_Query {
 						return Factory::resolve_tax_rate( $rate_id, $context );
 					},
 				],
-				'allowedCountries'     => [
+				'countries'        => [
+					'type'        => [ 'list_of' => 'CountriesEnum' ],
+					'description' => __( 'Countries', 'wp-graphql-woocommerce' ),
+					'resolve'     => static function () {
+						$wc_countries = new \WC_Countries();
+						$countries    = $wc_countries->get_countries();
+
+						return array_keys( $countries );
+					},
+				],
+				'allowedCountries' => [
 					'type'        => [ 'list_of' => 'CountriesEnum' ],
 					'description' => __( 'Countries that the store sells to', 'wp-graphql-woocommerce' ),
 					'resolve'     => static function () {
@@ -479,7 +489,7 @@ class Root_Query {
 						return array_keys( $countries );
 					},
 				],
-				'allowedCountryStates' => [
+				'countryStates'    => [
 					'type'        => [ 'list_of' => 'CountryState' ],
 					'args'        => [
 						'country' => [
@@ -535,10 +545,11 @@ class Root_Query {
 				'RootQuery',
 				$field_name,
 				[
-					'type'        => $type_name,
+					'type'              => $type_name,
 					/* translators: Product type slug */
-					'description' => sprintf( __( 'A %s product object', 'wp-graphql-woocommerce' ), $type_key ),
-					'args'        => [
+					'description'       => sprintf( __( 'A %s product object', 'wp-graphql-woocommerce' ), $type_key ),
+					'deprecationReason' => 'Use "product" instead.',
+					'args'              => [
 						'id'     => [
 							'type'        => 'ID',
 							'description' => sprintf(
@@ -552,7 +563,7 @@ class Root_Query {
 							'description' => __( 'Type of ID being used identify product', 'wp-graphql-woocommerce' ),
 						],
 					],
-					'resolve'     => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $type_key, $unsupported_type_enabled ) {
+					'resolve'           => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $type_key, $unsupported_type_enabled ) {
 						$id      = isset( $args['id'] ) ? $args['id'] : null;
 						$id_type = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 

--- a/tests/wpunit/ConnectionPaginationTest.php
+++ b/tests/wpunit/ConnectionPaginationTest.php
@@ -149,6 +149,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 		$query = '
 			query ($first: Int, $last: Int, $after: String, $before: String) {
 				products(first: $first, last: $last, after: $after, before: $before) {
+					found
 					nodes {
 						databaseId
                     }
@@ -170,6 +171,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 		$variables = [ 'first' => 2 ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
+			$this->expectedField( 'products.found', 5 ),
 			$this->expectedField( 'products.pageInfo.hasPreviousPage', false ),
 			$this->expectedField( 'products.pageInfo.hasNextPage', true ),
 			$this->expectedField( 'products.pageInfo.startCursor', $this->toCursor( $products[0] ) ),
@@ -191,6 +193,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 		];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
+			$this->expectedField( 'products.found', self::IS_NULL ),
 			$this->expectedField( 'products.pageInfo.hasPreviousPage', true ),
 			$this->expectedField( 'products.pageInfo.hasNextPage', false ),
 			$this->expectedField( 'products.pageInfo.startCursor', $this->toCursor( $products[2] ) ),
@@ -210,6 +213,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 		$variables = [ 'last' => 2 ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
+			$this->expectedField( 'products.found', 5 ),
 			$this->expectedField( 'products.pageInfo.hasPreviousPage', true ),
 			$this->expectedField( 'products.pageInfo.hasNextPage', false ),
 			$this->expectedField( 'products.pageInfo.startCursor', $this->toCursor( $products[3] ) ),
@@ -231,6 +235,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 		];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
+			$this->expectedField( 'products.found', self::IS_NULL ),
 			$this->expectedField( 'products.pageInfo.hasPreviousPage', true ),
 			$this->expectedField( 'products.pageInfo.hasNextPage', true ),
 			$this->expectedField( 'products.pageInfo.startCursor', $this->toCursor( $products[1] ) ),

--- a/tests/wpunit/RootQueriesTest.php
+++ b/tests/wpunit/RootQueriesTest.php
@@ -1,6 +1,29 @@
 <?php
 
 class RootQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
+	public function testBillingCountriesQuery() {
+		// Create shipping zones and shipping rates.
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', [ 'US', 'CA' ] );
+
+		// Create query
+		$query = '
+			query {
+				countries
+			}
+		';
+
+		$response = $this->graphql( compact( 'query' ) );
+		$expected = [
+			$this->expectedField( 'countries.#', 'US' ),
+			$this->expectedField( 'countries.#', 'CA' ),
+			$this->expectedField( 'countries.#', 'GB' ),
+			$this->expectedField( 'countries.#', 'JP' ),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+	}
+
 	public function testShippingCountriesQuery() {
 		// Create shipping zones and shipping rates.
 		update_option( 'woocommerce_allowed_countries', 'specific' );
@@ -31,7 +54,7 @@ class RootQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTe
 		// Create query
 		$query = '
 			query ($country: CountriesEnum!) {
-				allowedCountryStates(country: $country) {
+				countryStates(country: $country) {
 					name
 					code
 				}
@@ -42,14 +65,14 @@ class RootQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTe
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
 			$this->expectedObject(
-				'allowedCountryStates.#',
+				'countryStates.#',
 				[
 					$this->expectedField( 'name', 'Alaska' ),
 					$this->expectedField( 'code', 'AL' ),
 				]
 			),
 			$this->expectedObject(
-				'allowedCountryStates.#',
+				'countryStates.#',
 				[
 					$this->not()->expectedField( 'name', 'Ontario' ),
 					$this->not()->expectedField( 'code', 'ON' ),
@@ -63,14 +86,14 @@ class RootQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTe
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = [
 			$this->expectedObject(
-				'allowedCountryStates.#',
+				'countryStates.#',
 				[
 					$this->expectedField( 'name', 'Ontario' ),
 					$this->expectedField( 'code', 'ON' ),
 				]
 			),
 			$this->expectedObject(
-				'allowedCountryStates.#',
+				'countryStates.#',
 				[
 					$this->not()->expectedField( 'name', 'Alaska' ),
 					$this->not()->expectedField( 'code', 'AL' ),


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Renames `allowedCountryStates` query to `countryStates`.
- Adds `countries` query for get a complete list all countries not just the one the store ships to.
- Adds the connection field `found` the product connections see example usage below

```graphql
{
  products(first: 20) {
    found
    pageInfo {
      endCursor
    }
    nodes {
      id
    }
  }
}
```
The `found` field should only be resolved on the initial query from a connection without `after` or `before` cursors and will return null when cursors are provided. See screenshots below for output examples.
![image](https://github.com/wp-graphql/wp-graphql-woocommerce/assets/13604318/181f28ea-e6c7-422e-90ff-65e62d872cd0)
![image](https://github.com/wp-graphql/wp-graphql-woocommerce/assets/13604318/8f56e4dc-2b76-44ed-9409-b6d810e01df3)



Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
