### PR TITLE
Fix docs metadata leaking into Table of Contents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "WPGraphQL for WooCommerce"
 description: "Comprehensive documentation for WPGraphQL for WooCommerce (WooGraphQL) - the WPGraphQL extension that integrates WooCommerce with GraphQL for headless e-commerce solutions."
 author: "Geoff Taylor"
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, headless, e-commerce"
--->
+---
 
 # WPGraphQL for WooCommerce
 

--- a/docs/configuring-graphql-client-for-user-session.md
+++ b/docs/configuring-graphql-client-for-user-session.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Configuring GraphQL Client for User Session"
 description: "A step-by-step guide on how to configure your GraphQL client to handle user sessions, authentication, and more when working with WPGraphQL for WooCommerce and WPGraphQL."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, user session, authentication, configuration, client"
 author: "Geoff Taylor"
--->
+---
 
 # Configuring a GraphQL Client for WooCommerce User Session Management
 

--- a/docs/development-w-docker.md
+++ b/docs/development-w-docker.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Development w/ Docker"
 author: "Geoff Taylor"
 description: "A simple to follow guide on using the WPGraphQL for WooCommerce App Docker Image."
 keywords: ""
--->
+---
 
 # Coming Soon
 

--- a/docs/handling-user-authentication.md
+++ b/docs/handling-user-authentication.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Handling User Authentication with WooGraphQL"
 description: "Learn how to handle user authentication in your headless WooCommerce application using WPGraphQL for WooCommerce and WPGraphQL for secure and seamless user experiences."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, user authentication, login, register, secure, headless"
 author: "Geoff Taylor"
--->
+---
 
 # Handling User Authentication
 

--- a/docs/handling-user-session-and-using-cart-mutations.md
+++ b/docs/handling-user-session-and-using-cart-mutations.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Handling User Session and Using Cart Mutations with WooGraphQL"
 description: "Discover how to manage user sessions and perform cart mutations using WPGraphQL for WooCommerce and WPGraphQL in your headless WooCommerce application for a smooth shopping experience."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, user session, cart mutations, headless, shopping experience"
 author: "Geoff Taylor"
--->
+---
 
 # Handling User Session and Using Cart Mutations
 

--- a/docs/harmonizing-with-wordpress.md
+++ b/docs/harmonizing-with-wordpress.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Harmonizing with WordPress"
 description: "Learn how to create a secure checkout button and understand the security behind the URL validation."
 keywords: "WooGraphQL, WooCommerce, checkout functionality, secure checkout, session transferring URLs, nonce generation, session meta, URL validation, Client Session ID, UpdateSession mutation, GraphQL, cart page, WordPress, frontend security"
 author: "Geoff Taylor"
--->
+---
 
 # Harmonizing with WordPress
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "WPGraphQL for WooCommerce Installation Guide"
 author: "Geoff Taylor"
 description: "Step-by-step instructions to install and set up WooGraphQL, the WPGraphQL extension that integrates WooCommerce with GraphQL for headless e-commerce solutions."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, installation, setup, headless e-commerce"
--->
+---
 
 # Installation
 

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Local Testing"
 author: "Geoff Taylor"
 description: "An extensive guide on local testing w/ WooGraphQL."
 keywords: ""
--->
+---
 
 # Local CLI Testing
 

--- a/docs/routing-by-uri.md
+++ b/docs/routing-by-uri.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Routing by URI with WooGraphQL"
 description: "Discover how to implement routing by URI in your headless WooCommerce application using WPGraphQL for WooCommerce and WPGraphQL for efficient and user-friendly navigation."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, routing, URI, headless, navigation"
 author: "Geoff Taylor"
--->
+---
 
 # Routing By URI
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "WPGraphQL for WooCommerce Settings Guide"
 description: "Learn how to configure and manage WPGraphQL for WooCommerce settings to optimize the integration of WooCommerce with WPGraphQL for your headless e-commerce solution."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, settings, configuration, headless e-commerce"
 author: "Geoff Taylor"
--->
+---
 
 # WPGraphQL for WooCommerce Settings
 

--- a/docs/testing-quick-start.md
+++ b/docs/testing-quick-start.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Testing (Quick-Start Guide)"
 author: "Geoff Taylor"
 description: "A simple guide to get started testing with WooGraphQL."
 keywords: ""
--->
+---
 
 # Testing (Quick-Start Guide)
 

--- a/docs/testing-w-docker.md
+++ b/docs/testing-w-docker.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Testing w/ Docker"
 author: "Geoff Taylor"
 description: "An extensive guide on testing w/ WPGraphQL for WooCommerce + Docker."
 keywords: ""
--->
+---
 
 # Coming Soon
 

--- a/docs/using-cart-data.md
+++ b/docs/using-cart-data.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Cart Data with WooGraphQL"
 description: "Learn how to retrieve and utilize cart data in your headless WooCommerce application with WPGraphQL for WooCommerce and WPGraphQL, enabling seamless shopping experiences for your customers."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, cart data, headless, shopping experience"
 author: "Geoff Taylor"
--->
+---
 
 # Using Cart Data
 

--- a/docs/using-checkout-mutation-and-order-mutations.md
+++ b/docs/using-checkout-mutation-and-order-mutations.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Checkout Mutation + Order Mutations with WooGraphQL"
 description: "Learn how to handle repeat shoppers with existing payment methods using the `checkout` mutation, and side-stepping WooCommerce's management of the session completely by using the `createOrder` mutation."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, checkout mutation, createOrder mutation, session management"
 author: "Geoff Taylor"
--->
+---
 
 # Using Checkout Mutation and Order Mutations
 

--- a/docs/using-composite-product-data-and-mutations.md
+++ b/docs/using-composite-product-data-and-mutations.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Composite Product Data + Mutations with WooGraphQL"
 description: "Learn how to use the Composite Product functionality with WPGraphQL for WooCommerce by building upon the code from `Using Product Data` and `Creating Session Provider and using Cart Mutations`."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, Composite Product functionality, Product Data, Session Provider, Cart Mutations"
 author: "Geoff Taylor"
--->
+---
 
 # Using Composite Product Data + Mutations
 

--- a/docs/using-customer-data-and-mutations.md
+++ b/docs/using-customer-data-and-mutations.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Customer Data + Mutations with WooGraphQL"
 description: "Learn how to utilize the `customer` query and mutations by building a clone of a WooCommerce's user account pages in React.js."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, customer query, customer mutations, React.js, user account pages"
 author: "Geoff Taylor"
--->
+---
 
 # Using Customer Data + Mutations
 

--- a/docs/using-order-data.md
+++ b/docs/using-order-data.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Order Data with WooGraphQL"
 description: "Learn how to utilize the Order queries and type by building a basic order status page in React.js that works by taking an `email` and returning a list of all the orders connected to that `email`."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, Order queries, React.js, order status page"
 author: "Geoff Taylor"
--->
+---
 
 # Using Order Data
 

--- a/docs/using-product-addons-data-and-mutations.md
+++ b/docs/using-product-addons-data-and-mutations.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Product Add-ons Data + Mutations with WooGraphQL"
 author: "Geoff Taylor"
 description: "Learn how to use the Product Add-on functionality with WPGraphQL for WooCommerce by building upon the code from `Using Product Data` and `Creating Session Provider and using Cart Mutations`."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, Product Add-on functionality, Product Data, Session Provider, Cart Mutations"
--->
+---
 
 # Coming Soon
 

--- a/docs/using-product-bundle-data-and-mutations.md
+++ b/docs/using-product-bundle-data-and-mutations.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Product Bundle Data + Mutations with WooGraphQL"
 description: "Learn how to use the Product Bundle functionality with WPGraphQL for WooCommerce by building upon the code from `Using Product Data` and `Creating Session Provider and using Cart Mutations`."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, Product Bundle functionality, Product Data, Session Provider, Cart Mutations"
 author: "Geoff Taylor"
--->
+---
 
 # Using Product Bundle Data + Mutations
 

--- a/docs/using-product-data.md
+++ b/docs/using-product-data.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Product Data with WooGraphQL"
 description: "Learn how to efficiently fetch and use product data in your headless WooCommerce application using WPGraphQL for WooCommerce and WPGraphQL for a seamless shopping experience."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, product data, headless, shopping experience"
 author: "Geoff Taylor"
--->
+---
 
 # Using Product Data
 

--- a/docs/using-subscription-data-and-mutations.md
+++ b/docs/using-subscription-data-and-mutations.md
@@ -1,9 +1,9 @@
-<!--
+---
 title: "Using Subscription Data + Mutations with WooGraphQL"
 description: "Learn how to use the Subscription functionality provided by WooGraphQL Pro and build upon the code written in `Using Product Data` and `Routing by URI` by rewriting the `ProductListing` and `SingleProduct` components to support `SubscriptionProduct` types."
 keywords: "WooGraphQL, WPGraphQL, WooCommerce, GraphQL, Subscription functionality, ProductListing, SingleProduct, SubscriptionProduct types"
 author: "Geoff Taylor"
--->
+---
 
 # Using Subscription Data + Mutations
 


### PR DESCRIPTION
If commenting out titles was intentional, feel free to ignore this PR 🙂

The commented HTML metadata is currently rendered into the docs navigation / table of contents, which makes the sidebar difficult to use.

This is how it looks on the docs pages:
<img width="1257" height="827" alt="image" src="https://github.com/user-attachments/assets/428739e7-8b7c-44c0-a6b2-7563493c9e2d" />

