### PR TITLE
`downloadsRemaining` returns `null` when is of valid type `string`

### DIFF
--- a/includes/data/connection/class-downloadable-item-connection-resolver.php
+++ b/includes/data/connection/class-downloadable-item-connection-resolver.php
@@ -55,8 +55,8 @@ class Downloadable_Item_Connection_Resolver extends AbstractConnectionResolver {
 					$is_expired          = isset( $downloadable_item['access_expires'] )
 						? time() > $downloadable_item['access_expires']->getTimestamp()
 						: false;
-					$downloads_remaining = ( 'integer' === gettype( $downloadable_item['downloads_remaining'] ) )
-						? 0 < $downloadable_item['downloads_remaining']
+					$downloads_remaining = ( is_numeric( $downloadable_item['downloads_remaining'] ) )
+						? 0 < intval( $downloadable_item['downloads_remaining'] )
 						: true;
 
 					return $active ? ( ! $is_expired && $downloads_remaining ) : ( $is_expired || ! $downloads_remaining );
@@ -79,8 +79,8 @@ class Downloadable_Item_Connection_Resolver extends AbstractConnectionResolver {
 				$has_downloads_remaining = $where_args['hasDownloadsRemaining'];
 
 				$query_args['filters'][] = static function ( $downloadable_item ) use ( $has_downloads_remaining ) {
-					$downloads_remaining = ( 'integer' === gettype( $downloadable_item['downloads_remaining'] ) )
-						? 0 < $downloadable_item['downloads_remaining']
+					$downloads_remaining = ( is_numeric( $downloadable_item['downloads_remaining'] ) )
+						? 0 < intval( $downloadable_item['downloads_remaining'] )
 						: true;
 
 					return $has_downloads_remaining === $downloads_remaining;

--- a/includes/type/object/class-downloadable-item-type.php
+++ b/includes/type/object/class-downloadable-item-type.php
@@ -63,8 +63,8 @@ class Downloadable_Item_Type {
 						'type'        => 'Int',
 						'description' => __( 'Number of times the item can be downloaded.', 'wp-graphql-woocommerce' ),
 						'resolve'     => static function ( $source ) {
-							return isset( $source['downloads_remaining'] ) && 'integer' === gettype( $source['downloads_remaining'] )
-								? $source['downloads_remaining']
+							return isset( $source['downloads_remaining'] ) && is_numeric( $source['downloads_remaining'] )
+								? intval( $source['downloads_remaining'] )
 								: null;
 						},
 					],

--- a/tests/_support/Helper/crud-helpers/customer.php
+++ b/tests/_support/Helper/crud-helpers/customer.php
@@ -219,8 +219,8 @@ class CustomerHelper extends WCG_Helper {
 				'url'                => $item['download_url'],
 				'accessExpires'      => $item['access_expires'],
 				'downloadId'         => $item['download_id'],
-				'downloadsRemaining' => isset( $item['downloads_remaining'] ) && 'integer' === gettype( $item['downloads_remaining'] )
-					? $item['downloads_remaining']
+				'downloadsRemaining' => isset( $item['downloads_remaining'] ) && is_numeric( $item['downloads_remaining'] )
+					? intval( $item['downloads_remaining'] )
 					: null,
 				'name'               => $item['download_name'],
 				'product'            => array( 'databaseId' => $item['product_id'] ),

--- a/tests/_support/Helper/crud-helpers/order.php
+++ b/tests/_support/Helper/crud-helpers/order.php
@@ -456,8 +456,8 @@ class OrderHelper extends WCG_Helper {
 				'url'                => $item['download_url'],
 				'accessExpires'      => $item['access_expires'],
 				'downloadId'         => $item['download_id'],
-				'downloadsRemaining' => isset( $item['downloads_remaining'] ) && 'integer' === gettype( $item['downloads_remaining'] )
-					? $item['downloads_remaining']
+				'downloadsRemaining' => isset( $item['downloads_remaining'] ) && is_numeric( $item['downloads_remaining'] )
+					? intval( $item['downloads_remaining'] )
 					: null,
 				'name'               => $item['download_name'],
 				'product'            => array( 'databaseId' => $item['product_id'] ),

--- a/tests/wpunit/DownloadableItemQueriesTest.php
+++ b/tests/wpunit/DownloadableItemQueriesTest.php
@@ -83,8 +83,8 @@ class DownloadableItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 								$this->expectedField( 'downloadId', $item['download_id'] ),
 								$this->expectedField(
 									'downloadsRemaining',
-									isset( $item['downloads_remaining'] ) && 'integer' === gettype( $item['downloads_remaining'] )
-										? $item['downloads_remaining']
+									isset( $item['downloads_remaining'] ) && is_numeric( $item['downloads_remaining'] )
+										? intval( $item['downloads_remaining'] )
 										: static::IS_NULL
 								),
 								$this->expectedField( 'name', $item['download_name'] ),
@@ -360,8 +360,8 @@ class DownloadableItemQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\
 						$this->expectedField( 'downloadId', $item['download_id'] ),
 						$this->expectedField(
 							'downloadsRemaining',
-							isset( $item['downloads_remaining'] ) && 'integer' === gettype( $item['downloads_remaining'] )
-								? $item['downloads_remaining']
+							isset( $item['downloads_remaining'] ) && is_numeric( $item['downloads_remaining'] )
+								? intval( $item['downloads_remaining'] )
 								: static::IS_NULL
 						),
 						$this->expectedField( 'name', $item['download_name'] ),


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR fixes an issue when `downloadsRemaining` is of type `string` instead of the expected one `integer`. It changes how we check for valid values for `downloadsRemaining` everywhere in the codebase, and applies the most minimal set of changes to ensure we're not nullifying valid strigified values.


Does this close any currently open issues?
------------------------------------------
Closes #937.


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
Let me know if there's any extra changes you'd like me to make.
