### PR TITLE
chore: bump deps to meet actual requirements and lint for WPCS 3.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,11 +1,11 @@
 === WPGraphQL WooCommerce ===
 Contributors: kidunot89, ranaaterning, jasonbahl, saleebm
 Tags: GraphQL, WooCommerce, WPGraphQL
-Requires at least: 5.9
+Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 7.2
+Requires PHP: 7.3
 Requires WooCommerce: 7.9.0
-Requires WPGraphQL: 1.14.0+
+Requires WPGraphQL: 1.16.0+
 Works with WPGraphQL-JWT-Authentication: 0.7.0+
 Stable tag: 0.18.3
 License: GPL-3

--- a/access-functions.php
+++ b/access-functions.php
@@ -195,13 +195,13 @@ if ( ! function_exists( 'wc_graphql_underscore_to_camel_case' ) ) {
 	/**
 	 * Converts a camel case formatted string to a underscore formatted string.
 	 *
-	 * @param string  $string      String to be formatted.
+	 * @param string  $str         String to be formatted.
 	 * @param boolean $capitalize  Capitalize first letter of string.
 	 *
 	 * @return string
 	 */
-	function wc_graphql_underscore_to_camel_case( $string, $capitalize = false ) {
-		$str = str_replace( ' ', '', ucwords( str_replace( '-', ' ', $string ) ) );
+	function wc_graphql_underscore_to_camel_case( $str, $capitalize = false ) {
+		$str = str_replace( ' ', '', ucwords( str_replace( '-', ' ', $str ) ) );
 
 		if ( ! $capitalize ) {
 			$str[0] = strtolower( $str[0] );
@@ -215,14 +215,14 @@ if ( ! function_exists( 'wc_graphql_camel_case_to_underscore' ) ) {
 	/**
 	 * Converts a camel case formatted string to a underscore formatted string.
 	 *
-	 * @param string $string  String to be formatted.
+	 * @param string $str String to be formatted.
 	 *
 	 * @return string
 	 */
-	function wc_graphql_camel_case_to_underscore( $string ) {
+	function wc_graphql_camel_case_to_underscore( $str ) {
 		preg_match_all(
 			'!([A-Z][A-Z0-9]*(?=$|[A-Z][a-z0-9])|[A-Za-z][a-z0-9]+)!',
-			$string,
+			$str,
 			$matches
 		);
 
@@ -240,13 +240,13 @@ if ( ! function_exists( 'woographql_setting' ) ) :
 	/**
 	 * Get an option value from WooGraphQL settings
 	 *
-	 * @param string $option_name  The key of the option to return.
-	 * @param mixed  $default      The default value the setting should return if no value is set.
-	 * @param string $section_name The settings section name.
+	 * @param string $option_name   The key of the option to return.
+	 * @param mixed  $default_value The default value the setting should return if no value is set.
+	 * @param string $section_name  The settings section name.
 	 *
 	 * @return mixed|string|int|boolean
 	 */
-	function woographql_setting( string $option_name, $default = '', $section_name = 'woographql_settings' ) {
+	function woographql_setting( string $option_name, $default_value = '', $section_name = 'woographql_settings' ) {
 		$section_fields = get_option( $section_name );
 
 		/**
@@ -256,27 +256,27 @@ if ( ! function_exists( 'woographql_setting' ) ) :
 		 * @param string $section_name   The name of the section
 		 * @param mixed  $default        The default value for the option being retrieved
 		 */
-		$section_fields = apply_filters( 'woographql_settings_section_fields', $section_fields, $section_name, $default );
+		$section_fields = apply_filters( 'woographql_settings_section_fields', $section_fields, $section_name, $default_value );
 
 		/**
 		 * Get the value from the stored data, or return the default
 		 */
-		if ( is_array( $default ) ) {
-			$value = is_array( $section_fields ) && ! empty( $section_fields[ $option_name ] ) ? $section_fields[ $option_name ] : $default;
+		if ( is_array( $default_value ) ) {
+			$value = is_array( $section_fields ) && ! empty( $section_fields[ $option_name ] ) ? $section_fields[ $option_name ] : $default_value;
 		} else {
-			$value = isset( $section_fields[ $option_name ] ) ? $section_fields[ $option_name ] : $default;
+			$value = isset( $section_fields[ $option_name ] ) ? $section_fields[ $option_name ] : $default_value;
 		}
 
 		/**
 		 * Filter the value before returning it
 		 *
 		 * @param mixed  $value          The value of the field
-		 * @param mixed  $default        The default value if there is no value set
+		 * @param mixed  $default_value  The default value if there is no value set
 		 * @param string $option_name    The name of the option
 		 * @param array  $section_fields The setting values within the section
 		 * @param string $section_name   The name of the section the setting belongs to
 		 */
-		return apply_filters( 'woographql_settings_section_field_value', $value, $default, $option_name, $section_fields, $section_name );
+		return apply_filters( 'woographql_settings_section_field_value', $value, $default_value, $option_name, $section_fields, $section_name );
 	}
 endif;
 

--- a/access-functions.php
+++ b/access-functions.php
@@ -379,14 +379,3 @@ if ( ! function_exists( 'woographql_verify_nonce' ) ) :
 		return false;
 	}
 endif;
-
-
-
-
-
-
-
-
-
-
-

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "firebase/php-jwt": "^6.1.0"
     },
     "require-dev": {
-        "axepress/wp-graphql-cs": "^1.0.0-beta",
-        "axepress/wp-graphql-stubs": "^1.14.0",
-        "php-stubs/woocommerce-stubs": "^7.5.0",
+        "axepress/wp-graphql-cs": "^2.0.0-beta",
+        "axepress/wp-graphql-stubs": "~1.16.0",
+        "php-stubs/woocommerce-stubs": "7.9.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpdoc-parser": "^1.22.0",
         "phpstan/phpstan": "^1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be031931e9c26c33fd5fe96ad7022dff",
+    "content-hash": "0a63256d1a0b55f5be349b050cf48c59",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -73,24 +73,25 @@
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6"
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
-                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
                 "sirbrillig/phpcs-variable-analysis": "^2.11.17",
-                "squizlabs/php_codesniffer": "^3.7.1",
-                "wp-coding-standards/wpcs": "^2.3"
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "wp-coding-standards/wpcs": "^3.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -122,29 +123,27 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2023-08-24T15:11:13+00:00"
+            "time": "2023-09-05T11:01:05+00:00"
         },
         {
             "name": "axepress/wp-graphql-cs",
-            "version": "1.0.0-beta.3",
+            "version": "2.0.0-beta.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AxeWP/WPGraphQL-Coding-Standards.git",
-                "reference": "365a066df667d1aea3b6d48611b19fa50b2944a7"
+                "reference": "88b27c5216716fdd3193ddfe33cad04ab1774b5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AxeWP/WPGraphQL-Coding-Standards/zipball/365a066df667d1aea3b6d48611b19fa50b2944a7",
-                "reference": "365a066df667d1aea3b6d48611b19fa50b2944a7",
+                "url": "https://api.github.com/repos/AxeWP/WPGraphQL-Coding-Standards/zipball/88b27c5216716fdd3193ddfe33cad04ab1774b5c",
+                "reference": "88b27c5216716fdd3193ddfe33cad04ab1774b5c",
                 "shasum": ""
             },
             "require": {
-                "automattic/vipwpcs": "^2.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "automattic/vipwpcs": "^3.0",
                 "php": ">=7.2",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
-                "slevomat/coding-standard": "^8.12",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "slevomat/coding-standard": "^8.12"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -182,20 +181,20 @@
                 "issues": "https://github.com/AxeWP/WPGraphQL-Coding-Standards/issues",
                 "source": "https://github.com/AxeWP/WPGraphQL-Coding-Standards"
             },
-            "time": "2023-08-04T19:56:47+00:00"
+            "time": "2023-11-05T13:36:28+00:00"
         },
         {
             "name": "axepress/wp-graphql-stubs",
-            "version": "v1.17.0",
+            "version": "v1.16.0+repack.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AxeWP/wp-graphql-stubs.git",
-                "reference": "df660d1d0cacd51e139dbd2082b5381ccde7fed6"
+                "reference": "47ce4c7e0c715bea84bc84b675e274b94a8c22f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/df660d1d0cacd51e139dbd2082b5381ccde7fed6",
-                "reference": "df660d1d0cacd51e139dbd2082b5381ccde7fed6",
+                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/47ce4c7e0c715bea84bc84b675e274b94a8c22f4",
+                "reference": "47ce4c7e0c715bea84bc84b675e274b94a8c22f4",
                 "shasum": ""
             },
             "require": {
@@ -226,7 +225,7 @@
             ],
             "support": {
                 "issues": "https://github.com/AxeWP/wp-graphql-stubs/issues",
-                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.17.0"
+                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.16.0+repack.1"
             },
             "funding": [
                 {
@@ -234,7 +233,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-13T01:13:11+00:00"
+            "time": "2023-10-01T17:13:28+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -578,6 +577,142 @@
             "time": "2022-10-24T09:00:36+00:00"
         },
         {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-09-20T22:06:18+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
+        },
+        {
             "name": "phpstan/extension-installer",
             "version": "1.3.1",
             "source": {
@@ -670,16 +805,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.38",
+            "version": "1.10.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691"
+                "reference": "c6174523c2a69231df55bdc65b61655e72876d76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5302bb402c57f00fb3c2c015bac86e0827e4b691",
-                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6174523c2a69231df55bdc65b61655e72876d76",
+                "reference": "c6174523c2a69231df55bdc65b61655e72876d76",
                 "shasum": ""
             },
             "require": {
@@ -728,7 +863,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-06T14:19:14+00:00"
+            "time": "2023-11-05T12:57:57+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -991,22 +1126,22 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v1.3.1",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "78db560e7989b50b05bec50ee5d862b41892654a"
+                "reference": "b8516ed6bab7ec50aae981698ce3f67f1be2e45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/78db560e7989b50b05bec50ee5d862b41892654a",
-                "reference": "78db560e7989b50b05bec50ee5d862b41892654a",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/b8516ed6bab7ec50aae981698ce3f67f1be2e45a",
+                "reference": "b8516ed6bab7ec50aae981698ce3f67f1be2e45a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
                 "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
-                "phpstan/phpstan": "^1.10.0",
+                "phpstan/phpstan": "^1.10.30",
                 "symfony/polyfill-php73": "^1.12.0"
             },
             "require-dev": {
@@ -1047,36 +1182,44 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.1"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.2"
             },
-            "time": "2023-10-14T18:59:35+00:00"
+            "time": "2023-10-16T17:23:56+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1093,6 +1236,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -1100,7 +1244,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         }
     ],
     "aliases": [],
@@ -1111,7 +1261,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2"
+        "php": ">=7.3"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/includes/class-jwt-auth-schema-filters.php
+++ b/includes/class-jwt-auth-schema-filters.php
@@ -194,7 +194,7 @@ class JWT_Auth_Schema_Filters {
 				[
 					'type'        => 'String',
 					'description' => __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' ),
-					'resolve'     => static function ( $payload ) {
+					'resolve'     => static function () {
 						/**
 						 * Session Handler.
 						 *

--- a/includes/class-jwt-auth-schema-filters.php
+++ b/includes/class-jwt-auth-schema-filters.php
@@ -127,12 +127,12 @@ class JWT_Auth_Schema_Filters {
 	 * Adds all JWT related fields to the Customer mutation output.
 	 *
 	 * @param array                             $fields         Mutation output field definitions.
-	 * @param \WPGraphQL\Type\WPInputObjectType $object         The WPInputObjectType the fields are be added to.
+	 * @param \WPGraphQL\Type\WPInputObjectType $object_type    The WPInputObjectType the fields are be added to.
 	 * @param \WPGraphQL\Registry\TypeRegistry  $type_registry  TypeRegistry instance.
 	 *
 	 * @return array
 	 */
-	public static function add_jwt_output_fields( $fields, $object, $type_registry ): array {
+	public static function add_jwt_output_fields( $fields, $object_type, $type_registry ): array {
 		$fields = array_merge(
 			$fields,
 			[

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -386,7 +386,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 								return;
 							}
 
-							echo sprintf(
+							printf(
 								'<div class="notice notice-error">' .
 								'<p>%s</p>' .
 								'</div>',

--- a/includes/data/connection/class-order-item-connection-resolver.php
+++ b/includes/data/connection/class-order-item-connection-resolver.php
@@ -136,7 +136,7 @@ class Order_Item_Connection_Resolver extends AbstractConnectionResolver {
 
 		// If cursor set, move index up one to ensure cursor not included in keys.
 		if ( $cursor ) {
-			$offset++;
+			++$offset;
 		}
 
 		$items = array_slice( $items, $offset, $this->query_amount + 1 );

--- a/includes/mutation/class-payment-method-delete.php
+++ b/includes/mutation/class-payment-method-delete.php
@@ -11,9 +11,7 @@
 namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WC_Payment_Tokens;
-use WPGraphQL\AppContext;
 
 /**
  * Class Payment_Method_Delete
@@ -73,7 +71,7 @@ class Payment_Method_Delete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input ) {
 			global $wp;
 			if ( ! is_user_logged_in() ) {
 				throw new UserError( __( 'Must be authenticated to set a default payment method', 'wp-graphql-woocommerce' ) );

--- a/includes/mutation/class-payment-method-set-default.php
+++ b/includes/mutation/class-payment-method-set-default.php
@@ -11,9 +11,7 @@
 namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WC_Payment_Tokens;
-use WPGraphQL\AppContext;
 
 /**
  * Class Payment_Method_Set_Default
@@ -79,7 +77,7 @@ class Payment_Method_Set_Default {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input ) {
 			global $wp;
 			if ( ! is_user_logged_in() ) {
 				throw new UserError( __( 'Must be authenticated to set a default payment method', 'wp-graphql-woocommerce' ) );

--- a/includes/mutation/class-review-delete-restore.php
+++ b/includes/mutation/class-review-delete-restore.php
@@ -106,7 +106,7 @@ class Review_Delete_Restore {
 			'review'     => [
 				'type'        => 'Comment',
 				'description' => __( 'The affected product review', 'wp-graphql-woocommerce' ),
-				'resolve'     => static function ( $payload, $args, AppContext $context, ResolveInfo $info ) use ( $restore ) {
+				'resolve'     => static function ( $payload, $args, AppContext $context ) use ( $restore ) {
 					if ( empty( $payload['commentObject'] ) ) {
 						return null;
 					}

--- a/includes/mutation/class-review-write.php
+++ b/includes/mutation/class-review-write.php
@@ -76,7 +76,7 @@ class Review_Write {
 			'review' => [
 				'type'        => 'Comment',
 				'description' => __( 'The product review that was created', 'wp-graphql-woocommerce' ),
-				'resolve'     => static function ( $payload, $args, AppContext $context ) {
+				'resolve'     => static function ( $payload ) {
 					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
 						return null;
 					}

--- a/includes/mutation/class-update-session.php
+++ b/includes/mutation/class-update-session.php
@@ -59,7 +59,7 @@ class Update_Session {
 		return [
 			'session'  => [
 				'type'    => [ 'list_of' => 'MetaData' ],
-				'resolve' => static function ( $payload ) {
+				'resolve' => static function () {
 					/**
 					 * Session handler.
 					 *

--- a/includes/mutation/class-update-session.php
+++ b/includes/mutation/class-update-session.php
@@ -11,8 +11,6 @@
 namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Cart_Mutation;
 use WPGraphQL\WooCommerce\Model\Customer;
 
@@ -94,7 +92,7 @@ class Update_Session {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) {
+		return static function ( $input ) {
 			Cart_Mutation::check_session_token();
 
 			// Guard against missing input.

--- a/includes/type/input/class-orderby-inputs.php
+++ b/includes/type/input/class-orderby-inputs.php
@@ -56,4 +56,3 @@ class Orderby_Inputs {
 		}
 	}
 }
-

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -643,7 +643,7 @@ class Cart_Type {
 					'description'    => [
 						'type'        => 'String',
 						'description' => __( 'Description of applied coupon', 'wp-graphql-woocommerce' ),
-						'resolve'     => static function ( $source, array $args ) {
+						'resolve'     => static function ( $source ) {
 							$coupon = new \WC_Coupon( $source );
 							return $coupon->get_description();
 						},

--- a/includes/type/object/class-product-category-type.php
+++ b/includes/type/object/class-product-category-type.php
@@ -38,7 +38,7 @@ class Product_Category_Type {
 				'display'   => [
 					'type'        => 'ProductCategoryDisplay',
 					'description' => __( 'Product category display type', 'wp-graphql-woocommerce' ),
-					'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					'resolve'     => static function ( $source ) {
 						$display = get_term_meta( $source->term_id, 'display_type', true );
 						return ! empty( $display ) ? $display : 'default';
 					},
@@ -46,7 +46,7 @@ class Product_Category_Type {
 				'menuOrder' => [
 					'type'        => 'Integer',
 					'description' => __( 'Product category menu order', 'wp-graphql-woocommerce' ),
-					'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					'resolve'     => static function ( $source ) {
 						$order = get_term_meta( $source->term_id, 'order', true );
 						return ! empty( $order ) ? $order : 0;
 					},

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -11,7 +11,6 @@ namespace WPGraphQL\WooCommerce\Type\WPObject;
 use Automattic\WooCommerce\StoreApi\Utilities\ProductQueryFilters;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Factory;
@@ -61,7 +60,7 @@ class Root_Query {
 						],
 					],
 					'description' => __( 'The cart object', 'wp-graphql-woocommerce' ),
-					'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					'resolve'     => static function ( $source, array $args ) {
 						$item = Factory::resolve_cart()->get_cart_item( $args['key'] );
 						if ( empty( $item ) || empty( $item['key'] ) ) {
 							throw new UserError( __( 'Failed to retrieve cart item.', 'wp-graphql-woocommerce' ) );
@@ -678,7 +677,7 @@ class Root_Query {
 							'description' => __( 'Type of ID being used identify product', 'wp-graphql-woocommerce' ),
 						],
 					],
-					'resolve'           => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $type_key, $unsupported_type_enabled ) {
+					'resolve'           => static function ( $source, array $args, AppContext $context ) use ( $type_key, $unsupported_type_enabled ) {
 						$id      = isset( $args['id'] ) ? $args['id'] : null;
 						$id_type = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
 

--- a/includes/utils/class-protected-router.php
+++ b/includes/utils/class-protected-router.php
@@ -143,28 +143,26 @@ class Protected_Router {
 		$is_auth_request = false;
 		if ( isset( $_GET[ self::$route ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$is_auth_request = true;
-		} else {
+		} elseif ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 			// Check the server to determine if the auth endpoint is being requested.
-			if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
-				$host = wp_unslash( $_SERVER['HTTP_HOST'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				$uri  = wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$host = wp_unslash( $_SERVER['HTTP_HOST'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$uri  = wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-				if ( ! is_string( $host ) ) {
-					return false;
-				}
+			if ( ! is_string( $host ) ) {
+				return false;
+			}
 
-				if ( ! is_string( $uri ) ) {
-					return false;
-				}
+			if ( ! is_string( $uri ) ) {
+				return false;
+			}
 
-				$parsed_site_url    = wp_parse_url( site_url( self::$route ), PHP_URL_PATH );
-				$auth_url           = ! empty( $parsed_site_url ) ? wp_unslash( $parsed_site_url ) : self::$route;
-				$parsed_request_url = wp_parse_url( $uri, PHP_URL_PATH );
-				$request_url        = ! empty( $parsed_request_url ) ? wp_unslash( $parsed_request_url ) : '';
+			$parsed_site_url    = wp_parse_url( site_url( self::$route ), PHP_URL_PATH );
+			$auth_url           = ! empty( $parsed_site_url ) ? wp_unslash( $parsed_site_url ) : self::$route;
+			$parsed_request_url = wp_parse_url( $uri, PHP_URL_PATH );
+			$request_url        = ! empty( $parsed_request_url ) ? wp_unslash( $parsed_request_url ) : '';
 
-				// Determine if the route is indeed a download request.
-				$is_auth_request = false !== strpos( $request_url, $auth_url );
-			}//end if
+			// Determine if the route is indeed a download request.
+			$is_auth_request = false !== strpos( $request_url, $auth_url );
 		}//end if
 
 		/**

--- a/includes/utils/class-protected-router.php
+++ b/includes/utils/class-protected-router.php
@@ -408,4 +408,3 @@ class Protected_Router {
 		exit;
 	}
 }
-

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -39,13 +39,13 @@
 		Tests for PHP version compatibility.
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#Recomended-additional-rulesets
 	-->
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.3-"/>
 
 	<!--
 		Tests for WordPress version compatibility.
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_wp_version" value="6.1"/>
 
 	<!-- Rules: WPGraphQL Coding Standards -->
 	<!-- https://github.com/AxeWP/WPGraphQL-Coding-Standards/WPGraphQL/ruleset.xml -->
@@ -55,10 +55,13 @@
 		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingVariable" />
 
 		<!-- @todo add and remediate -->
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed" />
 		<exclude name="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable" />
+		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped" />
 		<!-- @todo review and allowlist -->
-		<exclude name="WordPressVIPMinimum.Performance.WPQueryParams" />
+		<exclude name="WordPress.WP.Capabilities.Undetermined" />
 		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path" />
+		<exclude name="WordPressVIPMinimum.Performance.WPQueryParams" />
 		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users" />
 		<!-- @todo maybe add later-->
 		<exclude name="SlevomatCodingStandard.Functions.DisallowEmptyFunction.EmptyFunction" />
@@ -67,6 +70,7 @@
 
 	<!-- Individual rule configuration -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/tests/</exclude-pattern>
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
 			<property name="prefixes" type="array" value="WPGraphQL\WooCommerce,woographql,WPGRAPHQL_WOOCOMMERCE,WP_GraphQL_WooCommerce,graphql_,wc_graphql_"/>
@@ -78,40 +82,63 @@
 			<property name="text_domain" type="array" value="wp-graphql-woocommerce"/>
 		</properties>
 	</rule>
-	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
+	<rule ref="WordPress.WP.Capabilities">
 		<properties>
-			<property name="blank_line_check" value="true"/>
+			<!-- Add 3rd-party and custom capabilities -->
+			<property name="custom_capabilities" type="array" value="manage_woocommerce,edit_shop_orders" />
 		</properties>
 	</rule>
 
-	<!-- Enforce Short array syntax `[]`  -->
-	<rule ref="WordPress">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
-	</rule>
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-
 	<!-- Rules to exclude for test files -->
-	<rule ref="WordPress.NamingConventions">
+	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
-	<rule ref="Squiz.Commenting">
-		<!-- Allow for inline @var typing -->
-		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+	<rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.ClassComment.Missing">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.Missing">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.WrongStyle">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.VariableComment.Missing">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.PHP.CommentedOutCode.Found">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
+	<rule ref="Squiz.PHP.DisallowMultipleAssignments">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="Universal.NamingConventions.NoReservedKeywordParameterNames">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
 	<rule ref="WordPress.Files.FileName">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
-	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">
-		<exclude-pattern>/tests/</exclude-pattern>
-	</rule>
-	<rule ref="WordPress.PHP.DontExtract">
+	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.WP.AlternativeFunctions">
+		<exclude-pattern>/tests/</exclude-pattern>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
 </ruleset>

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -43,5 +43,3 @@ if ( ! defined( 'STRIPE_API_PUBLISHABLE_KEY' ) && false !== getenv( 'STRIPE_API_
 if ( ! defined( 'STRIPE_API_SECRET_KEY' ) && false !== getenv( 'STRIPE_API_SECRET_KEY' ) ) {
 	define( 'STRIPE_API_SECRET_KEY', getenv( 'STRIPE_API_SECRET_KEY' ) );
 }
-
-

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -15,10 +15,9 @@
  * @method void comment($description)
  * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
  *
- * @SuppressWarnings(PHPMD)
+ * @SuppressWarnings(\PHPMD)
  */
 class AcceptanceTester extends \Codeception\Actor {
-
 	use _generated\AcceptanceTesterActions;
 
 	/**

--- a/tests/_support/Factory/CartFactory.php
+++ b/tests/_support/Factory/CartFactory.php
@@ -8,8 +8,6 @@
 
 namespace Tests\WPGraphQL\WooCommerce\Factory;
 
-use Tests\WPGraphQL\WooCommerce\Utils\Dummy;
-
 /**
  * Cart factory class for testing.
  */

--- a/tests/_support/Factory/OrderFactory.php
+++ b/tests/_support/Factory/OrderFactory.php
@@ -8,8 +8,6 @@
 
 namespace Tests\WPGraphQL\WooCommerce\Factory;
 
-use Tests\WPGraphQL\WooCommerce\Utils\Dummy;
-
 /**
  * Order factory class for testing.
  */
@@ -135,7 +133,7 @@ class OrderFactory extends \WP_UnitTest_Factory_For_Thing {
 
 			// Save and return ID.
 			return $order->save();
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			$order->delete( true );
 
 			throw new \Exception( $e->getMessage() );

--- a/tests/_support/Factory/PaymentTokenFactory.php
+++ b/tests/_support/Factory/PaymentTokenFactory.php
@@ -8,13 +8,10 @@
 
 namespace Tests\WPGraphQL\WooCommerce\Factory;
 
-use Tests\WPGraphQL\WooCommerce\Utils\Dummy;
-
 /**
  * Cart factory class for testing.
  */
 class PaymentTokenFactory {
-
 	/**
 	 * Create a new credit card payment token
 	 *

--- a/tests/_support/Factory/ProductVariationFactory.php
+++ b/tests/_support/Factory/ProductVariationFactory.php
@@ -8,8 +8,6 @@
 
 namespace Tests\WPGraphQL\WooCommerce\Factory;
 
-use Tests\WPGraphQL\WooCommerce\Utils\Dummy;
-
 /**
  * Product variation factory class for testing.
  */
@@ -43,12 +41,12 @@ class ProductVariationFactory extends \WP_UnitTest_Factory_For_Thing {
 		}
 
 		// if ( ! empty( $args['meta_data'] ) ) {
-		// 	$variation->set_meta_data( $args['meta_data'] );
-		// 	unset( $args['meta_data'] );
+		// $variation->set_meta_data( $args['meta_data'] );
+		// unset( $args['meta_data'] );
 		// }
 		// if ( ! empty( $args['attributes'] ) ) {
-		// 	$variation->set_attributes( $args['attributes'] );
-		// 	unset( $args['attributes'] );
+		// $variation->set_attributes( $args['attributes'] );
+		// unset( $args['attributes'] );
 		// }
 		// $variation->set_props( $args );
 

--- a/tests/_support/Factory/RefundFactory.php
+++ b/tests/_support/Factory/RefundFactory.php
@@ -8,8 +8,6 @@
 
 namespace Tests\WPGraphQL\WooCommerce\Factory;
 
-use Tests\WPGraphQL\WooCommerce\Utils\Dummy;
-
 /**
  * Refund factory class for testing.
  */
@@ -79,6 +77,4 @@ class RefundFactory extends \WP_UnitTest_Factory_For_Thing {
 			)
 		);
 	}
-
-
 }

--- a/tests/_support/Factory/ShippingZoneFactory.php
+++ b/tests/_support/Factory/ShippingZoneFactory.php
@@ -67,8 +67,7 @@ class ShippingZoneFactory extends \WP_UnitTest_Factory_For_Thing {
 
 	public function get_object_by_id( $id ) {
 		if ( class_exists( '\WC_Shipping_Zones' ) ) {
-			$zone = \WC_Shipping_Zones::get_zone( $id );
-			return $zone;
+			return \WC_Shipping_Zones::get_zone( $id );
 		}
 
 		return false;
@@ -76,8 +75,7 @@ class ShippingZoneFactory extends \WP_UnitTest_Factory_For_Thing {
 
 	public function getAllZones() {
 		if ( class_exists( '\WC_Shipping_Zones' ) ) {
-			$all_zones = \WC_Shipping_Zones::get_zones();
-			return $all_zones;
+			return \WC_Shipping_Zones::get_zones();
 		}
 
 		return false;

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -15,10 +15,9 @@
  * @method void comment($description)
  * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
  *
- * @SuppressWarnings(PHPMD)
+ * @SuppressWarnings(\PHPMD)
  */
 class FunctionalTester extends \Codeception\Actor {
-
 	use _generated\FunctionalTesterActions;
 
 	/**

--- a/tests/_support/Helper/GraphQLE2E.php
+++ b/tests/_support/Helper/GraphQLE2E.php
@@ -50,10 +50,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -93,10 +90,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -130,10 +124,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -172,10 +163,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -213,10 +201,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -258,10 +243,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -289,10 +271,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -332,10 +311,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -373,10 +349,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -413,10 +386,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -595,10 +565,7 @@ class GraphQLE2E extends \Codeception\Module {
         ';
 
 		// Send GraphQL request and get response.
-		$response = $this->sendGraphQLRequest( $mutation, $input, $request_headers );
-
-		// Return response.
-		return $response;
+		return $this->sendGraphQLRequest( $mutation, $input, $request_headers );
 	}
 
 	/**
@@ -742,12 +709,12 @@ class GraphQLE2E extends \Codeception\Module {
 	/**
 	 * Initializes store options and actions
 	 *
-	 * @param AcceptanceTester $I
+	 * @param \Helper\AcceptanceTester $I
 	 * @return void
 	 */
 	public function _setupStore() {
 		$wpdb = $this->getModule( 'WPDb' );
-		$wpdb->useTheme('twentytwentyone');
+		$wpdb->useTheme( 'twentytwentyone' );
 		// Turn on tax calculations and store shipping countries. Important!
 		update_option( 'woocommerce_ship_to_countries', 'all' );
 		update_option( 'woocommerce_prices_include_tax', 'no' );
@@ -769,7 +736,7 @@ class GraphQLE2E extends \Codeception\Module {
 		// Additional cart fees.
 		add_action(
 			'woocommerce_cart_calculate_fees',
-			function() {
+			static function () {
 				$percentage = 0.01;
 				$surcharge  = ( \WC()->cart->cart_contents_total + \WC()->cart->shipping_total ) * $percentage;
 				\WC()->cart->add_fee( 'Surcharge', $surcharge, true, '' );
@@ -814,11 +781,11 @@ class GraphQLE2E extends \Codeception\Module {
 	/**
 	 * Adds Product in database
 	 *
-	 * @param AcceptanceTester $I
-	 * @param array            $args        Product args.
-	 * @param integer          $product_id  ID for product being created.
-	 * @param string           $term        Product type. Defaults to 'simple'.
-	 * @param integer          $term_id     Product type term ID.
+	 * @param \Helper\AcceptanceTester $I
+	 * @param array                    $args        Product args.
+	 * @param integer                  $product_id  ID for product being created.
+	 * @param string                   $term        Product type. Defaults to 'simple'.
+	 * @param integer                  $term_id     Product type term ID.
 	 * @return void
 	 */
 	public function haveAProductInTheDatabase( $args, &$product_id, $term = 'simple', &$term_id = 0 ) {
@@ -886,7 +853,6 @@ class GraphQLE2E extends \Codeception\Module {
 		);
 		$wpdb->haveTermRelationshipInDatabase( $product_id, $term_id );
 	}
-
 
 	public function setupStoreAndUsers() {
 		$this->_setupStore();

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -33,7 +33,7 @@ class Wpunit extends \Codeception\Module {
 		$helper->create_attribute( 'size', [ 'small', 'medium', 'large' ] );
 		$helper->create_attribute( 'color', [ 'red', 'blue', 'green' ] );
 		codecept_debug( 'ATTRIBUTES_LOADED' );
-		add_action( 'init_graphql_request', [ __CLASS__, 'shortcode_test_init' ] );
+		add_action( 'init_graphql_request', [ self::class, 'shortcode_test_init' ] );
 		codecept_debug( 'SHORTCODE_INITIALIZED' );
 		\Stripe\Stripe::setApiKey(
 			defined( 'STRIPE_API_SECRET_KEY' ) ? STRIPE_API_SECRET_KEY : getenv( 'STRIPE_API_SECRET_KEY' )
@@ -95,7 +95,7 @@ class Wpunit extends \Codeception\Module {
 	}
 
 	public static function shortcode_test_init() {
-		add_shortcode( 'shortcode_test', [ __CLASS__, 'shortcode_test_handler' ] );
+		add_shortcode( 'shortcode_test', [ self::class, 'shortcode_test_handler' ] );
 	}
 
 	public static function shortcode_test_handler( $atts ) {

--- a/tests/_support/Utils/Dummy.php
+++ b/tests/_support/Utils/Dummy.php
@@ -17,17 +17,17 @@ final class Dummy {
 	/**
 	 * Stores the instance of the Dummy class
 	 *
-	 * @var Dummy The one true dummy =P
+	 * @var \Tests\WPGraphQL\WooCommerce\Utils\Dummy The one true dummy =P
 	 */
 	private static $instance;
 
 	/**
 	 * Returns the dummy =P.
 	 *
-	 * @return Dummy
+	 * @return \Tests\WPGraphQL\WooCommerce\Utils\Dummy
 	 */
 	public static function instance() {
-		if ( ! isset( self::$instance ) && ! ( is_a( self::$instance, __CLASS__ ) ) ) {
+		if ( ! isset( self::$instance ) && ! ( is_a( self::$instance, self::class ) ) ) {
 			self::$instance = new self();
 		}
 

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -15,14 +15,12 @@
  * @method void comment($description)
  * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
  *
- * @SuppressWarnings(PHPMD)
+ * @SuppressWarnings(\PHPMD)
  */
 class WpunitTester extends \Codeception\Actor {
-
 	use _generated\WpunitTesterActions;
 
 	/**
 	 * Define custom actions here
 	 */
-
 }

--- a/tests/acceptance/CustomerProceedsToCheckoutCept.php
+++ b/tests/acceptance/CustomerProceedsToCheckoutCept.php
@@ -10,12 +10,10 @@ $I->click( '#submit' );
 $I->logOut();
 
 // Make quick helper for managing the session token.
-$request_headers = function () use ( $I, &$last_request_headers ) {
-	$last_request_headers = [
+$request_headers = static function () use ( $I ) {
+	return [
 		'woocommerce-session' => 'Session ' . $I->wantHTTPResponseHeaders( 'woocommerce-session' ),
 	];
-
-	return $last_request_headers;
 };
 
 // Begin test.
@@ -83,7 +81,7 @@ $cart_url = $success['data']['updateSession']['customer']['cartUrl'];
 
 $I->wantTo( 'Go cart page and confirm empty and session not seen' );
 $I->amOnPage( '/cart' );
-$I->seeElement('.wc-empty-cart-message');
+$I->seeElement( '.wc-empty-cart-message' );
 
 $I->wantTo( 'Authenticate with cart url and confirm page redirect' );
 $I->stopFollowingRedirects();

--- a/tests/acceptance/NewCustomerCheckingOutCept.php
+++ b/tests/acceptance/NewCustomerCheckingOutCept.php
@@ -4,12 +4,10 @@ $I = new AcceptanceTester( $scenario );
 $product_catalog = $I->getCatalog();
 
 // Make quick helper for managing the session token.
-$request_headers = function () use ( $I, &$last_request_headers ) {
-	$last_request_headers = [
+$request_headers = static function () use ( $I ) {
+	return [
 		'woocommerce-session' => 'Session ' . $I->wantHTTPResponseHeaders( 'woocommerce-session' ),
 	];
-
-	return $last_request_headers;
 };
 
 // Begin test.

--- a/tests/acceptance/NewCustomerCheckingOutCept.php
+++ b/tests/acceptance/NewCustomerCheckingOutCept.php
@@ -4,10 +4,12 @@ $I = new AcceptanceTester( $scenario );
 $product_catalog = $I->getCatalog();
 
 // Make quick helper for managing the session token.
-$request_headers = static function () use ( $I ) {
-	return [
+$request_headers = function () use ( $I, &$last_request_headers ) {
+	$last_request_headers = [
 		'woocommerce-session' => 'Session ' . $I->wantHTTPResponseHeaders( 'woocommerce-session' ),
 	];
+
+	return $last_request_headers;
 };
 
 // Begin test.

--- a/tests/functional/CartTransactionQueueCest.php
+++ b/tests/functional/CartTransactionQueueCest.php
@@ -267,14 +267,14 @@ class CartTransactionQueueCest {
 		$timeout  = 300;
 		$client   = new \GuzzleHttp\Client( compact( 'base_uri', 'headers', 'timeout' ) );
 
-		$iterator = function( $requests ) use ( $client ) {
+		$iterator = static function ( $requests ) use ( $client ) {
 			$stagger = 1000;
 			foreach ( $requests as $index => $payload ) {
-				yield function() use ( $client, $stagger, $index, $payload ) {
+				yield static function () use ( $client, $stagger, $index, $payload ) {
 					$body      = json_encode( $payload );
 					$delay     = $stagger * $index + 1;
 					$connected = false;
-					$progress  = function( $downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes ) use ( $index, &$connected ) {
+					$progress  = static function ( $downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes ) use ( $index, &$connected ) {
 						if ( $uploadTotal === $uploadedBytes && 0 === $downloadTotal && ! $connected ) {
 							\codecept_debug( "Session mutation request $index connected @ " . ( new \Carbon\Carbon() )->format( 'Y-m-d H:i:s' ) );
 							$connected = true;
@@ -290,7 +290,7 @@ class CartTransactionQueueCest {
 			$iterator( $requests ),
 			[
 				'concurrency' => 5,
-				'fulfilled'   => function ( $response, $index ) use ( $I, $expected_responses ) {
+				'fulfilled'   => static function ( $response, $index ) use ( $I, $expected_responses ) {
 					\codecept_debug( "Finished session mutation request $index @ " . ( new \Carbon\Carbon() )->format( 'Y-m-d H:i:s' ) );
 
 					$expected = $expected_responses[ $index ];

--- a/tests/functional/ProtectedRouterCest.php
+++ b/tests/functional/ProtectedRouterCest.php
@@ -50,11 +50,9 @@ class ProtectedRouterCest {
 	}
 
 	public function _getLastRequestHeaders( $I ) {
-		$headers = [
+		return [
 			'woocommerce-session' => 'Session ' . $I->wantHTTPResponseHeaders( 'woocommerce-session' ),
 		];
-
-		return $headers;
 	}
 
 	public function tryToProceedToCheckoutPage( FunctionalTester $I ) {
@@ -84,7 +82,7 @@ class ProtectedRouterCest {
 
 		$I->wantTo( 'Go checkout page and confirm session not seen' );
 		$I->amOnPage( '/checkout' );
-		$I->seeElement('.wc-empty-cart-message');
+		$I->seeElement( '.wc-empty-cart-message' );
 
 		$I->wantTo( 'Authenticate with nonced url and confirm page redirect to checkout page' );
 		$I->stopFollowingRedirects();
@@ -101,7 +99,6 @@ class ProtectedRouterCest {
 		$I->see( 'Checkout' );
 		$I->see( 't-shirt' );
 	}
-
 
 	public function tryToProceedToCheckoutPageWithExpiredUrl( FunctionalTester $I ) {
 		$this->_startNewSession( $I );
@@ -171,7 +168,7 @@ class ProtectedRouterCest {
 
 		$I->wantTo( 'Go checkout page and confirm session not seen' );
 		$I->amOnPage( '/checkout' );
-		$I->seeElement('.wc-empty-cart-message');
+		$I->seeElement( '.wc-empty-cart-message' );
 
 		$I->wantTo( 'Attempt to authenticate with expired url and confirm page redirect to checkout page' );
 		$I->stopFollowingRedirects();
@@ -181,7 +178,6 @@ class ProtectedRouterCest {
 		$I->dontSeeInCurrentUrl( '/checkout/' );
 		$I->startFollowingRedirects();
 	}
-
 
 	public function tryToProceedToCheckoutPageWithInvalidNonce( FunctionalTester $I ) {
 		$session_data  = $this->_startNewSession( $I );
@@ -209,7 +205,7 @@ class ProtectedRouterCest {
 
 		$I->wantTo( 'Go checkout page and confirm session not seen' );
 		$I->amOnPage( '/checkout' );
-		$I->seeElement('.wc-empty-cart-message');
+		$I->seeElement( '.wc-empty-cart-message' );
 
 		$I->wantTo( 'Attempt to authenticate with nonced url and confirm page redirect to checkout page' );
 		$I->stopFollowingRedirects();

--- a/tests/wpunit/CheckoutMutationTest.php
+++ b/tests/wpunit/CheckoutMutationTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use WPGraphQL\Type\WPEnumType;
 
 class CheckoutMutationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
 	public function setUp(): void {
@@ -63,7 +62,7 @@ class CheckoutMutationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 		// Additional cart fees.
 		add_action(
 			'woocommerce_cart_calculate_fees',
-			function() {
+			static function () {
 				$percentage = 0.01;
 				$surcharge  = ( WC()->cart->cart_contents_total + WC()->cart->shipping_total ) * $percentage;
 				WC()->cart->add_fee( 'Surcharge', $surcharge, true, '' );

--- a/tests/wpunit/CollectionStatsQueryTest.php
+++ b/tests/wpunit/CollectionStatsQueryTest.php
@@ -1,23 +1,24 @@
 <?php
 
 class CollectionStatsQueryTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-    public function setUp(): void {
-        parent::setUp();
-        update_option( 'woocommerce_attribute_lookup_enabled', 'yes' );
-        update_option( 'woocommerce_attribute_lookup_direct_updates', 'yes' );
-    }
-    
-    public function testCollectionStatsQuery() {
-        $this->factory->product_variation->createSome(
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_attribute_lookup_enabled', 'yes' );
+		update_option( 'woocommerce_attribute_lookup_direct_updates', 'yes' );
+	}
+	
+	public function testCollectionStatsQuery() {
+		$this->factory->product_variation->createSome(
 			$this->factory->product->createVariable()
 		);
-        $this->factory->product->createSimple();
-        $this->factory->product->createSimple();
-        $this->factory->product_variation->createSome(
+		$this->factory->product->createSimple();
+		$this->factory->product->createSimple();
+		$this->factory->product_variation->createSome(
 			$this->factory->product->createVariable()
 		);
 
-        $query = '
+		$query = '
             query ($where: CollectionStatsWhereArgs, $taxonomies: [CollectionStatsQueryInput]) {
                 collectionStats(
                     calculatePriceRange: true
@@ -44,80 +45,80 @@ class CollectionStatsQueryTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
             }
         ';
 
-        $variables = [
-            'where' => [
-                'attributes' => [
-                    [
-                        'taxonomy' => 'PA_COLOR',
-                        'terms'    => 'red',
-                        'operator' => 'IN',
-                    ],
-                ]
-            ],
-            'taxonomies' => [
-                [
-                    'taxonomy' => 'PA_COLOR',
-                    'relation' => 'AND',
-                ]
-            ]
-        ];
-        $response  = $this->graphql( compact( 'query', 'variables' ) );
-        $expected  = [
-            $this->expectedNode(
-                'collectionStats.attributeCounts', 
-                [
-                    $this->expectedField('slug', 'PA_COLOR' ),
-                    $this->expectedField('label', 'color' ),
-                    $this->expectedField('name', 'color' ),
-                    $this->expectedNode(
-                        'terms',
-                        [
-                            $this->expectedField( 'node.slug', 'red' ),
-                            $this->expectedField( 'count', 2 ),
-                            $this->expectedField( 'termId', self::NOT_FALSY ),
-                        ] 
-                    ),
-                    $this->expectedNode(
-                        'terms',
-                        [
-                            $this->expectedField( 'node.slug', 'blue' ),
-                            $this->expectedField( 'count', 2 ),
-                            $this->expectedField( 'termId', self::NOT_FALSY ),
-                        ] 
-                    ),
-                    $this->expectedNode(
-                        'terms',
-                        [
-                            $this->expectedField( 'node.slug', 'green' ),
-                            $this->expectedField( 'count', 2 ),
-                            $this->expectedField( 'termId', self::NOT_FALSY ),
-                        ] 
-                    ),
-                ],
-                0
-            ),
-            $this->expectedNode(
-                'collectionStats.stockStatusCounts',
-                [
-                    $this->expectedField( 'status', 'IN_STOCK' ),
-                    $this->expectedField( 'count', 2 ),
-                ]
-            ),
-            $this->expectedNode(
-                'collectionStats.stockStatusCounts',
-                [
-                    $this->expectedField( 'status', 'OUT_OF_STOCK' ),
-                    $this->expectedField( 'count', 0 ),
-                ]
-            ),
-            $this->expectedNode(
-                'collectionStats.stockStatusCounts',
-                [
-                    $this->expectedField( 'status', 'ON_BACKORDER' ),
-                    $this->expectedField( 'count', 0 ),
-                ]
-            ),
-        ];
-        $this->assertQuerySuccessful( $response, $expected );
-    }
+		$variables = [
+			'where'      => [
+				'attributes' => [
+					[
+						'taxonomy' => 'PA_COLOR',
+						'terms'    => 'red',
+						'operator' => 'IN',
+					],
+				],
+			],
+			'taxonomies' => [
+				[
+					'taxonomy' => 'PA_COLOR',
+					'relation' => 'AND',
+				],
+			],
+		];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedNode(
+				'collectionStats.attributeCounts', 
+				[
+					$this->expectedField( 'slug', 'PA_COLOR' ),
+					$this->expectedField( 'label', 'color' ),
+					$this->expectedField( 'name', 'color' ),
+					$this->expectedNode(
+						'terms',
+						[
+							$this->expectedField( 'node.slug', 'red' ),
+							$this->expectedField( 'count', 2 ),
+							$this->expectedField( 'termId', self::NOT_FALSY ),
+						] 
+					),
+					$this->expectedNode(
+						'terms',
+						[
+							$this->expectedField( 'node.slug', 'blue' ),
+							$this->expectedField( 'count', 2 ),
+							$this->expectedField( 'termId', self::NOT_FALSY ),
+						] 
+					),
+					$this->expectedNode(
+						'terms',
+						[
+							$this->expectedField( 'node.slug', 'green' ),
+							$this->expectedField( 'count', 2 ),
+							$this->expectedField( 'termId', self::NOT_FALSY ),
+						] 
+					),
+				],
+				0
+			),
+			$this->expectedNode(
+				'collectionStats.stockStatusCounts',
+				[
+					$this->expectedField( 'status', 'IN_STOCK' ),
+					$this->expectedField( 'count', 2 ),
+				]
+			),
+			$this->expectedNode(
+				'collectionStats.stockStatusCounts',
+				[
+					$this->expectedField( 'status', 'OUT_OF_STOCK' ),
+					$this->expectedField( 'count', 0 ),
+				]
+			),
+			$this->expectedNode(
+				'collectionStats.stockStatusCounts',
+				[
+					$this->expectedField( 'status', 'ON_BACKORDER' ),
+					$this->expectedField( 'count', 0 ),
+				]
+			),
+		];
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 }

--- a/tests/wpunit/ConnectionPaginationTest.php
+++ b/tests/wpunit/ConnectionPaginationTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function toCursor( $id ) {
 		if ( $id instanceof \WC_Product_Download ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
@@ -24,7 +23,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 
 		usort(
 			$coupons,
-			function( $key_a, $key_b ) {
+			static function ( $key_a, $key_b ) {
 				return $key_a < $key_b;
 			}
 		);
@@ -141,7 +140,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 
 		usort(
 			$products,
-			function( $key_a, $key_b ) {
+			static function ( $key_a, $key_b ) {
 				return $key_a < $key_b;
 			}
 		);
@@ -268,7 +267,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 
 		usort(
 			$orders,
-			function( $key_a, $key_b ) {
+			static function ( $key_a, $key_b ) {
 				return $key_a < $key_b;
 			}
 		);
@@ -382,7 +381,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 
 		usort(
 			$refunds,
-			function( $key_a, $key_b ) {
+			static function ( $key_a, $key_b ) {
 				return $key_a < $key_b;
 			}
 		);
@@ -615,7 +614,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 
 		];
 		$products = array_map(
-			function( $download ) {
+			function ( $download ) {
 				return $this->factory->product->createSimple(
 					[
 						'downloadable' => true,
@@ -633,7 +632,7 @@ class ConnectionPaginationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Woo
 			],
 			[
 				'line_items' => array_map(
-					function( $product_id ) {
+					static function ( $product_id ) {
 						return [
 							'product' => $product_id,
 							'qty'     => 1,

--- a/tests/wpunit/CoreInterfaceQueriesTest.php
+++ b/tests/wpunit/CoreInterfaceQueriesTest.php
@@ -395,5 +395,4 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testQueryProductWithNodeByUri() {
 	}
-
 }

--- a/tests/wpunit/CouponMutationsTest.php
+++ b/tests/wpunit/CouponMutationsTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class CouponMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	// Tests
 	public function testCreateCoupon() {
 		$query = '

--- a/tests/wpunit/CouponQueriesTest.php
+++ b/tests/wpunit/CouponQueriesTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use GraphQLRelay\Relay;
 class CouponQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function expectedCouponData( $coupon_id ) {
 		$coupon = new \WC_Coupon( $coupon_id );
 

--- a/tests/wpunit/CustomerMutationsTest.php
+++ b/tests/wpunit/CustomerMutationsTest.php
@@ -5,7 +5,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 	/**
 	 * Faker instance.
 	 *
-	 * @var Faker\Factory
+	 * @var \Faker\Factory
 	 */
 	private $faker;
 
@@ -36,7 +36,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 		$username   = $this->faker->userName();
 		$password   = $this->faker->password();
 		$email      = $this->faker->email();
-		$phone	    = $this->faker->phoneNumber();
+		$phone      = $this->faker->phoneNumber();
 		$address    = $this->faker->streetAddress();
 		$city       = $this->faker->city();
 		$state      = $this->faker->state();
@@ -84,7 +84,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 			'state'     => null,
 			'postcode'  => null,
 			'country'   => null,
-			'phone'		=> null,
+			'phone'     => null,
 		];
 	}
 
@@ -100,7 +100,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 			'postcode'  => null,
 			'country'   => null,
 			'email'     => null,
-			'phone'		=> null,
+			'phone'     => null,
 		];
 	}
 
@@ -151,9 +151,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 		';
 
 		$variables = [ 'input' => $input ];
-		$response  = $this->graphql( compact( 'query', 'variables' ) );
-
-		return $response;
+		return $this->graphql( compact( 'query', 'variables' ) );
 	}
 
 	private function executeUpdateCustomerMutation( $input ) {
@@ -197,9 +195,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 		';
 
 		$variables = [ 'input' => $input ];
-		$response  = $this->graphql( compact( 'query', 'variables' ) );
-
-		return $response;
+		return $this->graphql( compact( 'query', 'variables' ) );
 	}
 
 	public function testRegisterMutationWithoutCustomerInfo() {
@@ -418,7 +414,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 		 */
 		$customer_input = $this->generateCustomerInput();
 		unset( $customer_input['username'] );
-		$response       = $this->executeUpdateCustomerMutation(
+		$response = $this->executeUpdateCustomerMutation(
 			array_merge(
 				$customer_input,
 				[
@@ -485,7 +481,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 		\WC()->initialize_session();
 		$customer_input = $this->generateCustomerInput();
 		unset( $customer_input['username'] );
-		$response       = $this->executeUpdateCustomerMutation( $customer_input );
+		$response = $this->executeUpdateCustomerMutation( $customer_input );
 
 		$expected = [
 			$this->expectedObject(
@@ -661,7 +657,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 		 *
 		 * Test "metaData" input field with "updateCustomer" mutation.
 		 */
-		$query     = '
+		$query = '
 			mutation( $input: UpdateCustomerInput! ) {
 				updateCustomer( input: $input ) {
 					customer {
@@ -715,7 +711,7 @@ class CustomerMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGra
 		 *
 		 * Test "metaData" input field with "updateCustomer" mutation on the session user.
 		 */
-		$query     = '
+		$query = '
 			mutation( $input: UpdateCustomerInput! ) {
 				updateCustomer( input: $input ) {
 					customer {

--- a/tests/wpunit/CustomerQueriesTest.php
+++ b/tests/wpunit/CustomerQueriesTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class CustomerQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function expectedCustomerData( $id ) {
 		$customer = new \WC_Customer( $id );
 		$customer->read_meta_data( true );
@@ -618,7 +617,7 @@ class CustomerQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 		// Reinitialize WC session with QL_Session_Handler set.
 		add_filter(
 			'woocommerce_session_handler',
-			function( $session_class ) {
+			static function ( $session_class ) {
 				return '\WPGraphQL\WooCommerce\Utils\QL_Session_Handler';
 			}
 		);

--- a/tests/wpunit/DownloadableItemQueriesTest.php
+++ b/tests/wpunit/DownloadableItemQueriesTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class DownloadableItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function setUp(): void {
 		// before
 		parent::setUp();
@@ -72,7 +71,7 @@ class DownloadableItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 		$this->loginAsCustomer();
 		$response = $this->graphql( compact( 'query' ) );
 		$expected = array_map(
-			function( $item ) {
+			function ( $item ) {
 				return $this->expectedNode(
 					'customer.orders.nodes',
 					[
@@ -102,7 +101,6 @@ class DownloadableItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}
-
 
 	public function testOrderToDownloadableItemsQueryArgs() {
 		$valid_product        = $this->factory->product->createSimple(
@@ -350,7 +348,7 @@ class DownloadableItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 		$this->loginAsCustomer();
 		$response = $this->graphql( compact( 'query' ) );
 		$expected = array_map(
-			function( $item ) {
+			function ( $item ) {
 				return $this->expectedNode(
 					'customer.downloadableItems.nodes',
 					[

--- a/tests/wpunit/IntrospectionQueryTest.php
+++ b/tests/wpunit/IntrospectionQueryTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class IntrospectionQueryTest extends \Codeception\TestCase\WPTestCase {
-
 	public function setUp(): void {
 		// before
 		parent::setUp();

--- a/tests/wpunit/MetaDataQueriesTest.php
+++ b/tests/wpunit/MetaDataQueriesTest.php
@@ -1,9 +1,7 @@
 <?php
 
-use GraphQLRelay\Relay;
 
 class MetaDataQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	// tests
 	public function testCartMetaDataQueries() {
 		// Create Variation Product.

--- a/tests/wpunit/OrderItemQueriesTest.php
+++ b/tests/wpunit/OrderItemQueriesTest.php
@@ -1,10 +1,8 @@
 <?php
 
-use GraphQLRelay\Relay;
 use WPGraphQL\Type\WPEnumType;
 
 class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	// tests
 	public function testCouponLinesQuery() {
 		$order_id = $this->factory->order->createNew();
@@ -41,7 +39,7 @@ class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 		$variables = [ 'id' => $id ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_map(
-			function( $item ) {
+			function ( $item ) {
 				return $this->expectedNode(
 					'order.couponLines.nodes',
 					[
@@ -95,7 +93,7 @@ class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 		$variables = [ 'id' => $id ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_map(
-			function( $item ) {
+			function ( $item ) {
 				return $this->expectedNode(
 					'order.feeLines.nodes',
 					[
@@ -153,7 +151,7 @@ class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 		$variables = [ 'id' => $id ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_map(
-			function( $item ) {
+			function ( $item ) {
 				return $this->expectedNode(
 					'order.shippingLines.nodes',
 					[
@@ -214,7 +212,7 @@ class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 		$variables = [ 'id' => $id ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_map(
-			function( $item ) {
+			function ( $item ) {
 				return $this->expectedNode(
 					'order.taxLines.nodes',
 					[
@@ -284,7 +282,7 @@ class OrderItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGrap
 		$variables = [ 'id' => $id ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_map(
-			function( $item ) {
+			function ( $item ) {
 				return $this->expectedNode(
 					'order.lineItems.nodes',
 					[

--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -3,7 +3,6 @@
 use WPGraphQL\Type\WPEnumType;
 
 class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
-
 	public function setUp(): void {
 		// before
 		parent::setUp();
@@ -206,15 +205,13 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
             }
         ";
 
-		$actual = graphql(
+		return graphql(
 			[
 				'query'          => $mutation,
 				'operation_name' => $operation_name,
 				'variables'      => [ 'input' => $input ],
 			]
 		);
-
-		return $actual;
 	}
 
 	// tests
@@ -343,7 +340,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'couponLines'   => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										function ( $item ) {
 											return [
 												'databaseId' => $item->get_id(),
 												'orderId'  => $item->get_order_id(),
@@ -362,7 +359,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'feeLines'      => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										static function ( $item ) {
 											return [
 												'databaseId' => $item->get_id(),
 												'orderId'  => $item->get_order_id(),
@@ -383,7 +380,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'shippingLines' => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										static function ( $item ) {
 											return [
 												'databaseId' => $item->get_id(),
 												'orderId'  => $item->get_order_id(),
@@ -406,7 +403,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'taxLines'      => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										static function ( $item ) {
 											return [
 												'rateCode' => $item->get_rate_code(),
 												'label'    => $item->get_label(),
@@ -423,7 +420,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'lineItems'     => [
 								'nodes' => array_values(
 									array_map(
-										function( $item ) {
+										function ( $item ) {
 											return [
 												'productId' => $item->get_product_id(),
 												'variationId' => ! empty( $item->get_variation_id() )
@@ -667,7 +664,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'couponLines'   => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										function ( $item ) {
 											return [
 												'databaseId' => $item->get_id(),
 												'orderId'  => $item->get_order_id(),
@@ -686,7 +683,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'feeLines'      => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										static function ( $item ) {
 											return [
 												'databaseId' => $item->get_id(),
 												'orderId'  => $item->get_order_id(),
@@ -707,7 +704,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'shippingLines' => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										static function ( $item ) {
 											return [
 												'databaseId' => $item->get_id(),
 												'orderId'  => $item->get_order_id(),
@@ -730,7 +727,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'taxLines'      => [
 								'nodes' => array_reverse(
 									array_map(
-										function( $item ) {
+										static function ( $item ) {
 											return [
 												'rateCode' => $item->get_rate_code(),
 												'label'    => $item->get_label(),
@@ -747,7 +744,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 							'lineItems'     => [
 								'nodes' => array_values(
 									array_map(
-										function( $item ) {
+										function ( $item ) {
 											return [
 												'productId' => $item->get_product_id(),
 												'variationId' => ! empty( $item->get_variation_id() )

--- a/tests/wpunit/OrderQueriesTest.php
+++ b/tests/wpunit/OrderQueriesTest.php
@@ -3,11 +3,10 @@
 use WPGraphQL\Type\WPEnumType;
 
 class OrderQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function expectedOrderData( $order_id ) {
 		$order = \wc_get_order( $order_id );
 
-		$expected = [
+		return [
 			$this->expectedObject(
 				'order',
 				[
@@ -91,8 +90,6 @@ class OrderQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLT
 				]
 			),
 		];
-
-		return $expected;
 	}
 
 	// tests
@@ -284,7 +281,7 @@ class OrderQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLT
 		$orders   = [
 			$this->factory->order->createNew(
 				[
-					'billing_email' => 'test@example.com'
+					'billing_email' => 'test@example.com',
 				],
 				[
 					'line_items' => [

--- a/tests/wpunit/PaymentGatewayQueriesTest.php
+++ b/tests/wpunit/PaymentGatewayQueriesTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class PaymentGatewayQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function setUp(): void {
 		// before
 		parent::setUp();
@@ -156,5 +155,4 @@ class PaymentGatewayQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\Wo
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}
-
 }

--- a/tests/wpunit/PaymentMethodMutationsTest.php
+++ b/tests/wpunit/PaymentMethodMutationsTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class PaymentMethodMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	// Tests
 	public function testSetDefaultPaymentMethodMutation() {
 		// Create customer.

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -99,7 +99,7 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 				'image_id'      => null,
 				'regular_price' => 10,
 			]
-		);	
+		);  
 		$other_product_id_2 = $this->factory->product->createSimple();
 		$this->clearSchema();
 
@@ -150,16 +150,16 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 		$variables = [ 'size' => 'small' ];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_map(
-			function( $id ) {
+			function ( $id ) {
 				return $this->expectedField( 'allPaSize.nodes.0.variations.nodes.#.id', $this->toRelayId( 'product_variation', $id ) );
 			},
 			array_filter(
 				$variation_ids,
-				function( $id ) {
+				static function ( $id ) {
 					$variation       = new \WC_Product_Variation( $id );
 					$small_attribute = array_filter(
 						$variation->get_attributes(),
-						function( $attribute ) {
+						static function ( $attribute ) {
 							return 'small' === $attribute;
 						}
 					);

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -1,6 +1,5 @@
 <?php
 class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function getExpectedProductData( $product_id ) {
 		$product         = \wc_get_product( $product_id );
 		$is_shop_manager = false;
@@ -519,7 +518,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		';
 
 		$all_expected_product_nodes = array_map(
-			function( $product_id ) {
+			function ( $product_id ) {
 				return $this->expectedNode(
 					'products.nodes',
 					[ 'id' => $this->toRelayId( 'product', $product_id ) ]
@@ -546,7 +545,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids ) {
+			static function ( $node, $index ) use ( $product_ids ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return 'test-product-1' === $product->get_slug();
 			},
@@ -578,7 +577,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids ) {
+			static function ( $node, $index ) use ( $product_ids ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return 'simple' === $product->get_type();
 			},
@@ -609,7 +608,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids ) {
+			static function ( $node, $index ) use ( $product_ids ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return 'simple' !== $product->get_type();
 			},
@@ -628,7 +627,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids ) {
+			static function ( $node, $index ) use ( $product_ids ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return $product->get_featured();
 			},
@@ -647,7 +646,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids ) {
+			static function ( $node, $index ) use ( $product_ids ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return 10.00 >= floatval( $product->get_price() );
 			},
@@ -697,7 +696,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids, $category_3 ) {
+			static function ( $node, $index ) use ( $product_ids, $category_3 ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return in_array( $category_3, $product->get_category_ids(), true );
 			},
@@ -742,7 +741,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids, $category_4 ) {
+			static function ( $node, $index ) use ( $product_ids, $category_4 ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return ! in_array( $category_4, $product->get_category_ids(), true );
 			},
@@ -773,7 +772,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids, $category_4 ) {
+			static function ( $node, $index ) use ( $product_ids, $category_4 ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return in_array( $category_4, $product->get_category_ids(), true );
 			},
@@ -806,7 +805,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$expected  = array_filter(
 			$all_expected_product_nodes,
-			function( $node, $index ) use ( $product_ids, $category_4, $category_3 ) {
+			static function ( $node, $index ) use ( $product_ids, $category_4, $category_3 ) {
 				$product = \wc_get_product( $product_ids[ $index ] );
 				return ! in_array( $category_4, $product->get_category_ids(), true )
 					&& in_array( $category_3, $product->get_category_ids(), true );

--- a/tests/wpunit/ProductReviewMutationsTest.php
+++ b/tests/wpunit/ProductReviewMutationsTest.php
@@ -3,7 +3,6 @@
 use GraphQLRelay\Relay;
 
 class ProductReviewMutationsTest extends \Codeception\TestCase\WPTestCase {
-
 	public function setUp(): void {
 		// before
 		parent::setUp();

--- a/tests/wpunit/ProductVariationQueriesTest.php
+++ b/tests/wpunit/ProductVariationQueriesTest.php
@@ -3,7 +3,6 @@
 use WPGraphQL\Type\WPEnumType;
 
 class ProductVariationQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function expectedProductVariationData( $id ) {
 		$data = new WC_Product_Variation( $id );
 
@@ -93,7 +92,7 @@ class ProductVariationQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 		$id           = $this->toRelayId( 'product_variation', $variation_id );
 
 		// Create query.
-		$query        = '
+		$query = '
             query ($id: ID, $idType: ProductVariationIdTypeEnum) {
                 productVariation(id: $id, idType: $idType) {
                     id
@@ -165,8 +164,8 @@ class ProductVariationQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 			'idType' => 'DATABASE_ID',
 
 		];
-		$response  = $this->graphql( compact( 'query', 'variables' ) );
-		$expected  = $this->expectedProductVariationData( $variation_id );
+		$response = $this->graphql( compact( 'query', 'variables' ) );
+		$expected = $this->expectedProductVariationData( $variation_id );
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}
@@ -234,7 +233,7 @@ class ProductVariationQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 					. ' - '
 					. \wc_graphql_price( end( $prices['regular_price'] ) )
 			),
-			$this->expectedField( 'product.salePrice', self::IS_NULL )
+			$this->expectedField( 'product.salePrice', self::IS_NULL ),
 		];
 
 		$this->assertQuerySuccessful( $response, $expected );
@@ -336,7 +335,7 @@ class ProductVariationQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 					$this->expectedField( 'fileExists', $downloads[0]->file_exists() ),
 					$this->expectedField( 'file', $downloads[0]->get_file() ),
 				]
-			)
+			),
 		];
 
 		$this->assertQuerySuccessful( $response, $expected );

--- a/tests/wpunit/QLSessionHandlerTest.php
+++ b/tests/wpunit/QLSessionHandlerTest.php
@@ -3,9 +3,9 @@
  * Unit test for QL_Session_Handler
  */
 
+use WPGraphQL\WooCommerce\Utils\QL_Session_Handler;
 use WPGraphQL\WooCommerce\Vendor\Firebase\JWT\JWT;
 use WPGraphQL\WooCommerce\Vendor\Firebase\JWT\Key;
-use WPGraphQL\WooCommerce\Utils\QL_Session_Handler;
 
 if ( ! defined( 'GRAPHQL_WOOCOMMERCE_SECRET_KEY' ) ) {
 	define( 'GRAPHQL_WOOCOMMERCE_SECRET_KEY', 'graphql-woo-cart-session' );

--- a/tests/wpunit/RefundQueriesTest.php
+++ b/tests/wpunit/RefundQueriesTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use GraphQLRelay\Relay;
 class RefundQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function expectedRefundData( $refund_id ) {
 		$refund = \wc_get_order( $refund_id );
 
@@ -81,7 +79,7 @@ class RefundQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 		$this->loginAs( 1 );
 		$response = $this->graphql( compact( 'query', 'variables' ) );
 		$expected = $this->expectedRefundData( $refund_id );
-		//$expected[] = $this->expectedField( 'refund.refundedBy.databaseId', $refund->get_refunded_by() );
+		// $expected[] = $this->expectedField( 'refund.refundedBy.databaseId', $refund->get_refunded_by() );
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}

--- a/tests/wpunit/ShippingMethodQueriesTest.php
+++ b/tests/wpunit/ShippingMethodQueriesTest.php
@@ -81,7 +81,7 @@ class ShippingMethodQueriesTest extends \Codeception\TestCase\WPTestCase {
 		$wc_shipping = WC_Shipping::instance();
 		$methods     = array_values(
 			array_map(
-				function( $method ) {
+				static function ( $method ) {
 					return [ 'id' => Relay::toGlobalId( 'shipping_method', $method->id ) ];
 				},
 				$wc_shipping->get_shipping_methods()

--- a/tests/wpunit/TaxRateQueriesTest.php
+++ b/tests/wpunit/TaxRateQueriesTest.php
@@ -4,7 +4,7 @@ class TaxRateQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 	public function expectedTaxRateData( $rate_id ) {
 		$rate = $this->factory->tax_rate->get_object_by_id( $rate_id );
 
-		$expected = [
+		return [
 			$this->expectedField( 'taxRate.id', $this->toRelayId( 'tax_rate', $rate_id ) ),
 			$this->expectedField( 'taxRate.databaseId', absint( $rate->tax_rate_id ) ),
 			$this->expectedField( 'taxRate.country', ! empty( $rate->tax_rate_country ) ? $rate->tax_rate_country : self::IS_NULL ),
@@ -24,8 +24,6 @@ class TaxRateQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 					: 'STANDARD'
 			),
 		];
-
-		return $expected;
 	}
 
 	// tests
@@ -128,7 +126,7 @@ class TaxRateQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		 */
 		$response = $this->graphql( compact( 'query' ) );
 		$expected = array_map(
-			function( $id ) {
+			function ( $id ) {
 				return $this->expectedNode(
 					'taxRates.nodes',
 					[
@@ -149,7 +147,7 @@ class TaxRateQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$reduced_tax_rates = array_values(
 			array_filter(
 				$rates,
-				function( $id ) {
+				function ( $id ) {
 					$rate = $this->factory->tax_rate->get_object_by_id( $id );
 					return 'reduced-rate' === $rate->tax_rate_class;
 				}
@@ -158,7 +156,7 @@ class TaxRateQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$variables         = [ 'class' => 'REDUCED_RATE' ];
 		$response          = $this->graphql( compact( 'query', 'variables' ) );
 		$expected          = array_map(
-			function( $id ) {
+			function ( $id ) {
 				return $this->expectedNode(
 					'taxRates.nodes',
 					[

--- a/tests/wpunit/TransferSessionHandlerTest.php
+++ b/tests/wpunit/TransferSessionHandlerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use function WPGraphQL\WooCommerce\get_includes_directory;
 use WPGraphQL\WooCommerce\Utils\Transfer_Session_Handler;
+use function WPGraphQL\WooCommerce\get_includes_directory;
 class TransferSessionHandlerTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
 	/**
 	 * Session handler instance.
 	 *
-	 * @var Transfer_Session_Handler
+	 * @var \WPGraphQL\WooCommerce\Utils\Transfer_Session_Handler
 	 */
 	private $session;
 

--- a/tests/wpunit/UpdateSessionMutationTest.php
+++ b/tests/wpunit/UpdateSessionMutationTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class UpdateSessionMutationTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function testUpdateSessionMutation() {
 		// Create registered customer.
 		$registered = $this->factory->customer->create();

--- a/tests/wpunit/VariationAttributeQueriesTest.php
+++ b/tests/wpunit/VariationAttributeQueriesTest.php
@@ -1,7 +1,6 @@
 <?php
 
 class VariationAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTestCase {
-
 	public function expectedAttributes( $id ) {
 		$product    = wc_get_product( $id );
 		$attributes = 'variable' === $product->get_type()
@@ -37,6 +36,7 @@ class VariationAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCas
 
 		return $expected;
 	}
+
 	public function expectedDefaultAttributes( $id ) {
 		$product    = wc_get_product( $id );
 		$attributes = $product->get_attributes();
@@ -164,7 +164,7 @@ class VariationAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCas
 			],
 		];
 		$attributes     = array_map(
-			function( $data, $index ) {
+			static function ( $data, $index ) {
 				\codecept_debug( $data );
 				$attribute = new \WC_Product_Attribute();
 				$attribute->set_id( $data['attribute_id'] );
@@ -222,5 +222,4 @@ class VariationAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCas
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}
-
 }

--- a/tests/wpunit/bootstrap.php
+++ b/tests/wpunit/bootstrap.php
@@ -4,7 +4,6 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
-use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
  * Remove the "extensions" payload from GraphQL results
@@ -12,7 +11,7 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  */
 add_filter(
 	'graphql_request_results',
-	function( $response ) {
+	static function ( $response ) {
 		unset( $response['extensions'] );
 
 		return $response;

--- a/wp-graphql-woocommerce.php
+++ b/wp-graphql-woocommerce.php
@@ -10,6 +10,8 @@
  * Domain Path: /languages
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * Requires at least: 6.1
+ * Requires PHP: 7.3
  * WC requires at least: 7.9.0
  * WC tested up to: 8.1.1
  * WPGraphQL requires at least: 1.16.0+


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR bumps the minimum WordPress (6.1) and minimum PHP (7.3) versions to match the upstream requirements ( from WooCommerce 7.9.0 ).

Additionally, the PHPCS ruleset has been updated to WPCS 3.0 (since older versions arent compatible with PHP 8.0+) and the resulting smells either remediated (when it wouldnt be a breaking change to do so) or allowlisted.

**No actual code functionality has been changed**

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** `develop`
- **WPGraphQL Version:** 1.18.0
- **WordPress Version: 6.3.2
- **WooCommerce Version: 7.9.0, 8.2.1
