### PR TITLE
test: add customer refund fields visibility test

### DIFF
--- a/tests/wpunit/RefundQueriesTest.php
+++ b/tests/wpunit/RefundQueriesTest.php
@@ -294,4 +294,89 @@ class RefundQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}
+
+	public function testCustomerRefundFieldsNotNull() {
+		$order_id  = $this->factory->order->createNew( [ 'customer_id' => $this->customer ] );
+		$this->loginAsShopManager();
+		$refund_id = $this->factory->refund->createNew( $order_id, [ 'amount' => 0.5 ] );
+		$refund    = \wc_get_order( $refund_id );
+		$relay_id  = $this->toRelayId( 'order', $order_id );
+
+		/**
+		 * Assertion One
+		 *
+		 * Customer can see refund fields via customer.refunds connection.
+		 */
+		$query = '
+			query {
+				customer {
+					refunds {
+						nodes {
+							databaseId
+							title
+							amount
+							reason
+						}
+					}
+				}
+			}
+		';
+
+		$this->loginAsCustomer();
+		$response = $this->graphql( compact( 'query' ) );
+
+		$expected = [
+			$this->expectedNode(
+				'customer.refunds.nodes',
+				[
+					'databaseId' => $refund->get_id(),
+					'title'      => $refund->get_post_title(),
+					'amount'     => floatval( $refund->get_amount() ),
+					'reason'     => $refund->get_reason(),
+				]
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		// Clear loader cache.
+		$this->clearLoaderCache( 'wc_post' );
+
+		/**
+		 * Assertion Two
+		 *
+		 * Customer can see refund fields via order.refunds connection.
+		 */
+		$query = '
+			query ( $id: ID! ) {
+				order( id: $id ) {
+					refunds {
+						nodes {
+							databaseId
+							title
+							amount
+							reason
+						}
+					}
+				}
+			}
+		';
+
+		$variables = [ 'id' => $relay_id ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+
+		$expected = [
+			$this->expectedNode(
+				'order.refunds.nodes',
+				[
+					'databaseId' => $refund->get_id(),
+					'title'      => $refund->get_post_title(),
+					'amount'     => floatval( $refund->get_amount() ),
+					'reason'     => $refund->get_reason(),
+				]
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------

Adds a new test `testCustomerRefundFieldsNotNull` to `RefundQueriesTest` that verifies customers can see refund restricted fields (`title`, `amount`, `reason`) through both:

1. `customer { refunds { nodes { ... } } }` connection
2. `order(id: $id) { refunds { nodes { ... } } }` connection

The reported bug was that these fields returned `null` for customers querying their own refunds. Testing confirms this has been resolved — the `owner_matches_current_user()` method correctly resolves the parent order for refunds and grants access.

Does this close any currently open issues?
------------------------------------------

Resolves #431

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

Test passes locally:
```
vendor/bin/codecept run wpunit RefundQueriesTest:testCustomerRefundFieldsNotNull
OK (1 test, 2 assertions)
```

Any other comments?
-------------------

The bug was reported in 2021 and appears to have been fixed in a subsequent release. This PR adds test coverage to prevent regression.