### PR TITLE
fix: DownloadableItem "product" field type changed to ProductUnion

### DIFF
--- a/includes/type/object/class-downloadable-item-type.php
+++ b/includes/type/object/class-downloadable-item-type.php
@@ -76,7 +76,7 @@ class Downloadable_Item_Type {
 						},
 					],
 					'product'            => [
-						'type'        => 'Product',
+						'type'        => 'ProductUnion',
 						'description' => __( 'Product of downloadable item.', 'wp-graphql-woocommerce' ),
 						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							return Factory::resolve_crud_object( $source['product_id'], $context );


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Changes **DownloadableItem's** product field type to **ProductUnion** to add support for product variation. Resolves #502 


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
