### PR TITLE
fix: Products query "where.search" param patched

### DIFF
--- a/tests/wpunit/ProductsQueriesTest.php
+++ b/tests/wpunit/ProductsQueriesTest.php
@@ -5,6 +5,7 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 		$products = [
 			$this->factory->product->createSimple([
 				'name'          => 'Product Blue',
+				'slug'          => 'product-blue',
 				'description'   => 'A peach description',
 				'price'         => 100,
 				'regular_price' => 100,
@@ -16,6 +17,7 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 			]),
 			$this->factory->product->createSimple([
 				'name'          => 'Product Green',
+				'slug'          => 'product-green',
 				'description'   => 'A turquoise description',
 				'sku' 		    => 'green-sku',
 				'price'         => 200,
@@ -28,6 +30,7 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 			]),
 			$this->factory->product->createSimple([
 				'name'          => 'Product Red',
+				'slug'          => 'product-red',
 				'description'   => 'A maroon description',
 				'price'         => 300,
 				'regular_price' => 300,
@@ -39,6 +42,7 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 			]),
 			$this->factory->product->createSimple([
 				'name'          => 'Product Yellow',
+				'slug'          => 'product-yellow',
 				'description'   => 'A teal description',
 				'price'         => 400,
 				'regular_price' => 400,
@@ -50,6 +54,7 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 			]),
 			$this->factory->product->createSimple([
 				'name'          => 'Product Purple',
+				'slug'          => 'product-purple',
 				'description'   => 'A magenta description',
 				'price'         => 500,
 				'regular_price' => 500,
@@ -1024,6 +1029,8 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 				nodes {
 					id
 					name
+					description
+					sku
 					... on ProductWithPricing {
 						databaseId
 						price
@@ -1056,9 +1063,7 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 		/**
 		 * Assert search by product sku.
 		 */
-		$variables = [
-			'search' => 'green-sku',
-		];
+		$variables = [ 'search' => 'green-sku' ];
 		$response = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertQuerySuccessful(
 			$response,
@@ -1071,7 +1076,41 @@ class ProductsQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraph
 					0
 				),
 			],
+			'Failed to search products by product sku.'
+		);
+
+		// Search by product description.
+		$variables = [ 'search' => 'magenta' ];
+		$response = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertQuerySuccessful(
+			$response,
+			[
+				$this->expectedNode(
+					'products.nodes',
+					[
+						$this->expectedField( 'id', $this->toRelayId( 'post', $products[4] ) )
+					],
+					0
+				),
+			],
 			'Failed to search products by product description content.'
+		);
+
+		// Search by slug.
+		$variables = [ 'search' => 'product-red' ];
+		$response = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertQuerySuccessful(
+			$response,
+			[
+				$this->expectedNode(
+					'products.nodes',
+					[
+						$this->expectedField( 'id', $this->toRelayId( 'post', $products[2] ) )
+					],
+					0
+				),
+			],
+			'Failed to search products by product slug.'
 		);
 	}
 }


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic. Learn how to modify the tests [here](https://woographql.com/contributing/2-local-testing).

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the `products` query's `where.search` parameter by replacing the `search` query clauses added by the `Automattic\WooCommerce\StoreApi\Utilities\ProductQuery` class


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…
