### PR TITLE
Fix: Correct number formatting by removing unnecessary price separators

### DIFF
--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -657,11 +657,11 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			];
 		}
 		if ( ! empty( $where_args['minPrice'] ) ) {
-			$query_args['min_price'] = str_replace( '.', '', number_format( $where_args['minPrice'], 2 ) );
+			$query_args['min_price'] = number_format( $where_args['minPrice'], 2,"","");
 		}
 
 		if ( ! empty( $where_args['maxPrice'] ) ) {
-			$query_args['max_price'] = str_replace( '.', '', number_format( $where_args['maxPrice'], 2 ) );
+			$query_args['max_price'] = number_format( $where_args['maxPrice'], 2,"","");
 		}
 
 		if ( isset( $where_args['stockStatus'] ) ) {

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -657,11 +657,11 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			];
 		}
 		if ( ! empty( $where_args['minPrice'] ) ) {
-			$query_args['min_price'] = number_format( $where_args['minPrice'], 2,"","");
+			$query_args['min_price'] = number_format( $where_args['minPrice'], 2, '', '' );
 		}
 
 		if ( ! empty( $where_args['maxPrice'] ) ) {
-			$query_args['max_price'] = number_format( $where_args['maxPrice'], 2,"","");
+			$query_args['max_price'] = number_format( $where_args['maxPrice'], 2, '', '' );
 		}
 
 		if ( isset( $where_args['stockStatus'] ) ) {


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [ ] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request addresses an issue with number formatting in the maxPrice and minPrice filters for product queries in WPGraphQL WooCommerce. Previously, when users entered values greater than 999, the query failed to return the correct products due to improper formatting.

Specifically, when values over 999 were used in the `maxPrice` or `minPrice` filters, the query did not return the expected products, as demonstrated in the screenshots below.

The new commit resolves this issue by removing all number separators `,` and `.` The previous implementation used str_replace to remove periods `.` but it did not account for commas `,` which are also used as separators in large numbers. This has now been corrected.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
***Before:***
![error](https://github.com/user-attachments/assets/9e94096d-d554-418d-aac6-d462d611ab90)
***After:***
![solution](https://github.com/user-attachments/assets/988864c8-7066-4da3-9259-a3b46bcde59a)



Any other comments?
-------------------
...

Where has this been tested?
------------------------------
**WooGraphQL Version:** 0.21.0
**WPGraphQL Version:** 1.28.0
**WordPress Version:** 6.6.1
**WooCommerce Version:** 7.8.1
