### PR TITLE
fix: ID resolution made consistent across all edit and delete node mu…

### DIFF
--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -9,6 +9,7 @@
 namespace WPGraphQL\WooCommerce\Data\Mutation;
 
 use GraphQL\Error\UserError;
+use WPGraphQL\Utils\Utils;
 
 
 /**
@@ -34,18 +35,24 @@ class Order_Mutation {
 		 */
 		$post_type_object = get_post_type_object( 'shop_order' );
 
-		return apply_filters(
-			"graphql_woocommerce_authorized_to_{$mutation}_orders",
-			current_user_can(
-				'delete' === $mutation
-					? $post_type_object->cap->delete_posts
-					: $post_type_object->cap->edit_posts
-			),
-			$order_id,
-			$input,
-			$context,
-			$info
-		);
+		if ( $order_id === null ) {
+			return apply_filters(
+				"graphql_woocommerce_authorized_to_{$mutation}_orders",
+				current_user_can($post_type_object->cap->edit_posts),
+				$order_id,
+				$input,
+				$context,
+				$info
+			);
+		}
+
+		$order = \wc_get_order( $order_id );
+		$post_type = get_post_type( $order_id );
+
+		// Return true if user is owner or admin
+		$is_owner = 0 !== get_current_user_id() && $order->get_customer_id() === get_current_user_id();
+		$is_admin = \wc_rest_check_post_permissions( $post_type, 'edit', $order_id );
+		return $is_owner || $is_admin;
 	}
 
 	/**
@@ -565,25 +572,26 @@ class Order_Mutation {
 	/**
 	 * Validates order customer
 	 *
-	 * @param array $input  Input data describing order.
+	 * @param string $customer_id  ID of customer for order.
 	 *
 	 * @return bool
 	 */
-	public static function validate_customer( $input ) {
-		if ( ! empty( $input['customerId'] ) ) {
-			// Make sure customer exists.
-			if ( false === get_user_by( 'id', $input['customerId'] ) ) {
-				return false;
-			}
-			// Make sure customer is part of blog.
-			if ( is_multisite() && ! is_user_member_of_blog( $input['customerId'] ) ) {
-				add_user_to_blog( get_current_blog_id(), $input['customerId'], 'customer' );
-			}
-
-			return true;
+	public static function validate_customer( $customer_id ) {
+		$id = Utils::get_database_id_from_id( $customer_id );
+		if ( ! $id ) {
+			return false;
 		}
 
-		return false;
+		if ( false === get_user_by( 'id', $id ) ) {
+			return false;
+		}
+
+		// Make sure customer is part of blog.
+		if ( is_multisite() && ! is_user_member_of_blog( $id ) ) {
+			add_user_to_blog( get_current_blog_id(), $id, 'customer' );
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/mutation/class-coupon-create.php
+++ b/includes/mutation/class-coupon-create.php
@@ -13,9 +13,9 @@ namespace WPGraphQL\WooCommerce\Mutation;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 use WPGraphQL\WooCommerce\Data\Mutation\Coupon_Mutation;
 use WPGraphQL\WooCommerce\Model\Coupon;
-use WPGraphQL\Utils\Utils;
 
 /**
  * Class Coupon_Create
@@ -163,7 +163,7 @@ class Coupon_Create {
 	 */
 	public static function mutate_and_get_payload( $input, AppContext $context, ResolveInfo $info ) {
 		// Retrieve order ID.
-		if ( ! empty ( $input['id'] ) ) {
+		if ( ! empty( $input['id'] ) ) {
 			$coupon_id = Utils::get_database_id_from_id( $input['id'] );
 		} else {
 			$coupon_id = 0;

--- a/includes/mutation/class-coupon-create.php
+++ b/includes/mutation/class-coupon-create.php
@@ -12,10 +12,10 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Coupon_Mutation;
 use WPGraphQL\WooCommerce\Model\Coupon;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Coupon_Create
@@ -163,16 +163,14 @@ class Coupon_Create {
 	 */
 	public static function mutate_and_get_payload( $input, AppContext $context, ResolveInfo $info ) {
 		// Retrieve order ID.
-		$coupon_id = 0;
-		if ( ! empty( $input['id'] ) && is_numeric( $input['id'] ) ) {
-			$coupon_id = absint( $input['id'] );
-		} elseif ( ! empty( $input['id'] ) ) {
-			$id_components = Relay::fromGlobalId( $input['id'] );
-			if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-				throw new UserError( __( 'The "id" provided is invalid', 'wp-graphql-woocommerce' ) );
-			}
+		if ( ! empty ( $input['id'] ) ) {
+			$coupon_id = Utils::get_database_id_from_id( $input['id'] );
+		} else {
+			$coupon_id = 0;
+		}
 
-			$coupon_id = absint( $id_components['id'] );
+		if ( false === $coupon_id ) {
+			throw new UserError( __( 'Coupon ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 		}
 
 		$coupon = new \WC_Coupon( $coupon_id );

--- a/includes/mutation/class-coupon-delete.php
+++ b/includes/mutation/class-coupon-delete.php
@@ -13,8 +13,8 @@ namespace WPGraphQL\WooCommerce\Mutation;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
-use WPGraphQL\WooCommerce\Model\Coupon;
 use WPGraphQL\Utils\Utils;
+use WPGraphQL\WooCommerce\Model\Coupon;
 
 /**
  * Class Coupon_Delete

--- a/includes/mutation/class-coupon-delete.php
+++ b/includes/mutation/class-coupon-delete.php
@@ -12,9 +12,9 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Model\Coupon;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Coupon_Delete
@@ -87,17 +87,11 @@ class Coupon_Delete {
 	 */
 	public static function mutate_and_get_payload( $input, AppContext $context, ResolveInfo $info ) {
 		// Retrieve order ID.
-		$coupon_id = 0;
-		if ( ! empty( $input['id'] ) && is_numeric( $input['id'] ) ) {
-			$coupon_id = absint( $input['id'] );
-		} elseif ( ! empty( $input['id'] ) ) {
-			$id_components = Relay::fromGlobalId( $input['id'] );
-			if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-				throw new UserError( __( 'The "id" provided is invalid', 'wp-graphql-woocommerce' ) );
-			}
-
-			$coupon_id = absint( $id_components['id'] );
+		$coupon_id = Utils::get_database_id_from_id( $input['id'] );
+		if ( empty( $coupon_id ) ) {
+			throw new UserError( __( 'Coupon ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 		}
+
 		$coupon = new Coupon( $coupon_id );
 
 		if ( ! $coupon->ID ) {

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -167,7 +167,7 @@ class Order_Create {
 				WC()->payment_gateways();
 
 				// Validate customer ID, if set.
-				if ( ! empty( $input['customerId'] ) && ! Order_Mutation::validate_customer( $input ) ) {
+				if ( ! empty( $input['customerId'] ) && ! Order_Mutation::validate_customer( $input['customerId'] ) ) {
 					throw new UserError( __( 'Customer ID is invalid.', 'wp-graphql-woocommerce' ) );
 				}
 

--- a/includes/mutation/class-order-delete-items.php
+++ b/includes/mutation/class-order-delete-items.php
@@ -12,10 +12,10 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Order_Delete_Items
@@ -45,13 +45,14 @@ class Order_Delete_Items {
 	public static function get_input_fields() {
 		return array_merge(
 			[
-				'id'      => [
+				'id'          => [
 					'type'        => 'ID',
-					'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
+					'description' => __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' ),
 				],
-				'orderId' => [
-					'type'        => 'Int',
-					'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
+				'orderId'     => [
+					'type'              => 'Int',
+					'description'       => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
 				],
 				'itemIds' => [
 					'type'        => [ 'list_of' => 'Int' ],
@@ -87,20 +88,16 @@ class Order_Delete_Items {
 			// Retrieve order ID.
 			$order_id = null;
 			if ( ! empty( $input['id'] ) ) {
-				$id_components = Relay::fromGlobalId( $input['id'] );
-				if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-					throw new UserError( __( 'The "id" provided is invalid', 'wp-graphql-woocommerce' ) );
-				}
-				$order_id = absint( $id_components['id'] );
+				$order_id = Utils::get_database_id_from_id( $input['id'] );
 			} elseif ( ! empty( $input['orderId'] ) ) {
 				$order_id = absint( $input['orderId'] );
 			} else {
-				throw new UserError( __( 'No order ID provided.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Check if authorized to delete items on this order.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'delete-items', $order_id ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to delete an order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to delete order items.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Confirm item IDs.

--- a/includes/mutation/class-order-delete-items.php
+++ b/includes/mutation/class-order-delete-items.php
@@ -13,9 +13,9 @@ namespace WPGraphQL\WooCommerce\Mutation;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
-use WPGraphQL\Utils\Utils;
 
 /**
  * Class Order_Delete_Items
@@ -45,11 +45,11 @@ class Order_Delete_Items {
 	public static function get_input_fields() {
 		return array_merge(
 			[
-				'id'          => [
+				'id'      => [
 					'type'        => 'ID',
 					'description' => __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' ),
 				],
-				'orderId'     => [
+				'orderId' => [
 					'type'              => 'Int',
 					'description'       => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
 					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
@@ -93,6 +93,10 @@ class Order_Delete_Items {
 				$order_id = absint( $input['orderId'] );
 			} else {
 				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+			}
+
+			if ( ! $order_id ) {
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Check if authorized to delete items on this order.

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -12,11 +12,11 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WC_Order_Factory;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Order_Delete
@@ -48,11 +48,12 @@ class Order_Delete {
 			[
 				'id'          => [
 					'type'        => 'ID',
-					'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
+					'description' => __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' ),
 				],
 				'orderId'     => [
-					'type'        => 'Int',
-					'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
+					'type'              => 'Int',
+					'description'       => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
 				],
 				'forceDelete' => [
 					'type'        => 'Boolean',
@@ -88,15 +89,11 @@ class Order_Delete {
 			// Retrieve order ID.
 			$order_id = null;
 			if ( ! empty( $input['id'] ) ) {
-				$id_components = Relay::fromGlobalId( $input['id'] );
-				if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-					throw new UserError( __( 'The "id" provided is invalid', 'wp-graphql-woocommerce' ) );
-				}
-				$order_id = absint( $id_components['id'] );
+				$order_id = Utils::get_database_id_from_id( $input['id'] );
 			} elseif ( ! empty( $input['orderId'] ) ) {
 				$order_id = absint( $input['orderId'] );
 			} else {
-				throw new UserError( __( 'No order ID provided.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Check if authorized to delete this order.

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -14,9 +14,9 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WC_Order_Factory;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
-use WPGraphQL\Utils\Utils;
 
 /**
  * Class Order_Delete
@@ -87,13 +87,17 @@ class Order_Delete {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			// Retrieve order ID.
-			$order_id = null;
+			$order_id = false;
 			if ( ! empty( $input['id'] ) ) {
 				$order_id = Utils::get_database_id_from_id( $input['id'] );
 			} elseif ( ! empty( $input['orderId'] ) ) {
 				$order_id = absint( $input['orderId'] );
 			} else {
 				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+			}
+
+			if ( ! $order_id ) {
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 			}
 
 			// Check if authorized to delete this order.

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -12,11 +12,11 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WC_Order_Factory;
 use WPGraphQL\AppContext;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Order_Update
@@ -49,15 +49,16 @@ class Order_Update {
 			[
 				'id'         => [
 					'type'        => 'ID',
-					'description' => __( 'Order global ID', 'wp-graphql-woocommerce' ),
+					'description' => __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' ),
 				],
-				'orderId'    => [
-					'type'        => 'Int',
-					'description' => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
+				'orderId'     => [
+					'type'              => 'Int',
+					'description'       => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
 				],
 				'customerId' => [
-					'type'        => 'Int',
-					'description' => __( 'Order customer ID', 'wp-graphql-woocommerce' ),
+					'type'        => 'ID',
+					'description' => __( 'Database ID or global ID of the customer for the order', 'wp-graphql-woocommerce' ),
 				],
 			]
 		);
@@ -89,17 +90,13 @@ class Order_Update {
 			// Retrieve order ID.
 			$order_id = null;
 			if ( ! empty( $input['id'] ) ) {
-				$id_components = Relay::fromGlobalId( $input['id'] );
-				if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-					throw new UserError( __( 'The "id" provided is invalid', 'wp-graphql-woocommerce' ) );
-				}
-				$order_id = absint( $id_components['id'] );
+				$order_id = Utils::get_database_id_from_id( $input['id'] );
 			} elseif ( ! empty( $input['orderId'] ) ) {
 				$order_id = absint( $input['orderId'] );
 			} else {
-				throw new UserError( __( 'No order ID provided.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 			}
-
+			
 			// Check if authorized to update this order.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'update', $order_id ) ) {
 				throw new UserError( __( 'User does not have the capabilities necessary to update an order.', 'wp-graphql-woocommerce' ) );
@@ -133,7 +130,7 @@ class Order_Update {
 			\WC()->payment_gateways();
 
 			// Validate customer ID.
-			if ( ! empty( $input['customerId'] ) && ! Order_Mutation::validate_customer( $input ) ) {
+			if ( ! empty( $input['customerId'] ) && ! Order_Mutation::validate_customer( $input['customerId'] ) ) {
 				throw new UserError( __( 'New customer ID is invalid.', 'wp-graphql-woocommerce' ) );
 			}
 
@@ -147,7 +144,7 @@ class Order_Update {
 			}
 
 			// Actions for after the order is saved.
-			if ( true === $input['isPaid'] ) {
+			if ( isset( $input['isPaid'] ) && true === $input['isPaid'] ) {
 				$order->payment_complete(
 					! empty( $input['transactionId'] )
 						? $input['transactionId']

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -14,9 +14,9 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WC_Order_Factory;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 use WPGraphQL\WooCommerce\Data\Mutation\Order_Mutation;
 use WPGraphQL\WooCommerce\Model\Order;
-use WPGraphQL\Utils\Utils;
 
 /**
  * Class Order_Update
@@ -51,7 +51,7 @@ class Order_Update {
 					'type'        => 'ID',
 					'description' => __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' ),
 				],
-				'orderId'     => [
+				'orderId'    => [
 					'type'              => 'Int',
 					'description'       => __( 'Order WP ID', 'wp-graphql-woocommerce' ),
 					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
@@ -96,7 +96,11 @@ class Order_Update {
 			} else {
 				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
 			}
-			
+
+			if ( ! $order_id ) {
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+			}
+
 			// Check if authorized to update this order.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'update', $order_id ) ) {
 				throw new UserError( __( 'User does not have the capabilities necessary to update an order.', 'wp-graphql-woocommerce' ) );

--- a/includes/mutation/class-review-delete-restore.php
+++ b/includes/mutation/class-review-delete-restore.php
@@ -14,6 +14,7 @@ use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Review_Delete_Restore
@@ -130,12 +131,12 @@ class Review_Delete_Restore {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			// Retrieve the product review rating for the payload.
-			$id_parts = Relay::fromGlobalId( $input['id'] );
-			if ( empty( $id_parts['id'] ) ) {
+			$id = Utils::get_database_id_from_id( $input['id'] );
+			if ( ! $id ) {
 				throw new UserError( __( 'Invalid Product Review ID provided', 'wp-graphql-woocommerce' ) );
 			}
 
-			$rating = get_comment_meta( absint( $id_parts['id'] ), 'rating' );
+			$rating = get_comment_meta( absint( $id ), 'rating' );
 
 			// @codingStandardsIgnoreLine
 			switch ( $info->fieldName ) {

--- a/includes/mutation/class-review-update.php
+++ b/includes/mutation/class-review-update.php
@@ -15,6 +15,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Mutation\CommentUpdate;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class Review_Update
@@ -80,11 +81,9 @@ class Review_Update {
 			];
 
 			$payload       = [];
-			$id_parts      = ! empty( $input['id'] ) ? Relay::fromGlobalId( $input['id'] ) : null;
-			$payload['id'] = isset( $id_parts['id'] ) && absint( $id_parts['id'] ) ? absint( $id_parts['id'] ) : null;
-
-			if ( empty( $payload['id'] ) ) {
-				throw new UserError( __( 'The Review could not be updated', 'wp-graphql-woocommerce' ) );
+			$id = Utils::get_database_id_from_id( $input['id'] );
+			if ( ! $id ) {
+				throw new UserError( __( 'Provided review ID missing or invalid ', 'wp-graphql-woocommerce' ) );
 			}
 
 			if ( array_intersect_key( $input, $skip ) !== $input ) {

--- a/includes/mutation/class-review-update.php
+++ b/includes/mutation/class-review-update.php
@@ -12,7 +12,6 @@ namespace WPGraphQL\WooCommerce\Mutation;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Mutation\CommentUpdate;
 use WPGraphQL\Utils\Utils;
@@ -80,8 +79,8 @@ class Review_Update {
 				'clientMutationId' => 1,
 			];
 
-			$payload       = [];
-			$id = Utils::get_database_id_from_id( $input['id'] );
+			$payload = [];
+			$id      = Utils::get_database_id_from_id( $input['id'] );
 			if ( ! $id ) {
 				throw new UserError( __( 'Provided review ID missing or invalid ', 'wp-graphql-woocommerce' ) );
 			}

--- a/includes/mutation/class-tax-rate-create.php
+++ b/includes/mutation/class-tax-rate-create.php
@@ -13,6 +13,7 @@ namespace WPGraphQL\WooCommerce\Mutation;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class - Tax_Rate_Create
@@ -117,7 +118,10 @@ class Tax_Rate_Create {
 	 * @return array
 	 */
 	public static function mutate_and_get_payload( $input, AppContext $context, ResolveInfo $info ) {
-		$id         = ! empty( $input['id'] ) ? $input['id'] : null;
+		$id         = ! empty( $input['id'] ) ? Utils::get_database_id_from_id( $input['id'] ) : null;
+		if ( false === $id ) {
+			throw new UserError( __( 'Invalid ID provided.', 'wp-graphql-woocommerce' ) );
+		}
 		$action     = ! $id ? 'create' : 'update';
 		$permission = ! $id ? 'create' : 'edit';
 		if ( ! \wc_rest_check_manager_permissions( 'settings', $permission ) ) {

--- a/includes/mutation/class-tax-rate-create.php
+++ b/includes/mutation/class-tax-rate-create.php
@@ -118,7 +118,7 @@ class Tax_Rate_Create {
 	 * @return array
 	 */
 	public static function mutate_and_get_payload( $input, AppContext $context, ResolveInfo $info ) {
-		$id         = ! empty( $input['id'] ) ? Utils::get_database_id_from_id( $input['id'] ) : null;
+		$id = ! empty( $input['id'] ) ? Utils::get_database_id_from_id( $input['id'] ) : null;
 		if ( false === $id ) {
 			throw new UserError( __( 'Invalid ID provided.', 'wp-graphql-woocommerce' ) );
 		}
@@ -221,7 +221,7 @@ class Tax_Rate_Create {
 		/**
 		 * Filter tax rate object before responding.
 		 *
-		 * @param object $tax_rate_id  The shipping method object.
+		 * @param int    $tax_rate_id  The shipping method object.
 		 * @param array  $input        Request input.
 		 */
 		do_action( "graphql_woocommerce_tax_rate_{$action}", $id, $input );

--- a/includes/mutation/class-tax-rate-delete.php
+++ b/includes/mutation/class-tax-rate-delete.php
@@ -13,6 +13,7 @@ namespace WPGraphQL\WooCommerce\Mutation;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Class - Tax_Rate_Delete
@@ -75,11 +76,14 @@ class Tax_Rate_Delete {
 				throw new UserError( __( 'Sorry, you are not allowed to delete tax rates.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
 			}
 			global $wpdb;
-			$id = $input['id'];
+			$id = Utils::get_database_id_from_id( $input['id'] );
+			if ( ! $id ) {
+				throw new UserError( __( 'Invalid tax rate ID.', 'wp-graphql-woocommerce' ) );
+			}
 
 			$tax = $context->get_loader( 'tax_rate' )->load( $id );
 			if ( ! $tax ) {
-				throw new UserError( __( 'Invalid tax rate ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to locate tax rate', 'wp-graphql-woocommerce' ) );
 			}
 
 			/**

--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -625,7 +625,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 *
 		 * User without necessary capabilities cannot update order an order.
 		 */
-		wp_set_current_user( $this->customer );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'customer' ] ) );
 		$actual = $this->orderMutation(
 			$updated_input,
 			'updateOrder',
@@ -902,7 +902,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 *
 		 * User without necessary capabilities cannot delete order an order.
 		 */
-		wp_set_current_user( $this->customer );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'customer' ] ) );
 		$actual = $this->orderMutation(
 			$deleted_input,
 			'deleteOrder',
@@ -1056,7 +1056,7 @@ class OrderMutationsTest extends \Codeception\TestCase\WPTestCase {
 		 *
 		 * User without necessary capabilities cannot delete order an order.
 		 */
-		wp_set_current_user( $this->customer );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'customer' ] ) );
 		$actual = $this->orderMutation(
 			$deleted_items_input,
 			'deleteOrderItems',


### PR DESCRIPTION
…tations

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
- `WPGraphQL\Utils\Utils::get_database_id_from_id()` now used to resolve IDs in edit/delete mutations for types inheriting the `Node` interface.
- `orderId` field has been deprecated across all *order mutations.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…
