### PR TITLE
Add dateModified field to all WooCommerce product types in GraphQL schema

### DIFF
--- a/includes/type/object/class-product-types.php
+++ b/includes/type/object/class-product-types.php
@@ -78,7 +78,17 @@ class Product_Types {
 						'ProductWithPricing',
 					]
 				),
-				'fields'          => [],
+				'fields'          => [
+    'dateModified' => [
+        'type'        => 'String',
+        'description' => __( 'The date the product was last modified in GMT (ISO8601 format).', 'wp-graphql-woocommerce' ),
+        'resolve'     => static function ( Model $source ) {
+            $modified = $source->get_date_modified();
+            return $modified ? $modified->date( 'c' ) : null;
+        },
+    ],
+],
+
 			]
 		);
 	}
@@ -103,7 +113,17 @@ class Product_Types {
 						'ProductWithVariations',
 					]
 				),
-				'fields'          => [],
+				'fields'          => [
+    'dateModified' => [
+        'type'        => 'String',
+        'description' => __( 'The date the product was last modified in GMT (ISO8601 format).', 'wp-graphql-woocommerce' ),
+        'resolve'     => static function ( Model $source ) {
+            $modified = $source->get_date_modified();
+            return $modified ? $modified->date( 'c' ) : null;
+        },
+    ],
+],
+
 			]
 		);
 	}
@@ -121,20 +141,27 @@ class Product_Types {
 				'model'           => \WPGraphQL\WooCommerce\Model\Product::class,
 				'description'     => __( 'A external product object', 'wp-graphql-woocommerce' ),
 				'interfaces'      => self::get_product_interfaces( [ 'ProductWithPricing' ] ),
-				'fields'          => array_merge(
-					[
-						'externalUrl' => [
-							'type'        => 'String',
-							'description' => __( 'External product url', 'wp-graphql-woocommerce' ),
-						],
-						'buttonText'  => [
-							'type'        => 'String',
-							'description' => __( 'External product Buy button text', 'wp-graphql-woocommerce' ),
-						],
-					]
-				),
-			]
-		);
+				'fields'          => [
+        'externalUrl' => [
+            'type'        => 'String',
+            'description' => __( 'External product url', 'wp-graphql-woocommerce' ),
+        ],
+        'buttonText'  => [
+            'type'        => 'String',
+            'description' => __( 'External product Buy button text', 'wp-graphql-woocommerce' ),
+        ],
+        'dateModified' => [
+            'type'        => 'String',
+            'description' => __( 'The date the product was last modified in GMT (ISO8601 format).', 'wp-graphql-woocommerce' ),
+            'resolve'     => static function ( Model $source ) {
+                $modified = $source->get_date_modified();
+                return $modified ? $modified->date( 'c' ) : null;
+            },
+        ],
+    ],
+]
+);
+		
 	}
 
 	/**
@@ -197,6 +224,14 @@ class Product_Types {
 							return wc_graphql_price( $min_price );
 						},
 					],
+					 'dateModified' => [
+        'type'        => 'String',
+        'description' => __( 'The date the product was last modified in GMT (ISO8601 format).', 'wp-graphql-woocommerce' ),
+        'resolve'     => static function ( Model $source ) {
+            $modified = $source->get_date_modified();
+            return $modified ? $modified->date( 'c' ) : null;
+        },
+    ],
 				],
 			]
 		);
@@ -230,6 +265,14 @@ class Product_Types {
 							return 'unsupported';
 						},
 					],
+					'dateModified' => [
+        'type'        => 'String',
+        'description' => __( 'The date the product was last modified in GMT (ISO8601 format).', 'wp-graphql-woocommerce' ),
+        'resolve'     => static function ( Model $source ) {
+            $modified = $source->get_date_modified();
+            return $modified ? $modified->date( 'c' ) : null;
+        },
+    ],
 				],
 			]
 		);


### PR DESCRIPTION
### Overview
This PR adds a `dateModified` field to all WooCommerce product types in the WPGraphQL schema, including:

- SimpleProduct
- VariableProduct
- ExternalProduct
- GroupProduct
- UnsupportedProduct

The `dateModified` field returns the last modified date of the product in GMT (ISO8601 format).

### Motivation
Currently, there is no `dateModified` field available in the GraphQL schema for WooCommerce products. Adding this field enables developers to query products and get the last modified date directly via GraphQL.

### Implementation
- Added `dateModified` field to all product types in `class-product-types.php`.
- The field uses the product model's `get_date_modified()` method and returns the date in ISO8601 format.
- Works with inline fragments on the `ProductUnion` type.

### Example Query (GraphiQL)
```graphql
{
  products(first: 3) {
    nodes {
      id
      name
      ... on SimpleProduct {
        dateModified
      }
      ... on VariableProduct {
        dateModified
      }
      ... on ExternalProduct {
        dateModified
      }
      ... on GroupProduct {
        dateModified
      }
    }
  }
}

