### PR TITLE
fix: paymentMethod fields no longer throw for guest users

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.8.1",
+            "version": "v6.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26"
+                "reference": "f03270e63eaccf3019ef0f32849c497385774e11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5dbc8959427416b8ee09a100d7a8588c00fb2e26",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f03270e63eaccf3019ef0f32849c497385774e11",
+                "reference": "f03270e63eaccf3019ef0f32849c497385774e11",
                 "shasum": ""
             },
             "require": {
@@ -65,9 +65,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.8.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.9.0"
             },
-            "time": "2023-07-14T18:33:00+00:00"
+            "time": "2023-10-05T00:24:42+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -228,6 +228,10 @@ class Customer_Type {
 							return array_values( \WC_Payment_Tokens::get_customer_tokens( $source->ID ) );
 						}
 
+						if ( get_current_user_id() === 0 ) {
+							return [];
+						}
+
 						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
 					},
 				],
@@ -244,6 +248,10 @@ class Customer_Type {
 							);
 						}
 
+						if ( get_current_user_id() === 0 ) {
+							return [];
+						}
+
 						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
 					},
 				],
@@ -258,6 +266,10 @@ class Customer_Type {
 									return 'eCheck' === $token->get_type();
 								}
 							);
+						}
+
+						if ( get_current_user_id() === 0 ) {
+							return [];
 						}
 
 						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );

--- a/tests/wpunit/CollectionStatsQueryTest.php
+++ b/tests/wpunit/CollectionStatsQueryTest.php
@@ -67,7 +67,7 @@ class CollectionStatsQueryTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
                 'collectionStats.attributeCounts', 
                 [
                     $this->expectedField('slug', 'PA_COLOR' ),
-                    $this->expectedField('label', 'pa_color' ),
+                    $this->expectedField('label', 'color' ),
                     $this->expectedField('name', 'color' ),
                     $this->expectedNode(
                         'terms',

--- a/tests/wpunit/CollectionStatsQueryTest.php
+++ b/tests/wpunit/CollectionStatsQueryTest.php
@@ -67,7 +67,7 @@ class CollectionStatsQueryTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
                 'collectionStats.attributeCounts', 
                 [
                     $this->expectedField('slug', 'PA_COLOR' ),
-                    $this->expectedField('label', 'color' ),
+                    $this->expectedField('label', 'pa_color' ),
                     $this->expectedField('name', 'color' ),
                     $this->expectedNode(
                         'terms',

--- a/vendor-prefixed/firebase/php-jwt/src/BeforeValidException.php
+++ b/vendor-prefixed/firebase/php-jwt/src/BeforeValidException.php
@@ -8,6 +8,17 @@
 
 namespace WPGraphQL\WooCommerce\Vendor\Firebase\JWT;
 
-class BeforeValidException extends \UnexpectedValueException
+class BeforeValidException extends \UnexpectedValueException implements JWTExceptionWithPayloadInterface
 {
+    private object $payload;
+
+    public function setPayload(object $payload): void
+    {
+        $this->payload = $payload;
+    }
+
+    public function getPayload(): object
+    {
+        return $this->payload;
+    }
 }

--- a/vendor-prefixed/firebase/php-jwt/src/ExpiredException.php
+++ b/vendor-prefixed/firebase/php-jwt/src/ExpiredException.php
@@ -8,6 +8,17 @@
 
 namespace WPGraphQL\WooCommerce\Vendor\Firebase\JWT;
 
-class ExpiredException extends \UnexpectedValueException
+class ExpiredException extends \UnexpectedValueException implements JWTExceptionWithPayloadInterface
 {
+    private object $payload;
+
+    public function setPayload(object $payload): void
+    {
+        $this->payload = $payload;
+    }
+
+    public function getPayload(): object
+    {
+        return $this->payload;
+    }
 }

--- a/vendor-prefixed/firebase/php-jwt/src/JWT.php
+++ b/vendor-prefixed/firebase/php-jwt/src/JWT.php
@@ -159,23 +159,29 @@ class JWT
         // Check the nbf if it is defined. This is the time that the
         // token can actually be used. If it's not yet that time, abort.
         if (isset($payload->nbf) && floor($payload->nbf) > ($timestamp + static::$leeway)) {
-            throw new BeforeValidException(
+            $ex = new BeforeValidException(
                 'Cannot handle token with nbf prior to ' . \date(DateTime::ISO8601, (int) $payload->nbf)
             );
+            $ex->setPayload($payload);
+            throw $ex;
         }
 
         // Check that this token has been created before 'now'. This prevents
         // using tokens that have been created for later use (and haven't
         // correctly used the nbf claim).
         if (!isset($payload->nbf) && isset($payload->iat) && floor($payload->iat) > ($timestamp + static::$leeway)) {
-            throw new BeforeValidException(
+            $ex = new BeforeValidException(
                 'Cannot handle token with iat prior to ' . \date(DateTime::ISO8601, (int) $payload->iat)
             );
+            $ex->setPayload($payload);
+            throw $ex;
         }
 
         // Check if this token has expired.
         if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
-            throw new ExpiredException('Expired token');
+            $ex = new ExpiredException('Expired token');
+            $ex->setPayload($payload);
+            throw $ex;
         }
 
         return $payload;

--- a/vendor-prefixed/firebase/php-jwt/src/JWTExceptionWithPayloadInterface.php
+++ b/vendor-prefixed/firebase/php-jwt/src/JWTExceptionWithPayloadInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @license BSD-3-Clause
+ *
+ * Modified by Geoff Taylor using Strauss.
+ * @see https://github.com/BrianHenryIE/strauss
+ */
+namespace WPGraphQL\WooCommerce\Vendor\Firebase\JWT;
+
+interface JWTExceptionWithPayloadInterface
+{
+    /**
+     * Get the payload that caused this exception.
+     *
+     * @return object
+     */
+    public function getPayload(): object;
+
+    /**
+     * Get the payload that caused this exception.
+     *
+     * @param object $payload
+     * @return void
+     */
+    public function setPayload(object $payload): void;
+}


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Prevents query from throw if guests is query payment method fields.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
