### PR TITLE
fix: use term name for label instead of taxonomy slug in product attribtes.

### DIFF
--- a/includes/data/connection/class-variation-attribute-connection-resolver.php
+++ b/includes/data/connection/class-variation-attribute-connection-resolver.php
@@ -94,6 +94,7 @@ class Variation_Attribute_Connection_Resolver {
 					'id'          => $id,
 					'attributeId' => 0,
 					'name'        => $name,
+					'label'				=> $value,
 					'value'       => $value,
 				];
 			} else {
@@ -101,6 +102,7 @@ class Variation_Attribute_Connection_Resolver {
 					'id'          => $id,
 					'attributeId' => $term->term_id,
 					'name'        => $term->taxonomy,
+					'label' 			=> $term->name,
 					'value'       => $term->slug,
 				];
 			}

--- a/includes/type/object/class-variation-attribute-type.php
+++ b/includes/type/object/class-variation-attribute-type.php
@@ -44,11 +44,7 @@ class Variation_Attribute_Type {
 						'type'        => 'String',
 						'description' => __( 'Label of attribute', 'wp-graphql-woocommerce' ),
 						'resolve'     => static function ( $source ) {
-							if ( ! isset( $source['name'] ) ) {
-								return null;
-							}
-
-							return \wc_attribute_taxonomy_slug( $source['name'] );
+							return isset( $source['label'] ) ? $source['label'] : null;
 						},
 					],
 					'name'        => [


### PR DESCRIPTION
This pull request introduces improvements to how variation attributes are handled and resolved in the WooCommerce GraphQL integration. The key changes include adding a `label` field to variation attributes and simplifying the resolution logic for the `label` field.

### Enhancements to variation attribute handling:

* [`includes/data/connection/class-variation-attribute-connection-resolver.php`](diffhunk://#diff-b0dfadaf32068d2571dde512ef27a3fe2d56e72ffce7a151c1125a902fb792bcR97-R105): Added a new `label` field to the variation attributes data array. This field is populated with the attribute's value or term name, depending on the context.

* [`includes/type/object/class-variation-attribute-type.php`](diffhunk://#diff-e46ff100438c869ddf5841ad56ff1c7ed4bdfc2db9756588364dfd1878019e3aL47-R47): Simplified the resolver for the `label` field in the GraphQL schema. The resolver now directly returns the `label` field from the source if it exists, or `null` otherwise.What does this implement/fix? Explain your changes.
---------------------------------------------------
When asking for the "LABEL" of a term in product attributes, we are getting the taxonomy slug.


BEFORE
![image](https://github.com/user-attachments/assets/d2252a17-c0d9-453e-8d2a-400428b4d279)

Notice how we are getting `color` as the label of `green`.

AFTER
![image](https://github.com/user-attachments/assets/29d2807f-69d8-4871-a174-e6f7f1bc760c)

Notice how we are getting `Green` as the label of `green` as it should be.
