### PR TITLE
devops: add updateOrder metaData duplicate order regression test

### DIFF
--- a/tests/wpunit/OrderMutationsTest.php
+++ b/tests/wpunit/OrderMutationsTest.php
@@ -1280,4 +1280,112 @@ class OrderMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 		$actual = $this->orderNoteMutation( $invalid_order_input );
 		$this->assertQueryError( $actual );
 	}
+
+	/**
+	 * Test that updateOrder with only metaData does not create a duplicate order.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql-woocommerce/issues/591
+	 */
+	public function testUpdateOrderMetaDataDoesNotDuplicate() {
+		wp_set_current_user( $this->shop_manager );
+
+		// Create an order.
+		$order_id = $this->order->create(
+			[
+				'status'      => 'processing',
+				'customer_id' => $this->customer,
+			]
+		);
+
+		// Count orders before mutation.
+		$orders_before = wc_get_orders( [ 'return' => 'ids', 'limit' => -1 ] );
+		$count_before  = count( $orders_before );
+
+		// Update only metaData — the exact scenario from #591.
+		$mutation = '
+			mutation updateOrder($input: UpdateOrderInput!) {
+				updateOrder(input: $input) {
+					order {
+						databaseId
+						metaData {
+							key
+							value
+						}
+					}
+				}
+			}
+		';
+
+		$variables = [
+			'input' => [
+				'id'       => $order_id,
+				'metaData' => [
+					[
+						'key'   => '_tracking_number',
+						'value' => 'ABC123',
+					],
+				],
+			],
+		];
+
+		$response = $this->graphql(
+			[
+				'query'     => $mutation,
+				'variables' => $variables,
+			]
+		);
+
+		$expected = [
+			$this->expectedField( 'updateOrder.order.databaseId', $order_id ),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		// Verify metaData was set.
+		$order = wc_get_order( $order_id );
+		$this->assertEquals( 'ABC123', $order->get_meta( '_tracking_number' ) );
+
+		// Count orders after mutation — should be the same.
+		$orders_after = wc_get_orders( [ 'return' => 'ids', 'limit' => -1 ] );
+		$count_after  = count( $orders_after );
+
+		$this->assertEquals(
+			$count_before,
+			$count_after,
+			'updateOrder with new metaData should not create a duplicate order.'
+		);
+
+		// Now update the same meta key with a new value.
+		$count_before_update = $count_after;
+
+		$variables['input']['metaData'] = [
+			[
+				'key'   => '_tracking_number',
+				'value' => 'XYZ789',
+			],
+		];
+
+		$response = $this->graphql(
+			[
+				'query'     => $mutation,
+				'variables' => $variables,
+			]
+		);
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		// Verify metaData was updated.
+		$order = wc_get_order( $order_id );
+		$this->assertEquals( 'XYZ789', $order->get_meta( '_tracking_number' ) );
+
+		// Count orders after updating existing meta — should still be the same.
+		$orders_after_update = wc_get_orders( [ 'return' => 'ids', 'limit' => -1 ] );
+		$count_after_update  = count( $orders_after_update );
+
+		$this->assertEquals(
+			$count_before_update,
+			$count_after_update,
+			'updateOrder with existing metaData should not create a duplicate order.'
+		);
+	}
 }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side).
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side).
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------

Adds a regression test confirming that `updateOrder` with only `metaData` input does not create duplicate orders. The test covers both creating new meta and updating existing meta on an order.

Bug recreation was not possible on the current codebase. Investigation of the `add_order_meta` function via `git blame` shows the code has been largely unchanged since 2019. The reported issue was on very old plugin/WooCommerce versions (WooGraphQL 0.10.6, WooCommerce 4.7.2, WordPress 5.5.7) and was likely caused by an environmental factor or WooCommerce bug at that version.

The old `Relay::fromGlobalId()` ID resolution (replaced in #902 with `Utils::get_database_id_from_id()`) was also investigated but would not have caused duplicates — it either resolves correctly or throws a UserError.

Does this close any currently open issues?
------------------------------------------

Resolves #591

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A — bug is not reproducible on current codebase.

Any other comments?
-------------------

N/A