### PR TITLE
feat: Add a conditional filter hook before generating the session token

### DIFF
--- a/includes/utils/class-ql-session-handler.php
+++ b/includes/utils/class-ql-session-handler.php
@@ -202,13 +202,20 @@ class QL_Session_Handler extends WC_Session_Handler {
 
 		// Distribute new session token on GraphQL requests, otherwise distribute a new session cookie.
 		if ( Router::is_graphql_http_request() ) {
-			// Start new session.
-			$this->set_session_expiration();
+			$condition = apply_filters(
+				'graphql_generate_woocommerce_session_token_condition',
+				true
+			);
 
-			// Get Customer ID.
-			$this->_customer_id = is_user_logged_in() ? get_current_user_id() : $this->generate_customer_id();
-			$this->_data        = $this->get_session_data();
-			$this->set_customer_session_token( true );
+			if ( $condition ) {
+				// Start new session.
+				$this->set_session_expiration();
+
+				// Get Customer ID.
+				$this->_customer_id = is_user_logged_in() ? get_current_user_id() : $this->generate_customer_id();
+				$this->_data        = $this->get_session_data();
+				$this->set_customer_session_token( true );
+			}
 		} else {
 			$this->init_session_cookie();
 		}


### PR DESCRIPTION
What does this implement?
---------------------------------------------------
Sometimes, we need to avoid generating a session for certain services. I am using the App Router in Next.js version 14, and I send requests on the server side. I don’t want a WooCommerce session to be created unnecessarily for each request, as the request is on the server and does not have access to the session in local storage (it can access cookies, but I have run multiple requests initially before the cookies were set). Therefore, I would like to add a header to my server-side requests that indicates this API request came from the server and does not require the creation of a WooCommerce session.


Does this close any currently open issues?
------------------------------------------
Based on issue #908, my front-end is hosted at example.com while WordPress is hosted at `api.example.com`. As a result, the browser sends an `OPTIONS` request to check `CORS`. This filter hook can help resolve the issues. In the filter hook of my custom plugin, I can check if the request is an `OPTIONS` request and prevent the creation of a `session token`.


Example
------------------------------------------
```php
add_filter('graphql_generate_woocommerce_session_token_condition', 'graphql_generate_woocommerce_session_token_condition', 10);

function graphql_generate_woocommerce_session_token_condition() {
    $method = $_SERVER['REQUEST_METHOD'];
    $headers = getallheaders();
    return $method !== "OPTIONS" && !isset($headers['x-server-side']);
}
```
