### PR TITLE
feat: Add Product_Attributes_Connection_Orderby_Enum with MENU_ORDER

### DIFF
--- a/includes/class-type-registry.php
+++ b/includes/class-type-registry.php
@@ -48,6 +48,7 @@ class Type_Registry {
 		Type\WPEnum\Currency_Enum::register();
 		Type\WPEnum\Shipping_Location_Type_Enum::register();
 		Type\WPEnum\WC_Setting_Type_Enum::register();
+		Type\WPEnum\Product_Attributes_Connection_Orderby_Enum::register();
 
 		/**
 		 * InputObjects.

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -246,6 +246,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 			require $include_directory_path . 'type/enum/class-currency-enum.php';
 			require $include_directory_path . 'type/enum/class-shipping-location-type-enum.php';
 			require $include_directory_path . 'type/enum/class-wc-setting-type-enum.php';
+			require $include_directory_path . 'type/enum/class-product-attributes-connection-orderby-enum.php';
 
 			// Include interface type class files.
 			require $include_directory_path . 'type/interface/class-attribute.php';

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -120,7 +120,7 @@ class WC_Terms extends TermObjects {
 				'fromFieldName'  => 'terms',
 				'connectionArgs' => self::get_connection_args(
 					[
-						'orderby'             => [
+						'orderby' => [
 							'type'        => 'ProductAttributesConnectionOrderbyEnum',
 							'description' => __( 'Field(s) to order terms by. Defaults to \'name\'.', 'wp-graphql-woocommerce' ),
 						],

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -118,7 +118,14 @@ class WC_Terms extends TermObjects {
 				'toType'         => 'TermNode',
 				'queryClass'     => 'WP_Term_Query',
 				'fromFieldName'  => 'terms',
-				'connectionArgs' => self::get_connection_args(),
+				'connectionArgs' => self::get_connection_args(
+					[
+						'orderby'             => [
+							'type'        => 'ProductAttributesConnectionOrderbyEnum',
+							'description' => __( 'Field(s) to order terms by. Defaults to \'name\'.', 'wp-graphql-woocommerce' ),
+						],
+					]
+				),
 				'resolve'        => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 					if ( ! $source->is_taxonomy() ) {
 						throw new UserError( __( 'Invalid product attribute', 'wp-graphql-woocommerce' ) );

--- a/includes/type/enum/class-product-attributes-connection-orderby-enum.php
+++ b/includes/type/enum/class-product-attributes-connection-orderby-enum.php
@@ -6,6 +6,8 @@
  * @since   0.2.2
  */
 
+ namespace WPGraphQL\WooCommerce\Type\WPEnum;
+
 /**
  * Class Product_Attributes_Connection_Orderby_Enum
  */

--- a/includes/type/enum/class-product-attributes-connection-orderby-enum.php
+++ b/includes/type/enum/class-product-attributes-connection-orderby-enum.php
@@ -60,3 +60,4 @@ class Product_Attributes_Connection_Orderby_Enum {
 		);
 	}
 }
+

--- a/includes/type/enum/class-product-attributes-connection-orderby-enum.php
+++ b/includes/type/enum/class-product-attributes-connection-orderby-enum.php
@@ -19,7 +19,7 @@ class Product_Attributes_Connection_Orderby_Enum {
 		register_graphql_enum_type(
 			'ProductAttributesConnectionOrderbyEnum',
 			[
-				'description' => __( 'Taxonomy query operators', 'wp-graphql-woocommerce' ),
+				'description' => __( 'Product attributes connection orderby enum', 'wp-graphql-woocommerce' ),
 				'values'      => [
 					'NAME'        => [
 						'value'       => 'name',

--- a/includes/type/enum/class-product-attributes-connection-orderby-enum.php
+++ b/includes/type/enum/class-product-attributes-connection-orderby-enum.php
@@ -60,4 +60,3 @@ class Product_Attributes_Connection_Orderby_Enum {
 		);
 	}
 }
-

--- a/includes/type/enum/class-product-attributes-connection-orderby-enum.php
+++ b/includes/type/enum/class-product-attributes-connection-orderby-enum.php
@@ -6,13 +6,13 @@
  * @since   0.2.2
  */
 
- namespace WPGraphQL\WooCommerce\Type\WPEnum;
+namespace WPGraphQL\WooCommerce\Type\WPEnum;
 
 /**
  * Class Product_Attributes_Connection_Orderby_Enum
  */
 class Product_Attributes_Connection_Orderby_Enum {
-	 /**
+	/**
 	 * Registers type
 	 *
 	 * @return void
@@ -43,7 +43,7 @@ class Product_Attributes_Connection_Orderby_Enum {
 						'value'       => 'term_order',
 						'description' => __( 'Order the connection by term order.', 'wp-graphql-woocommerce' ),
 					],
-                    'MENU_ORDER'  => [
+					'MENU_ORDER'  => [
 						'value'       => 'menu_order',
 						'description' => __( 'Order the connection by woocommerce menu order.', 'wp-graphql-woocommerce' ),
 					],

--- a/includes/type/enum/class-product-attributes-connection-orderby-enum.php
+++ b/includes/type/enum/class-product-attributes-connection-orderby-enum.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WPEnum Type - Product_Attributes_Connection_Orderby_Enum
+ *
+ * @package WPGraphQL\WooCommerce\Type\WPEnum
+ * @since   0.2.2
+ */
+
+/**
+ * Class Product_Attributes_Connection_Orderby_Enum
+ */
+class Product_Attributes_Connection_Orderby_Enum {
+	 /**
+	 * Registers type
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		register_graphql_enum_type(
+			'ProductAttributesConnectionOrderbyEnum',
+			[
+				'description' => __( 'Taxonomy query operators', 'wp-graphql-woocommerce' ),
+				'values'      => [
+					'NAME'        => [
+						'value'       => 'name',
+						'description' => __( 'Order the connection by name.', 'wp-graphql-woocommerce' ),
+					],
+					'SLUG'        => [
+						'value'       => 'slug',
+						'description' => __( 'Order the connection by slug.', 'wp-graphql-woocommerce' ),
+					],
+					'TERM_GROUP'  => [
+						'value'       => 'term_group',
+						'description' => __( 'Order the connection by term group.', 'wp-graphql-woocommerce' ),
+					],
+					'TERM_ID'     => [
+						'value'       => 'term_id',
+						'description' => __( 'Order the connection by term id.', 'wp-graphql-woocommerce' ),
+					],
+					'TERM_ORDER'  => [
+						'value'       => 'term_order',
+						'description' => __( 'Order the connection by term order.', 'wp-graphql-woocommerce' ),
+					],
+                    'MENU_ORDER'  => [
+						'value'       => 'menu_order',
+						'description' => __( 'Order the connection by woocommerce menu order.', 'wp-graphql-woocommerce' ),
+					],
+					'DESCRIPTION' => [
+						'value'       => 'description',
+						'description' => __( 'Order the connection by description.', 'wp-graphql-woocommerce' ),
+					],
+					'COUNT'       => [
+						'value'       => 'count',
+						'description' => __( 'Order the connection by item count.', 'wp-graphql-woocommerce' ),
+					],
+				],
+			]
+		);
+	}
+}


### PR DESCRIPTION
This PR adds an enum for the product attributes orderBy enum. Adding the Menu_Order to return objects in the order defined.


Does this close any currently open issues?
------------------------------------------
https://github.com/wp-graphql/wp-graphql-woocommerce/issues/475



Any other comments?
------------------
Relevant PR: https://github.com/wp-graphql/wp-graphql/pull/3170


Where has this been tested?
---------------------------

- **WooGraphQL Version:** 0.20.0
- **WPGraphQL Version:** 1.27.2
- **WordPress Version:** 6.6
- **WooCommerce Version:** 9.1.2
