### PR TITLE
feat: Use Woocommerce Reset Password email for ResetPassword Mutation

### DIFF
--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -165,7 +165,7 @@ class WooCommerce_Filters {
 	 *                             the `WC_Email_Customer_Reset_Password` email is not enabled.
 	 */
 	public static function get_reset_password_message( $message, $key, $user_login ) {
-		/** @var \WC_Email_Customer_Reset_Password|null $wc_reset_email */
+		/** @var \WC_Email_Customer_Reset_Password $wc_reset_email */
 		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
 
 		if ( $wc_reset_email && $wc_reset_email->is_enabled() ) {
@@ -192,9 +192,13 @@ class WooCommerce_Filters {
 	 *                      the `WC_Email_Customer_Reset_Password` email is not enabled.
 	 */
 	public static function get_reset_password_title( $title ) {
-		/** @var \WC_Email_Customer_Reset_Password|null $wc_reset_email */
+		/** @var \WC_Email_Customer_Reset_Password $wc_reset_email */
 		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
 
-		return $wc_reset_email->is_enabled() ? $wc_reset_email->get_subject() : $title;
+		if ( $wc_reset_email && $wc_reset_email->is_enabled() ) {
+			return $wc_reset_email->get_subject();
+		}
+
+		return $title;
 	}
 }

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -167,7 +167,6 @@ class WooCommerce_Filters {
 	public static function get_reset_password_message( $message, $key, $user_login ) {
 		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
 		if ( $wc_reset_email->is_enabled() ) {
-			add_filter( 'retrieve_password_title', [ $wc_reset_email, 'get_subject' ] );
 			add_filter( 'wp_mail_content_type', [ $wc_reset_email, 'get_content_type' ] );
 
 			$wc_reset_email->user_login = $user_login;

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -165,7 +165,7 @@ class WooCommerce_Filters {
 	 *                             the `WC_Email_Customer_Reset_Password` email is not enabled.
 	 */
 	public static function get_reset_password_message( $message, $key, $user_login ) {
-		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
+		$wc_reset_email = \WC_Email_Customer_Reset_Password();
 		if ( $wc_reset_email && $wc_reset_email->is_enabled() ) {
 			add_filter( 'wp_mail_content_type', [ $wc_reset_email, 'get_content_type' ] );
 
@@ -190,7 +190,7 @@ class WooCommerce_Filters {
 	 *                      the `WC_Email_Customer_Reset_Password` email is not enabled.
 	 */
 	public static function get_reset_password_title( $title ) {
-		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
+		$wc_reset_email = \WC_Email_Customer_Reset_Password();
 		return $wc_reset_email->is_enabled() ? $wc_reset_email->get_subject() : $title;
 	}
 }

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -39,7 +39,7 @@ class WooCommerce_Filters {
 		// Add better support for Stripe payment gateway.
 		add_filter( 'graphql_stripe_process_payment_args', [ self::class, 'woographql_stripe_gateway_args' ], 10, 2 );
 
-		// WPGraphQL Reset password -> Use woocommerce email password template when requested
+		// WPGraphQL Reset password -> Use woocommerce email password template when requested.
 		add_filter( 'retrieve_password_message', [ self::class, 'get_reset_password_message' ], 10, 3 );
 		add_filter( 'retrieve_password_title', [ self::class, 'get_reset_password_title' ] );
 	}

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -166,7 +166,7 @@ class WooCommerce_Filters {
 	 */
 	public static function get_reset_password_message( $message, $key, $user_login ) {
 		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
-		if ( $wc_reset_email->is_enabled() ) {
+		if ( $wc_reset_email && $wc_reset_email->is_enabled() ) {
 			add_filter( 'wp_mail_content_type', [ $wc_reset_email, 'get_content_type' ] );
 
 			$wc_reset_email->user_login = $user_login;
@@ -178,7 +178,17 @@ class WooCommerce_Filters {
 		}
 	}
 
-	// Customizes the password reset title for ResetPassword Mutation
+	/**
+	 * Customizes the password reset title for ResetPassword Mutation.
+	 *
+	 * This function modifies the password reset email title to use WooCommerce's email subject
+	 * if the `WC_Email_Customer_Reset_Password` email is enabled.
+	 *
+	 * @param string $title The original password reset email title.
+	 *
+	 * @return string       The customized password reset email title. Returns the original title if
+	 *                      the `WC_Email_Customer_Reset_Password` email is not enabled.
+	 */
 	public static function get_reset_password_title( $title ) {
 		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
 		return $wc_reset_email->is_enabled() ? $wc_reset_email->get_subject() : $title;

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -175,9 +175,9 @@ class WooCommerce_Filters {
 			$wc_reset_email->reset_key  = $key;
 			$message                    = $wc_reset_email->style_inline( $wc_reset_email->get_content() );
 			return $message;
-		} else {
-			return $message;
 		}
+
+		return $message;
 	}
 
 	/**

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -39,7 +39,7 @@ class WooCommerce_Filters {
 		// Add better support for Stripe payment gateway.
 		add_filter( 'graphql_stripe_process_payment_args', [ self::class, 'woographql_stripe_gateway_args' ], 10, 2 );
 
-		// Use woocommerce email password template when requested
+		// WPGraphQL Reset password -> Use woocommerce email password template when requested
 		add_filter( 'retrieve_password_message', [ self::class, 'get_reset_password_message' ], 10, 4 );
 	}
 

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -169,17 +169,16 @@ class WooCommerce_Filters {
 		$message = $atts['message'];
 
 		// Check if email is about Password Reset get Woocommerce Email instead
-		if (strpos($subject, 'Password Reset') !== false) {
-			if (preg_match('/[?&]key=([^&]+)&login=([^&>]+)>?/', $message, $matches)) {
+		if ( strpos($subject, 'Password Reset') !== false ) {
+			if ( preg_match('/[?&]key=([^&]+)&login=([^&>]+)>?/', $message, $matches) ) {
 				$reset_key = $matches[1] ?? null;
 				$user_login = $matches[2] ?? null;
 
-				if ($reset_key && $user_login) {
-					$wc_emails = \WC()->mailer()->get_emails();
-					if (isset($wc_emails['WC_Email_Customer_Reset_Password'])) {
-						$wc_emails['WC_Email_Customer_Reset_Password']->trigger($user_login, $reset_key);
-						return true;
-					}
+				$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
+
+				if ( $reset_key && $user_login && $wc_reset_email->is_enabled() ) {
+					$wc_reset_email->trigger($user_login, $reset_key);
+					return true;
 				}
 			}
 		}

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -165,7 +165,9 @@ class WooCommerce_Filters {
 	 *                             the `WC_Email_Customer_Reset_Password` email is not enabled.
 	 */
 	public static function get_reset_password_message( $message, $key, $user_login ) {
-		$wc_reset_email = \WC_Email_Customer_Reset_Password();
+		/** @var \WC_Email_Customer_Reset_Password|null $wc_reset_email */
+		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
+
 		if ( $wc_reset_email && $wc_reset_email->is_enabled() ) {
 			add_filter( 'wp_mail_content_type', [ $wc_reset_email, 'get_content_type' ] );
 
@@ -190,7 +192,9 @@ class WooCommerce_Filters {
 	 *                      the `WC_Email_Customer_Reset_Password` email is not enabled.
 	 */
 	public static function get_reset_password_title( $title ) {
-		$wc_reset_email = \WC_Email_Customer_Reset_Password();
+		/** @var \WC_Email_Customer_Reset_Password|null $wc_reset_email */
+		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
+
 		return $wc_reset_email->is_enabled() ? $wc_reset_email->get_subject() : $title;
 	}
 }

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -167,19 +167,8 @@ class WooCommerce_Filters {
 	public static function get_reset_password_message( $message, $key, $user_login, $user_data ) {
 		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
 		if ( $wc_reset_email->is_enabled() ) {
-			add_filter(
-				'retrieve_password_title',
-				static function () use ( $wc_reset_email ) {
-					return $wc_reset_email->get_subject();
-				}
-			);
-
-			add_filter(
-				'wp_mail_content_type',
-				static function () use ( $wc_reset_email ) {
-					return $wc_reset_email->get_content_type();
-				}
-			);
+			add_filter( 'retrieve_password_title', [ $wc_reset_email, 'get_subject' ] );
+			add_filter( 'wp_mail_content_type', [ $wc_reset_email, 'get_content_type' ] );
 
 			$wc_reset_email->user_login = $user_login;
 			$wc_reset_email->reset_key  = $key;

--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -40,7 +40,8 @@ class WooCommerce_Filters {
 		add_filter( 'graphql_stripe_process_payment_args', [ self::class, 'woographql_stripe_gateway_args' ], 10, 2 );
 
 		// WPGraphQL Reset password -> Use woocommerce email password template when requested
-		add_filter( 'retrieve_password_message', [ self::class, 'get_reset_password_message' ], 10, 4 );
+		add_filter( 'retrieve_password_message', [ self::class, 'get_reset_password_message' ], 10, 3 );
+		add_filter( 'retrieve_password_title', [ self::class, 'get_reset_password_title' ] );
 	}
 
 	/**
@@ -150,7 +151,7 @@ class WooCommerce_Filters {
 	}
 
 	/**
-	 * Customizes the password reset message for WooCommerce.
+	 * Customizes the password reset message for ResetPassword Mutation.
 	 *
 	 * This function modifies the password reset message to use WooCommerce's email template
 	 * if the `WC_Email_Customer_Reset_Password` email is enabled. It sets the email subject
@@ -159,12 +160,11 @@ class WooCommerce_Filters {
 	 * @param string $message      The original password reset message.
 	 * @param string $key          The password reset key.
 	 * @param string $user_login   The username or email of the user requesting the password reset.
-	 * @param object $user_data    The user data object containing user details.
 	 *
 	 * @return string              The customized password reset message. Returns the original message if
 	 *                             the `WC_Email_Customer_Reset_Password` email is not enabled.
 	 */
-	public static function get_reset_password_message( $message, $key, $user_login, $user_data ) {
+	public static function get_reset_password_message( $message, $key, $user_login ) {
 		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
 		if ( $wc_reset_email->is_enabled() ) {
 			add_filter( 'retrieve_password_title', [ $wc_reset_email, 'get_subject' ] );
@@ -177,5 +177,11 @@ class WooCommerce_Filters {
 		} else {
 			return $message;
 		}
+	}
+
+	// Customizes the password reset title for ResetPassword Mutation
+	public static function get_reset_password_title( $title ) {
+		$wc_reset_email = \WC()->mailer()->emails['WC_Email_Customer_Reset_Password'];
+		return $wc_reset_email->is_enabled() ? $wc_reset_email->get_subject() : $title;
 	}
 }


### PR DESCRIPTION
This PR enhances the WooCommerce GraphQL functionality by adding a custom filter for handling password reset emails within the WooCommerce_Filters class. The new filter, retrieve_password_message, ensures that password reset emails are generated using the WooCommerce reset password email template.

### Purpose
The addition of the retrieve_password_message filter provides the following benefits:

- Consistent User Experience: Users will receive password reset emails formatted according to the WooCommerce email template, ensuring consistency with other WooCommerce communications.
- Enhanced Branding: By using WooCommerce's email template, the password reset process aligns with the overall branding and design of WooCommerce communications.
- Improved Front-End Integration: Users are directed to the WooCommerce front-end reset password page, rather than the default WordPress reset page (which is a wordpress reset-password page  /wp-login.php), providing a seamless and branded user experience.

This should PR resolves this [issue](https://github.com/wp-graphql/wp-graphql-woocommerce/issues/873)

### How to Disable
To revert to the default WordPress password reset email functionality, simply deactivate the "Customer Reset Password" email within the WooCommerce email settings. This will ensure that the standard WordPress password reset page is used instead of the WooCommerce front-end reset password page.

Where has this been tested?
---------------------------

- **WooGraphQL Version: 0.20.0
- **WPGraphQL Version: 1.27.2
- **WordPress Version: 6.6
- **WooCommerce Version: 9.1.2