### PR TITLE
Fix: Corrected maxPrice, minPrice handling in GraphQL product query to prevent errors with large values

### DIFF
--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -657,11 +657,11 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			];
 		}
 		if ( ! empty( $where_args['minPrice'] ) ) {
-			$query_args['min_price'] = str_replace( '.', '', number_format( $where_args['minPrice'], 2 ) );
+			$query_args['min_price'] = $where_args['minPrice'].'00';
 		}
 
 		if ( ! empty( $where_args['maxPrice'] ) ) {
-			$query_args['max_price'] = str_replace( '.', '', number_format( $where_args['maxPrice'], 2 ) );
+			$query_args['max_price'] = $where_args['maxPrice'].'00';
 		}
 
 		if ( isset( $where_args['stockStatus'] ) ) {


### PR DESCRIPTION
This pull request addresses an issue with number formatting in the `maxPrice` and `minPrice` filters for product queries in WPGraphQL WooCommerce. When users input values greater than 999, the query would fail to return the correct products due to improper formatting.

### Fixing Number Formatting

**Issue:**

When values greater than 999 were used in the `maxPrice` or `minPrice` filters, the query would not return the expected products, as shown in the screenshot below:

![error](https://github.com/user-attachments/assets/16e5bc7e-2316-4428-ad85-c5b2528c2076)

**Solution:**

The new commit corrects the number formatting for both `maxPrice` and `minPrice`, preventing issues with larger numbers. This fix allows the query to return the correct products, as shown below:

![solved](https://github.com/user-attachments/assets/f60d574f-69a6-4c08-b35a-5a37a54ab1fc)

The new commit adjusts values by appending '00' to the end of the input value. This ensures that the value is treated as a properly formatted price in cents.
