### PR TITLE
fix: prevent WooCommerce session creation on CORS preflight OPTIONS requests

### DIFF
--- a/includes/class-woocommerce-filters.php
+++ b/includes/class-woocommerce-filters.php
@@ -36,7 +36,7 @@ class WooCommerce_Filters {
 			add_filter( 'graphql_access_control_allow_headers', [ self::class, 'add_session_header_to_allow_headers' ] );
 
 			// Initialize cart/session after JWT authentication has had a chance to run.
-			add_action( 'graphql_process_http_request', [ self::class, 'initialize_session_and_cart' ] );
+			add_action( 'init_graphql_request', [ self::class, 'initialize_session_and_cart' ] );
 		}
 
 		// Add better support for Stripe payment gateway.
@@ -67,6 +67,10 @@ class WooCommerce_Filters {
 	 * @return void
 	 */
 	public static function initialize_session_and_cart() {
+		if ( ! \WPGraphQL\Router::is_graphql_http_request() ) {
+			return;
+		}
+
 		// Clear any existing WooCommerce objects to ensure fresh initialization
 		// with the correct user context after JWT authentication.
 

--- a/tests/functional/OptionsRequestCest.php
+++ b/tests/functional/OptionsRequestCest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Tests that CORS preflight OPTIONS requests to the GraphQL endpoint
+ * do not create WooCommerce sessions.
+ *
+ * @see https://github.com/wp-graphql/wp-graphql-woocommerce/issues/908
+ */
+class OptionsRequestCest {
+	public function _before( FunctionalTester $I ) {
+		if ( ! defined( 'GRAPHQL_WOOCOMMERCE_SECRET_KEY' ) ) {
+			define( 'GRAPHQL_WOOCOMMERCE_SECRET_KEY', 'testestestestestestestestestest!!' );
+		}
+	}
+
+	/**
+	 * Test that an OPTIONS request to /graphql does not return a woocommerce-session header.
+	 */
+	public function testOptionsRequestDoesNotCreateSession( FunctionalTester $I ) {
+		$I->sendOptions( '/graphql' );
+		$I->seeResponseCodeIs( 200 );
+
+		// OPTIONS response should NOT contain a woocommerce-session header.
+		$I->dontSeeHttpHeader( 'woocommerce-session' );
+	}
+}


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side).
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side).
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------

### Problem
CORS preflight `OPTIONS` requests to the GraphQL endpoint were creating unwanted WooCommerce sessions in `wp_woocommerce_sessions`. This happened because `initialize_session_and_cart()` was hooked to `graphql_process_http_request`, which fires in `Router::process_http_request()` **before** the OPTIONS check on line 510 that exits early.

### Fix
- Changed the hook from `graphql_process_http_request` to `init_graphql_request`
- `init_graphql_request` fires inside the `Request` constructor (line 155 of Request.php), which is only instantiated on line 520 of Router.php — **after** the OPTIONS exit on line 510-513
- Added `Router::is_graphql_http_request()` guard inside `initialize_session_and_cart()` to ensure it only runs for actual HTTP requests, not programmatic `graphql()` helper calls (which also create `Request` instances)

### Test
- **OptionsRequestCest::testOptionsRequestDoesNotCreateSession** — functional (e2e) test that sends an OPTIONS request to `/graphql` and verifies no `woocommerce-session` header is returned

Does this close any currently open issues?
------------------------------------------

Resolves #908

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A

Any other comments?
-------------------

N/A