### PR TITLE
fix: Potential Infinite loop caused by nested `pre_get_posts` hooks patched

### DIFF
--- a/includes/utils/class-protected-router.php
+++ b/includes/utils/class-protected-router.php
@@ -49,7 +49,6 @@ class Protected_Router {
 		self::$route = woographql_setting( 'authorizing_url_endpoint', apply_filters( 'woographql_authorizing_url_endpoint', self::$default_route ) );
 
 		$this->init();
-		
 	}
 
 	/**
@@ -61,17 +60,17 @@ class Protected_Router {
 		/**
 		 * Create the rewrite rule for the route
 		 */
-		add_action( 'init', [ self::$instance, 'add_rewrite_rule' ], 10 );
+		add_action( 'init', [ $this, 'add_rewrite_rule' ], 10 );
 
 		/**
 		 * Add the query var for the route
 		 */
-		add_filter( 'query_vars', [ self::$instance, 'add_query_var' ], 1, 1 );
+		add_filter( 'query_vars', [ $this, 'add_query_var' ], 1, 1 );
 
 		/**
 		 * Redirects the route to the graphql processor
 		 */
-		add_action( 'pre_get_posts', [ self::$instance, 'resolve_request' ], 1 );
+		add_action( 'pre_get_posts', [ $this, 'resolve_request' ], 1 );
 	}
 
 	/**
@@ -196,7 +195,7 @@ class Protected_Router {
 		 * Remove the resolve_request function from the pre_get_posts action
 		 * to prevent an infinite loop
 		 */
-		remove_action( 'pre_get_posts', [ self::$instance, 'resolve_request' ], 1 );
+		remove_action( 'pre_get_posts', [ $this, 'resolve_request' ], 1 );
 
 		/**
 		 * Access the $wp_query object


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds `remove_filter` at the top of **Protected_Router::resolve_request()** to avoid any possible recursive triggers of the hook resulting in an infinite loop


Does this close any currently open issues?
------------------------------------------
Resolves #846 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------

- **WooGraphQL Version:** …
- **WPGraphQL Version:** …
- **WordPress Version:**
- **WooCommerce Version:**
