### PR TITLE
fix: currency input field fixed for createOrder mutation

### DIFF
--- a/access-functions.php
+++ b/access-functions.php
@@ -195,19 +195,12 @@ if ( ! function_exists( 'wc_graphql_underscore_to_camel_case' ) ) {
 	/**
 	 * Converts a camel case formatted string to a underscore formatted string.
 	 *
-	 * @param string  $str         String to be formatted.
-	 * @param boolean $capitalize  Capitalize first letter of string.
+	 * @param string $str         String to be formatted.
 	 *
 	 * @return string
 	 */
-	function wc_graphql_underscore_to_camel_case( $str, $capitalize = false ) {
-		$str = str_replace( ' ', '', ucwords( str_replace( '-', ' ', $str ) ) );
-
-		if ( ! $capitalize ) {
-			$str[0] = strtolower( $str[0] );
-		}
-
-		return $str;
+	function wc_graphql_underscore_to_camel_case( $str ) {
+		return lcfirst( str_replace( ' ', '', ucwords( str_replace( '_', ' ', $str ) ) ) );
 	}
 }
 
@@ -220,19 +213,11 @@ if ( ! function_exists( 'wc_graphql_camel_case_to_underscore' ) ) {
 	 * @return string
 	 */
 	function wc_graphql_camel_case_to_underscore( $str ) {
-		preg_match_all(
-			'!([A-Z][A-Z0-9]*(?=$|[A-Z][a-z0-9])|[A-Za-z][a-z0-9]+)!',
-			$str,
-			$matches
-		);
-
-		$ret = $matches[0];
-
-		foreach ( $ret as &$match ) {
-			$match = strtoupper( $match ) === $match ? strtolower( $match ) : lcfirst( $match );
-		}
-
-		return implode( '_', $ret );
+		/**
+		 * @var string  Sort mutated string.
+		 */
+		$replace = preg_replace( '/(?<!^)[A-Z]/', '_$0', $str );
+		return strtolower( $replace );
 	}
 }//end if
 

--- a/includes/class-type-registry.php
+++ b/includes/class-type-registry.php
@@ -45,6 +45,7 @@ class Type_Registry {
 		Type\WPEnum\Cart_Error_Type::register();
 		Type\WPEnum\Product_Attribute_Enum::register();
 		Type\WPEnum\Attribute_Operator_Enum::register();
+		Type\WPEnum\Currency_Enum::register();
 
 		/**
 		 * InputObjects.

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -238,6 +238,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 			require $include_directory_path . 'type/enum/class-taxonomy-operator.php';
 			require $include_directory_path . 'type/enum/class-attribute-operator-enum.php';
 			require $include_directory_path . 'type/enum/class-product-attribute-enum.php';
+			require $include_directory_path . 'type/enum/class-currency-enum.php';
 
 			// Include interface type class files.
 			require $include_directory_path . 'type/interface/class-attribute.php';

--- a/includes/data/connection/class-coupon-connection-resolver.php
+++ b/includes/data/connection/class-coupon-connection-resolver.php
@@ -198,11 +198,17 @@ class Coupon_Connection_Resolver extends AbstractConnectionResolver {
 
 	/**
 	 * Returns meta keys to be used for connection ordering.
+	 * 
+	 * @param bool $is_numeric  Return numeric meta keys. Defaults to "true".
 	 *
 	 * @return array
 	 */
-	public function ordering_meta() {
-		return [];
+	public function ordering_meta( $is_numeric = true ) {
+		if ( ! $is_numeric ) {
+			return apply_filters( 'woographql_coupon_connection_orderby_meta_keys', [] );
+		}
+
+		return apply_filters( 'woographql_coupon_connection_orderby_numeric_meta_keys', [] );
 	}
 
 	/**

--- a/includes/data/connection/class-order-connection-resolver.php
+++ b/includes/data/connection/class-order-connection-resolver.php
@@ -227,17 +227,30 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 	/**
 	 * Returns meta keys to be used for connection ordering.
 	 *
+	 * @param bool $is_numeric  Return numeric meta keys. Defaults to "true".
+	 *
 	 * @return array
 	 */
-	public function ordering_meta() {
-		return [
-			'_order_key',
-			'_cart_discount',
-			'_order_total',
-			'_order_tax',
-			'_date_paid',
-			'_date_completed',
-		];
+	public function ordering_meta( $is_numeric = true ) {
+		if ( ! $is_numeric ) {
+			return apply_filters(
+				'woographql_order_connection_orderby_meta_keys',
+				[
+					'_order_key',
+					'_date_paid',
+					'_date_completed',
+				]
+			);
+		}
+
+		return apply_filters(
+			'woographql_order_connection_orderby_numeric_meta_keys',
+			[
+				'_cart_discount',
+				'_order_total',
+				'_order_tax',
+			]
+		);
 	}
 
 	/**

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -249,11 +249,20 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 	/**
 	 * Returns meta keys to be used for connection ordering.
 	 *
+	 * @param bool $is_numeric  Return numeric meta keys. Defaults to "true".
+	 * 
 	 * @return array
 	 */
-	public function ordering_meta() {
+	public function ordering_meta( $is_numeric = true ) {
+		if ( ! $is_numeric ) {
+			return apply_filters(
+				'woographql_product_connection_orderby_meta_keys',
+				[]
+			);
+		}
+
 		return apply_filters(
-			'graphql_woocommerce_products_add_sort_fields',
+			'woographql_product_connection_orderby_numeric_meta_keys',
 			[
 				'_price',
 				'_regular_price',

--- a/includes/data/connection/trait-wc-cpt-loader-common.php
+++ b/includes/data/connection/trait-wc-cpt-loader-common.php
@@ -87,11 +87,14 @@ trait WC_CPT_Loader_Common {
 				if ( in_array( $orderby_field, $post_fields, true ) ) {
 					$args['orderby'][ $orderby_field ] = $orderby_order;
 
-					// Handle meta fields.
+					// Handle non-numeric meta fields.
+				} elseif ( in_array( $orderby_field, $this->ordering_meta( false ), true ) ) {
+					$args['orderby']['meta_value'] = $orderby_order; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+					$args['meta_key']              = $orderby_field;
+					// Handle numeric meta fields.
 				} elseif ( in_array( $orderby_field, $this->ordering_meta(), true ) ) {
-					$args['orderby']['meta_value_num'] = $orderby_order;
-					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					$args['meta_key'] = $orderby_field;
+					$args['orderby']['meta_value_num'] = $orderby_order; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					$args['meta_key']                  = $orderby_field;
 				} else {
 					$args['orderby'][ $orderby_field ] = $orderby_order;
 				}

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -49,7 +49,7 @@ class Order_Create {
 				'description' => __( 'Parent order ID.', 'wp-graphql-woocommerce' ),
 			],
 			'currency'           => [
-				'type'        => 'String',
+				'type'        => 'CurrencyEnum',
 				'description' => __( 'Currency the order was created with, in ISO format.', 'wp-graphql-woocommerce' ),
 			],
 			'customerId'         => [

--- a/includes/type/enum/class-currency-enum.php
+++ b/includes/type/enum/class-currency-enum.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * WPEnum Type - CurrencyEnum
+ *
+ * @package WPGraphQL\WooCommerce\Type\WPEnum
+ * @since   TBD
+ */
+
+namespace WPGraphQL\WooCommerce\Type\WPEnum;
+
+/**
+ * Class Currency_Enum
+ */
+class Currency_Enum {
+	/**
+	 * Registers type
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		$currencies = get_woocommerce_currencies();
+		array_walk(
+			$currencies,
+			static function ( &$name, $code ) {
+				$name = [
+					'name'        => $code,
+					'value'       => $code,
+					'description' => $name,
+				];
+			}
+		);
+
+		register_graphql_enum_type(
+			'CurrencyEnum',
+			[
+				'description' => __( 'Currencies enumeration', 'wp-graphql-woocommerce' ),
+				'values'      => $currencies,
+			]
+		);
+	}
+}

--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -297,6 +297,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 					'value' => 'test value',
 				],
 			],
+			'currency' 		     => 'VND',
 			'isPaid'             => true,
 		];
 

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -500,7 +500,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 					typeNotIn: $typeNotIn,
 					featured: $featured,
 					maxPrice: $maxPrice,
-					orderby: $orderby
+					orderby: $orderby,
 					taxonomyFilter: $taxonomyFilter
 					include: $include
 					exclude: $exclude


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Fixes `currency` input field support in the `createOrder` mutation. Resolving #615 
- Fixes bug related to CPT connection sorting by meta. Adds some hooks for introducing custom sort options. Resolving #824


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
