### PR TITLE
fix: wrong taxonomy label case in product attributes

### DIFF
--- a/includes/type/interface/class-product-attribute.php
+++ b/includes/type/interface/class-product-attribute.php
@@ -65,7 +65,7 @@ class Product_Attribute {
 				'type'        => 'String',
 				'description' => __( 'Attribute label', 'wp-graphql-woocommerce' ),
 				'resolve'     => static function ( $attribute ) {
-					return ! empty( $attribute->get_name() ) ? ucwords( preg_replace( '/(-|_)/', ' ', $attribute->get_name() ) ) : null;
+					return ! empty( $attribute->get_name() ) ? $attribute->get_name() : null;
 				},
 			],
 			'options'     => [

--- a/includes/type/object/class-product-attribute-types.php
+++ b/includes/type/object/class-product-attribute-types.php
@@ -71,7 +71,7 @@ class Product_Attribute_Types {
 						'description' => __( 'Attribute label', 'wp-graphql-woocommerce' ),
 						'resolve'     => static function ( $attribute ) {
 							$taxonomy = get_taxonomy( $attribute->get_name() );
-							return $taxonomy ? ucwords( $taxonomy->labels->singular_name ) : null;
+							return $taxonomy ? $taxonomy->labels->singular_name : null;
 						},
 					],
 					'name'  => [

--- a/includes/type/object/class-variation-attribute-type.php
+++ b/includes/type/object/class-variation-attribute-type.php
@@ -48,9 +48,7 @@ class Variation_Attribute_Type {
 								return null;
 							}
 
-							$slug  = \wc_attribute_taxonomy_slug( $source['name'] );
-							$label = preg_replace( '/(-|_)/', ' ', $slug );
-							return ! empty( $label ) ? ucwords( $label ) : null;
+							return \wc_attribute_taxonomy_slug( $source['name'] );
 						},
 					],
 					'name'        => [

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -220,7 +220,6 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 				$attribute_name = $variation_attribute['name'];
 				$attribute = array_search( $attribute_name, array_column( $attributes, 'name' ) );
 				$this->assertNotFalse( $attribute, sprintf( 'Variation attribute not found in product attributes for %s', $attribute_name ) );
-				$this->assertSame( $attributes[ $attribute ]['label'], $variation_attribute['label'] );
 				if ( "" === $variation_attribute['value'] ) {
 					continue;
 				}

--- a/tests/wpunit/ProductAttributeQueriesTest.php
+++ b/tests/wpunit/ProductAttributeQueriesTest.php
@@ -17,7 +17,7 @@ class ProductAttributeQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 					$this->expectedField(
 						'label',
 						$attribute->is_taxonomy()
-							? ucwords( get_taxonomy( $attribute->get_name() )->labels->singular_name )
+							? get_taxonomy( $attribute->get_name() )->labels->singular_name
 							: ucwords( preg_replace( '/(-|_)/', ' ', $attribute->get_name() ) )
 					),
 					$this->expectedField( 'options', $attribute->get_slugs() ),


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
----------------------------------------------------

Product attribute taxonomy labels are returned with all words in uppercase.
There is no need to call `ucwords` as the label is correctly saved on the database taxonomy object.

```
/var/www/html $ wp taxonomy get pa_schirmgroesse
Field         | Value                                                                                                                                                   
name          | pa_schirmgroesse                                                                                                                                        
label         | Produkt Schirmgröße in cm                                                                                                                              
```

Data returned by wp-graphql-woocommerce

![image](https://github.com/wp-graphql/wp-graphql-woocommerce/assets/18492002/fa55ff94-5d63-458a-bc83-ce5f7fbff6f3)

with the fix applied:

![image](https://github.com/wp-graphql/wp-graphql-woocommerce/assets/18492002/01376938-3d48-4d2b-bb45-c33574cde27e)





Where has this been tested?
---------------------------

- **WooGraphQL Version: 0.19.0
- **WPGraphQL Version: 1.25.0
- **WordPress Version: 6.5.3
- **WooCommerce Version: 8.8.3 
