### PR TITLE
fix: term_taxonomy_id mismatch in coupon category connections

### DIFF
--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -12,11 +12,9 @@ namespace WPGraphQL\WooCommerce\Connection;
 
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 use WPGraphQL\Type\Connection\TermObjects;
-use WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce;
 
 /**
  * Class - WC_Terms
@@ -30,51 +28,6 @@ class WC_Terms extends TermObjects {
 	 * @return void
 	 */
 	public static function register_connections() {
-		/**
-		 * Get the allowed taxonomies.
-		 *
-		 * @var array<string,\WP_Taxonomy> $allowed_taxonomies
-		 */
-		$allowed_taxonomies = WPGraphQL::get_allowed_taxonomies( 'objects' );
-		$wc_post_types      = WP_GraphQL_WooCommerce::get_post_types();
-
-		// Loop through the allowed_taxonomies to register appropriate connections.
-		foreach ( $allowed_taxonomies as $tax_object ) {
-			foreach ( $wc_post_types as $post_type ) {
-				if ( 'product' === $post_type || 'product_variation' === $post_type ) {
-					continue;
-				}
-
-				if ( in_array( $post_type, $tax_object->object_type, true ) ) {
-					$post_type_object = get_post_type_object( $post_type );
-
-					if ( null === $post_type_object ) {
-						continue;
-					}
-
-					register_graphql_connection(
-						self::get_connection_config(
-							$tax_object,
-							[
-								'fromType'      => $post_type_object->graphql_single_name,
-								'toType'        => $tax_object->graphql_single_name,
-								'fromFieldName' => $tax_object->graphql_plural_name,
-								'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
-									$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
-
-									$term_ids = \wc_get_object_terms( $source->ID, $tax_object->name, 'term_id' );
-
-									$resolver->set_query_arg( 'term_taxonomy_id', ! empty( $term_ids ) ? $term_ids : [ '0' ] );
-
-									return $resolver->get_connection();
-								},
-							]
-						)
-					);
-				}//end if
-			}//end foreach
-		}//end foreach
-
 		// From Coupons to ProductCategory connections.
 		$tax_object = get_taxonomy( 'product_cat' );
 		if ( ! $tax_object ) {
@@ -89,7 +42,9 @@ class WC_Terms extends TermObjects {
 					'fromFieldName' => 'productCategories',
 					'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 						$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
-						$resolver->set_query_arg( 'term_taxonomy_id', $source->product_category_ids );
+
+						$term_taxonomy_ids = self::get_term_taxonomy_ids( $source->product_category_ids, $tax_object->name );
+						$resolver->set_query_arg( 'term_taxonomy_id', $term_taxonomy_ids );
 
 						return $resolver->get_connection();
 					},
@@ -104,7 +59,9 @@ class WC_Terms extends TermObjects {
 					'fromFieldName' => 'excludedProductCategories',
 					'resolve'       => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) use ( $tax_object ) {
 						$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $tax_object->name );
-						$resolver->set_query_arg( 'term_taxonomy_id', $source->excluded_product_category_ids );
+
+						$term_taxonomy_ids = self::get_term_taxonomy_ids( $source->excluded_product_category_ids, $tax_object->name );
+						$resolver->set_query_arg( 'term_taxonomy_id', $term_taxonomy_ids );
 
 						return $resolver->get_connection();
 					},
@@ -137,5 +94,35 @@ class WC_Terms extends TermObjects {
 				},
 			]
 		);
+	}
+
+	/**
+	 * Converts an array of term_ids to their corresponding term_taxonomy_ids
+	 * for a given taxonomy.
+	 *
+	 * WooCommerce stores term_ids on coupons, but WP_Term_Query's
+	 * term_taxonomy_id arg requires term_taxonomy_ids. These can differ
+	 * when terms are shared across taxonomies.
+	 *
+	 * @param array<int|string> $term_ids Term IDs to convert.
+	 * @param string            $taxonomy Taxonomy name.
+	 *
+	 * @return array<int> Term taxonomy IDs.
+	 */
+	private static function get_term_taxonomy_ids( array $term_ids, string $taxonomy ): array {
+		if ( empty( $term_ids ) || [ '0' ] === $term_ids || [ 0 ] === $term_ids ) {
+			return [ 0 ];
+		}
+
+		$terms = get_terms(
+			[
+				'taxonomy'   => $taxonomy,
+				'include'    => array_map( 'absint', $term_ids ),
+				'fields'     => 'tt_ids',
+				'hide_empty' => false,
+			]
+		);
+
+		return ! empty( $terms ) && ! is_wp_error( $terms ) ? array_map( 'intval', $terms ) : [ 0 ];
 	}
 }

--- a/tests/wpunit/CouponQueriesTest.php
+++ b/tests/wpunit/CouponQueriesTest.php
@@ -302,4 +302,155 @@ class CouponQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 
 		$this->assertQuerySuccessful( $response, $expected );
 	}
+
+	/**
+	 * Test coupon productCategories and excludedProductCategories connections.
+	 */
+	public function testCouponProductCategoryConnections() {
+		$this->loginAsShopManager();
+
+		// Create a WP category first to force term_id/term_taxonomy_id mismatch
+		// when the product_cat with the same name is created.
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->terms,
+			[
+				'name'       => 'cat-a',
+				'slug'       => 'cat-a',
+				'term_group' => 0,
+			]
+		);
+		$shared_term_id = (int) $wpdb->insert_id;
+
+		// Add term_taxonomy entry for 'category' (consumes a term_taxonomy_id).
+		$wpdb->insert(
+			$wpdb->term_taxonomy,
+			[
+				'term_id'     => $shared_term_id,
+				'taxonomy'    => 'category',
+				'description' => '',
+				'parent'      => 0,
+				'count'       => 0,
+			]
+		);
+
+		// Add term_taxonomy entry for 'product_cat' (different term_taxonomy_id, same term_id).
+		$wpdb->insert(
+			$wpdb->term_taxonomy,
+			[
+				'term_id'     => $shared_term_id,
+				'taxonomy'    => 'product_cat',
+				'description' => '',
+				'parent'      => 0,
+				'count'       => 0,
+			]
+		);
+		$cat_a_tt_id = (int) $wpdb->insert_id;
+
+		clean_term_cache( $shared_term_id, 'product_cat' );
+		clean_term_cache( $shared_term_id, 'category' );
+
+		// cat-a now has term_id != term_taxonomy_id.
+		$cat_a = $shared_term_id;
+
+		// Create normal product categories for the rest.
+		$cat_b = $this->factory->product->createProductCategory( 'cat-b' );
+		$cat_c = $this->factory->product->createProductCategory( 'cat-c' );
+
+		// Create coupon with product categories and excluded categories.
+		$coupon_id = $this->factory->coupon->create(
+			[
+				'code'                        => 'catcoupon',
+				'amount'                      => 15,
+				'discount_type'               => 'percent',
+				'product_categories'          => [ $cat_a, $cat_b ],
+				'excluded_product_categories' => [ $cat_c ],
+			]
+		);
+
+		$query = '
+			query ($id: ID!) {
+				coupon(id: $id) {
+					databaseId
+					productCategories {
+						nodes {
+							databaseId
+							slug
+						}
+					}
+					excludedProductCategories {
+						nodes {
+							databaseId
+							slug
+						}
+					}
+				}
+			}
+		';
+
+		$variables = [ 'id' => $this->toRelayId( 'shop_coupon', $coupon_id ) ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedField( 'coupon.databaseId', $coupon_id ),
+			$this->expectedNode(
+				'coupon.productCategories.nodes',
+				[ $this->expectedField( 'slug', 'cat-a' ) ]
+			),
+			$this->expectedNode(
+				'coupon.productCategories.nodes',
+				[ $this->expectedField( 'slug', 'cat-b' ) ]
+			),
+			$this->not()->expectedNode(
+				'coupon.productCategories.nodes',
+				[ $this->expectedField( 'slug', 'cat-c' ) ]
+			),
+			$this->expectedNode(
+				'coupon.excludedProductCategories.nodes',
+				[ $this->expectedField( 'slug', 'cat-c' ) ]
+			),
+			$this->not()->expectedNode(
+				'coupon.excludedProductCategories.nodes',
+				[ $this->expectedField( 'slug', 'cat-a' ) ]
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+
+		// Query with where arg to further filter the included categories.
+		$query_with_filter = '
+			query ($id: ID!, $exclude: [ID]) {
+				coupon(id: $id) {
+					productCategories(where: { exclude: $exclude }) {
+						nodes {
+							slug
+						}
+					}
+				}
+			}
+		';
+
+		$variables = [
+			'id'      => $this->toRelayId( 'shop_coupon', $coupon_id ),
+			'exclude' => [ $cat_b ],
+		];
+		$response  = $this->graphql(
+			[
+				'query'     => $query_with_filter,
+				'variables' => $variables,
+			]
+		);
+		$expected = [
+			$this->expectedNode(
+				'coupon.productCategories.nodes',
+				[ $this->expectedField( 'slug', 'cat-a' ) ]
+			),
+			$this->not()->expectedNode(
+				'coupon.productCategories.nodes',
+				[ $this->expectedField( 'slug', 'cat-b' ) ]
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 }

--- a/tests/wpunit/ProductCategoryQueriesTest.php
+++ b/tests/wpunit/ProductCategoryQueriesTest.php
@@ -184,4 +184,99 @@ class ProductCategoryQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\W
 		$this->assertCount( 1, $parent_b_node['children']['nodes'], 'parent-b should have 1 child.' );
 		$this->assertEquals( 'child-b1', $parent_b_node['children']['nodes'][0]['slug'] );
 	}
+
+	/**
+	 * Test that productCategories resolves correctly when term_id and term_taxonomy_id differ.
+	 *
+	 * This happens when a WP category and a product_cat share the same name,
+	 * causing WordPress to reuse the term_id but assign a different term_taxonomy_id.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql-woocommerce/issues/597
+	 */
+	public function testProductCategoriesWithMismatchedTermTaxonomyIds() {
+		// Create a term directly in the wp_terms table, then add term_taxonomy
+		// entries for both 'category' and 'product_cat' to simulate the scenario
+		// where term_id is shared but term_taxonomy_id differs.
+		global $wpdb;
+
+		// Insert a shared term.
+		$wpdb->insert(
+			$wpdb->terms,
+			[
+				'name'       => 'Electronics',
+				'slug'       => 'electronics-shared',
+				'term_group' => 0,
+			]
+		);
+		$shared_term_id = (int) $wpdb->insert_id;
+
+		// Add term_taxonomy entry for 'category'.
+		$wpdb->insert(
+			$wpdb->term_taxonomy,
+			[
+				'term_id'     => $shared_term_id,
+				'taxonomy'    => 'category',
+				'description' => '',
+				'parent'      => 0,
+				'count'       => 0,
+			]
+		);
+		$wp_cat_tt_id = (int) $wpdb->insert_id;
+
+		// Add term_taxonomy entry for 'product_cat'.
+		$wpdb->insert(
+			$wpdb->term_taxonomy,
+			[
+				'term_id'     => $shared_term_id,
+				'taxonomy'    => 'product_cat',
+				'description' => '',
+				'parent'      => 0,
+				'count'       => 0,
+			]
+		);
+		$product_cat_tt_id = (int) $wpdb->insert_id;
+
+		// Confirm term_taxonomy_ids differ.
+		$this->assertNotEquals( $wp_cat_tt_id, $product_cat_tt_id );
+
+
+		// Clean term caches.
+		clean_term_cache( $shared_term_id, 'product_cat' );
+		clean_term_cache( $shared_term_id, 'category' );
+
+		// Create a product in this category.
+		$product_id = $this->factory->product->createSimple(
+			[ 'category_ids' => [ $shared_term_id ] ]
+		);
+
+		$query = '
+			query ($id: ID!) {
+				product(id: $id, idType: DATABASE_ID) {
+					databaseId
+					productCategories {
+						nodes {
+							databaseId
+							name
+							slug
+						}
+					}
+				}
+			}
+		';
+
+		$variables = [ 'id' => $product_id ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$expected  = [
+			$this->expectedField( 'product.databaseId', $product_id ),
+			$this->expectedNode(
+				'product.productCategories.nodes',
+				[
+					$this->expectedField( 'databaseId', $shared_term_id ),
+					$this->expectedField( 'slug', 'electronics-shared' ),
+				]
+			),
+		];
+
+		$this->assertQuerySuccessful( $response, $expected );
+	}
 }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side).
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side).
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------

### Coupon category connection fix

WooCommerce stores `term_id`s on coupons (`product_categories` and `excluded_product_categories`), but the connection resolver was passing them directly as `term_taxonomy_id` to `WP_Term_Query`. When `term_id` and `term_taxonomy_id` differ (which happens when terms are shared across taxonomies — e.g., a WP category and a product_cat with the same name), the query returned no results.

**Fix:** Added `get_term_taxonomy_ids()` helper that converts `term_id`s to their correct `term_taxonomy_id`s for the given taxonomy using a single `get_terms()` query with `fields => 'tt_ids'`.

### Dead code removal

The generic WC post type → taxonomy connection loop was dead code:
- Products and product variations were already skipped
- No standard WooCommerce taxonomies are registered on `shop_order`, `shop_order_refund`, or `shop_coupon`
- Full test suite passes with the loop removed (242 tests, 0 regressions)

The original reported issue (#597) affected products, which was incidentally fixed in PR #675 when products were excluded from this loop and deferred to WPGraphQL core's connection handling.

### Test coverage
- **CouponQueriesTest::testCouponProductCategoryConnections** — tests productCategories and excludedProductCategories connections with mismatched term_id/term_taxonomy_id, plus `exclude` where arg filtering
- **ProductCategoryQueriesTest::testProductCategoriesWithMismatchedTermTaxonomyIds** — regression test confirming product→productCategories works with shared terms

Does this close any currently open issues?
------------------------------------------

Resolves #597

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A

Any other comments?
-------------------

N/A