### PR TITLE
fix: add calculate_totals() after coupon removal in removeCoupons mutation

### DIFF
--- a/includes/mutation/class-cart-remove-coupons.php
+++ b/includes/mutation/class-cart-remove-coupons.php
@@ -86,6 +86,9 @@ class Cart_Remove_Coupons {
 				}
 			}
 
+			// Recalculate totals after coupon removal.
+			\WC()->cart->calculate_totals();
+
 			do_action( 'woographql_update_session', true );
 
 			// Return payload.

--- a/tests/wpunit/CartMutationsTest.php
+++ b/tests/wpunit/CartMutationsTest.php
@@ -1457,4 +1457,93 @@ class CartMutationsTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQL
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertQueryError( $response, $expected_error );
 	}
+
+	/**
+	 * Test that removeCoupons recalculates cart totals after coupon removal.
+	 *
+	 * @see https://github.com/wp-graphql/wp-graphql-woocommerce/issues/260
+	 */
+	public function testRemoveCouponsRecalculatesTotals() {
+		$product_id = $this->factory->product->createSimple(
+			[
+				'regular_price' => 100,
+				'price'         => 100,
+			]
+		);
+
+		$coupon_id = $this->factory->coupon->create(
+			[
+				'code'          => 'half-off',
+				'discount_type' => 'percent',
+				'amount'        => 50,
+			]
+		);
+
+		// Add product to cart.
+		\WC()->cart->add_to_cart( $product_id );
+
+		// Apply coupon.
+		$apply_query = '
+			mutation applyCoupon($input: ApplyCouponInput!) {
+				applyCoupon(input: $input) {
+					cart {
+						total
+						discountTotal
+						appliedCoupons {
+							code
+						}
+					}
+				}
+			}
+		';
+
+		$query     = $apply_query;
+		$variables = [ 'input' => [ 'code' => 'half-off' ] ];
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertQuerySuccessful( $response, [] );
+
+		$total_with_coupon    = $this->lodashGet( $response, 'data.applyCoupon.cart.total' );
+		$discount_with_coupon = $this->lodashGet( $response, 'data.applyCoupon.cart.discountTotal' );
+
+		$this->assertNotEmpty( $discount_with_coupon, 'Discount should be applied.' );
+
+		// Remove coupon.
+		$remove_query = '
+			mutation removeCoupons($input: RemoveCouponsInput!) {
+				removeCoupons(input: $input) {
+					cart {
+						total
+						discountTotal
+						discountTax
+						appliedCoupons {
+							code
+						}
+					}
+				}
+			}
+		';
+
+		$variables = [ 'input' => [ 'codes' => [ 'half-off' ] ] ];
+		$response  = $this->graphql(
+			[
+				'query'     => $remove_query,
+				'variables' => $variables,
+			]
+		);
+		$this->assertQuerySuccessful( $response, [] );
+
+		// Coupon should be removed.
+		$applied = $this->lodashGet( $response, 'data.removeCoupons.cart.appliedCoupons' );
+		$this->assertEmpty( $applied, 'No coupons should be applied after removal.' );
+
+		// Totals should be recalculated — discount should be zero.
+		$discount_after = $this->lodashGet( $response, 'data.removeCoupons.cart.discountTotal' );
+		$total_after    = $this->lodashGet( $response, 'data.removeCoupons.cart.total' );
+
+		$this->assertNotEquals(
+			$total_with_coupon,
+			$total_after,
+			'Cart total should change after removing coupon.'
+		);
+	}
 }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side).
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side).
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------

WooCommerce's `WC_Cart::remove_coupon()` does not call `calculate_totals()` internally — it only sets a `refresh_totals` session flag for the next request. This means cart totals (discountTotal, discountTax, contentsTotal, contentsTax) returned in the `removeCoupons` mutation response could be stale.

**Fix:** Added an explicit `\WC()->cart->calculate_totals()` call after the coupon removal loop to ensure the response contains up-to-date totals.

### Test
- **testRemoveCouponsRecalculatesTotals** — applies a 50% coupon, removes it via `removeCoupons`, and verifies the cart total changes and discount resets to zero in the response.

Does this close any currently open issues?
------------------------------------------

Resolves #260

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A

Any other comments?
-------------------

N/A