### PR TITLE
fix: ProductAttributeEnum given default value, if no product attributes exist

### DIFF
--- a/includes/type/enum/class-product-attribute-enum.php
+++ b/includes/type/enum/class-product-attribute-enum.php
@@ -33,7 +33,7 @@ class Product_Attribute_Enum {
 		}
 
 		if ( empty( $taxonomy_values ) ) {
-			return;
+			$taxonomy_values['NONE'] = [ 'value' => 'none' ];
 		}
 
 		register_graphql_enum_type(

--- a/includes/type/enum/class-product-attribute-enum.php
+++ b/includes/type/enum/class-product-attribute-enum.php
@@ -32,6 +32,10 @@ class Product_Attribute_Enum {
 			}
 		}
 
+		if ( empty( $taxonomy_values ) ) {
+			return;
+		}
+
 		register_graphql_enum_type(
 			'ProductAttributeEnum',
 			[


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes **Enum type ProductAttributeEnum must define one or more values.** error by not registering the `ProductAttributeEnum` if no product attributes exist.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
