### PR TITLE
fix: Session transaction queue fix

### DIFF
--- a/includes/utils/class-ql-session-handler.php
+++ b/includes/utils/class-ql-session-handler.php
@@ -107,7 +107,6 @@ class QL_Session_Handler extends WC_Session_Handler {
 		 */
 		add_action( 'woocommerce_set_cart_cookies', [ $this, 'set_customer_session_token' ], 10 );
 		add_action( 'woographql_update_session', [ $this, 'set_customer_session_token' ], 10 );
-		add_action( 'graphql_after_resolve_field', [ $this, 'save_if_dirty' ], 10, 4 );
 		add_action( 'shutdown', [ $this, 'save_data' ] );
 		add_action( 'wp_logout', [ $this, 'destroy_session' ] );
 
@@ -413,19 +412,9 @@ class QL_Session_Handler extends WC_Session_Handler {
 	/**
 	 * Save any changes to database after a session mutations has been run.
 	 *
-	 * @param mixed                                $source   Operation root object.
-	 * @param array                                $args     Operation arguments.
-	 * @param \WPGraphQL\AppContext                $context  AppContext instance.
-	 * @param \GraphQL\Type\Definition\ResolveInfo $info     Operation ResolveInfo object.
-	 *
 	 * @return void
 	 */
-	public function save_if_dirty( $source, $args, $context, $info ) {
-		// Bail early, if not one of the session mutations.
-		if ( ! in_array( $info->fieldName, Session_Transaction_Manager::get_session_mutations(), true ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			return;
-		}
-
+	public function save_if_dirty() {
 		// Update if user recently authenticated.
 		if ( is_user_logged_in() && get_current_user_id() !== $this->_customer_id ) {
 			$this->_customer_id = get_current_user_id();

--- a/includes/utils/class-session-transaction-manager.php
+++ b/includes/utils/class-session-transaction-manager.php
@@ -61,7 +61,7 @@ class Session_Transaction_Manager {
 
 		add_action( 'graphql_before_resolve_field', [ $this, 'update_transaction_queue' ], 10, 4 );
 		add_action( 'graphql_mutation_response', [ $this, 'pop_transaction_id' ], 20, 6 );
-		add_action( 'woo_session_transaction_complete', [ $this->session_handler, 'save_if_dirty' ], 10 );
+		add_action( 'woographql_session_transaction_complete', [ $this->session_handler, 'save_if_dirty' ], 10 );
 	}
 
 	/**
@@ -155,7 +155,6 @@ class Session_Transaction_Manager {
 	public function next_transaction() {
 		// Update transaction queue.
 		$transaction_queue = $this->get_transaction_queue();
-		header( 'CODECEPT_DEBUG: ' . json_encode( array_column( $transaction_queue, 'transaction_id' ) ) );
 
 		// If lead transaction object invalid pop transaction and loop.
 		if ( ! is_array( $transaction_queue[0] ) ) {
@@ -241,10 +240,10 @@ class Session_Transaction_Manager {
 			/**
 			 * Mark transaction completion
 			 * 
-			 * @param $transition_id     Removed transaction ID.
-			 * @param $transaction_queue Transaction Queue.
+			 * @param string|null $transition_id     Removed transaction ID.
+			 * @param array       $transaction_queue Transaction Queue.
 			 */
-			do_action( 'woo_session_transaction_complete', $this->transaction_id, $transaction_queue );
+			do_action( 'woographql_session_transaction_complete', $this->transaction_id, $transaction_queue );
 			
 			// Clear transaction ID.
 			$this->transaction_id = null;

--- a/tests/functional/CartTransactionQueueCest.php
+++ b/tests/functional/CartTransactionQueueCest.php
@@ -268,11 +268,11 @@ class CartTransactionQueueCest {
 		$client   = new \GuzzleHttp\Client( compact( 'base_uri', 'headers', 'timeout' ) );
 
 		$iterator = static function ( $requests ) use ( $client ) {
-			$stagger = 1000;
+			$stagger = 800;
 			foreach ( $requests as $index => $payload ) {
 				yield static function () use ( $client, $stagger, $index, $payload ) {
 					$body      = json_encode( $payload );
-					$delay     = $stagger * $index + 1;
+					$delay     = $stagger * ($index + 1);
 					$connected = false;
 					$progress  = static function ( $downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes ) use ( $index, &$connected ) {
 						if ( $uploadTotal === $uploadedBytes && 0 === $downloadTotal && ! $connected ) {
@@ -294,8 +294,10 @@ class CartTransactionQueueCest {
 					\codecept_debug( "Finished session mutation request $index @ " . ( new \Carbon\Carbon() )->format( 'Y-m-d H:i:s' ) );
 
 					$expected = $expected_responses[ $index ];
+					$headers  = $response->getHeaders();
 					$body     = json_decode( $response->getBody(), true );
-
+					
+					\codecept_debug( $headers );
 					\codecept_debug( $body );
 					$I->assertEquals( $expected, $body['data'] );
 				},


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Changes hook used for **WPGraphQL\WooCommerce\Utils\Session_Transaction_Manager::pop_transaction_id** to **graphql_mutation_response**
- **woographql_session_transaction_complete** hook added to the end of **WPGraphQL\WooCommerce\Utils\Session_Transaction_Manager::pop_transaction_id**
- Changes hook used for **WPGraphQL\WooCommerce\Utils\QL_Session_Handler::save_if_dirty()** to **woographql_session_transaction_complete**


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
