### PR TITLE
devops: add product category children connection test

### DIFF
--- a/tests/wpunit/ProductTaxonomyQueriesTest.php
+++ b/tests/wpunit/ProductTaxonomyQueriesTest.php
@@ -4,11 +4,11 @@ class ProductTaxonomyQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\W
     public function testProductCategoriesToProductsQuery() {
         // Create categories.
 		$clothing_category_id = $this->factory->product->createProductCategory( 'clothing' );
-		$shoes_id = $this->factory->product->createProductCategory( 'shoes', [ 'parent' => $clothing_category_id ] );
-        $accessories_id = $this->factory->product->createProductCategory( 'accessories', [ 'parent' => $clothing_category_id ] );
+		$shoes_id = $this->factory->product->createProductCategory( 'shoes', $clothing_category_id );
+        $accessories_id = $this->factory->product->createProductCategory( 'accessories', $clothing_category_id );
         $electronics_category_id = $this->factory->product->createProductCategory( 'electronics' );
-        $smartphones_id = $this->factory->product->createProductCategory( 'smartphones', [ 'parent' => $electronics_category_id ] );
-        $laptops_id = $this->factory->product->createProductCategory( 'laptops', [ 'parent' => $electronics_category_id ] );
+        $smartphones_id = $this->factory->product->createProductCategory( 'smartphones', $electronics_category_id );
+        $laptops_id = $this->factory->product->createProductCategory( 'laptops', $electronics_category_id );
 
         // Create products.
         $clothing_ids = $this->factory->product->create_many( 5, [ 'category_ids' => [ $clothing_category_id ] ] );
@@ -46,17 +46,19 @@ class ProductTaxonomyQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\W
                 $this->expectedField( 'productCategory.id', $this->toRelayId( 'term', $clothing_category_id ) ),
                 $this->expectedField( 'productCategory.slug', 'clothing' ),
             ],
+            // Clothing products should appear.
             array_map(
                 function( $id ) {
                     return $this->expectedField( 'productCategory.products.nodes.#.databaseId', $id );
                 },
                 $clothing_ids
             ),
+            // Products from non-clothing categories should not appear.
             array_map(
                 function( $id ) {
                     return $this->not()->expectedField( 'productCategory.products.nodes.#.databaseId', $id );
                 },
-                array_merge( $smartphones_ids, $shoes_ids, $accessories_ids )
+                array_merge( $smartphones_ids, $electronics_ids, $laptops_ids )
             ),
         );
 
@@ -98,17 +100,19 @@ class ProductTaxonomyQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\W
                 $this->expectedField( 'productCategory.id', $this->toRelayId( 'term', $electronics_category_id ) ),
                 $this->expectedField( 'productCategory.slug', 'electronics' ),
             ],
+            // Electronics and its children's products should appear.
             array_map(
                 function( $id ) {
                     return $this->expectedField( 'productCategory.products.nodes.#.databaseId', $id );
                 },
                 array_merge( $electronics_ids, $laptops_ids )
             ),
+            // Products from non-electronics categories should not appear.
             array_map(
                 function( $id ) {
                     return $this->not()->expectedField( 'productCategory.products.nodes.#.databaseId', $id );
                 },
-                array_merge( $clothing_ids, $shoes_ids, $accessories_ids, $smartphones_ids )
+                array_merge( $clothing_ids, $shoes_ids, $accessories_ids )
             ),
         );
 
@@ -222,4 +226,70 @@ class ProductTaxonomyQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\W
 
         $this->assertQuerySuccessful( $response, $expected );
     }
+
+	public function testProductCategoryChildrenConnection() {
+		// Create parent categories.
+		$parent_a = $this->factory->product->createProductCategory( 'parent-a' );
+		$parent_b = $this->factory->product->createProductCategory( 'parent-b' );
+
+		// Create child categories.
+		$child_a1 = $this->factory->product->createProductCategory( 'child-a1', $parent_a );
+		$child_a2 = $this->factory->product->createProductCategory( 'child-a2', $parent_a );
+		$child_b1 = $this->factory->product->createProductCategory( 'child-b1', $parent_b );
+
+		$query = '
+			query GetProductCategories {
+				productCategories(where: {parent: 0}) {
+					nodes {
+						slug
+						name
+						children {
+							nodes {
+								name
+								slug
+							}
+						}
+					}
+				}
+			}
+		';
+
+		$response = $this->graphql( compact( 'query' ) );
+
+		$expected = [
+			$this->expectedField( 'productCategories.nodes.#.slug', 'parent-a' ),
+			$this->expectedField( 'productCategories.nodes.#.slug', 'parent-b' ),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		// Verify parent-a has its children.
+		$parent_a_node = null;
+		foreach ( $response['data']['productCategories']['nodes'] as $node ) {
+			if ( 'parent-a' === $node['slug'] ) {
+				$parent_a_node = $node;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $parent_a_node, 'parent-a category should exist in response.' );
+		$this->assertCount( 2, $parent_a_node['children']['nodes'], 'parent-a should have 2 children.' );
+
+		$child_slugs = array_column( $parent_a_node['children']['nodes'], 'slug' );
+		$this->assertContains( 'child-a1', $child_slugs );
+		$this->assertContains( 'child-a2', $child_slugs );
+
+		// Verify parent-b has its child.
+		$parent_b_node = null;
+		foreach ( $response['data']['productCategories']['nodes'] as $node ) {
+			if ( 'parent-b' === $node['slug'] ) {
+				$parent_b_node = $node;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $parent_b_node, 'parent-b category should exist in response.' );
+		$this->assertCount( 1, $parent_b_node['children']['nodes'], 'parent-b should have 1 child.' );
+		$this->assertEquals( 'child-b1', $parent_b_node['children']['nodes'][0]['slug'] );
+	}
 }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------

Adds a regression test for the `productCategories` `children` connection and fixes the existing taxonomy test factory usage.

- **New test** `testProductCategoryChildrenConnection`: Verifies that querying `productCategories(where: {parent: 0}) { children { nodes { slug } } }` correctly returns subcategories.
- **Fixed factory calls**: The existing `testProductCategoriesToProductsQuery` was passing arrays (`['parent' => $id]`) to `createProductCategory()` which expects an integer `$parent_id`. Fixed to pass integer IDs directly.
- **Updated assertions**: With proper parent-child hierarchy now in place, child category products correctly appear under their parent category queries. Updated the NOT-expected assertions accordingly.

Does this close any currently open issues?
------------------------------------------

Resolves #828

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

```
vendor/bin/codecept run wpunit ProductTaxonomyQueriesTest
OK (3 tests, 14 assertions)
```

Any other comments?
-------------------

The bug was reported on v0.18.0 and has since been fixed. This PR adds test coverage to prevent regression.