### PR TITLE
feat: add session transfer behavior setting for login session handling

### DIFF
--- a/includes/admin/class-general.php
+++ b/includes/admin/class-general.php
@@ -110,6 +110,19 @@ class General extends Section {
 				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
 			],
 			[
+				'name'     => 'session_transfer_behavior',
+				'label'    => __( 'Session Transfer Behavior', 'wp-graphql-woocommerce' ),
+				'desc'     => __( 'Controls how cart data is handled when a user logs in with an existing session from another device. "Keep new" keeps the current session data (default). "Keep old" restores the previously saved session data. "Merge" combines cart items from both sessions.', 'wp-graphql-woocommerce' ),
+				'type'     => 'select',
+				'options'  => [
+					'keep_new_fallback_old' => __( 'Keep new, fallback to old (default)', 'wp-graphql-woocommerce' ),
+					'keep_new'              => __( 'Keep new (always use current session)', 'wp-graphql-woocommerce' ),
+					'keep_old'              => __( 'Keep old (restore previously saved session)', 'wp-graphql-woocommerce' ),
+				],
+				'default'  => 'keep_new_fallback_old',
+				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
+			],
+			[
 				'name'    => 'enable_unsupported_product_type',
 				'label'   => __( 'Enable Unsupported types', 'wp-graphql-woocommerce' ),
 				'desc'    => __( 'Substitute unsupported product types with SimpleProduct', 'wp-graphql-woocommerce' ),

--- a/includes/utils/class-ql-session-handler.php
+++ b/includes/utils/class-ql-session-handler.php
@@ -166,12 +166,24 @@ class QL_Session_Handler extends WC_Session_Handler {
 			// If the user logs in, update session.
 			if ( is_user_logged_in() && strval( get_current_user_id() ) !== $this->_customer_id ) {
 				$guest_session_id   = $this->_customer_id;
+				$guest_data         = $this->_data;
 				$this->_customer_id = strval( get_current_user_id() );
 				$this->_dirty       = true;
 
-				// If session empty check for previous data associated with customer and assign that to the session.
-				if ( empty( $this->_data ) ) {
-					$this->_data = $this->get_session_data();
+				$existing_user_data = $this->get_session_data();
+
+				$transfer_behavior = woographql_setting( 'session_transfer_behavior', 'keep_new_fallback_old' );
+				switch ( $transfer_behavior ) {
+					case 'keep_new':
+						$this->_data = $guest_data;
+						break;
+					case 'keep_old':
+						$this->_data = ! empty( $existing_user_data ) ? $existing_user_data : $guest_data;
+						break;
+					case 'keep_new_fallback_old':
+					default:
+						$this->_data = ! empty( $guest_data ) ? $guest_data : $existing_user_data;
+						break;
 				}
 
 				// @phpstan-ignore-next-line

--- a/tests/functional/SessionTransferCest.php
+++ b/tests/functional/SessionTransferCest.php
@@ -1,0 +1,207 @@
+<?php
+
+use WPGraphQL\WooCommerce\Vendor\Firebase\JWT\JWT;
+use WPGraphQL\WooCommerce\Vendor\Firebase\JWT\Key;
+use Tests\WPGraphQL\Logger\CodeceptLogger as Signal;
+
+/**
+ * Tests session transfer behavior when a user logs in with an existing session.
+ *
+ * @see https://github.com/wp-graphql/wp-graphql-woocommerce/issues/909
+ */
+class SessionTransferCest {
+	private $product_catalog;
+
+	public function _before( FunctionalTester $I ) {
+		$this->product_catalog = $I->getCatalog();
+
+		if ( ! defined( 'GRAPHQL_WOOCOMMERCE_SECRET_KEY' ) ) {
+			define( 'GRAPHQL_WOOCOMMERCE_SECRET_KEY', 'testestestestestestestestestest!!' );
+		}
+	}
+
+	/**
+	 * Helper: Sets up a scenario with an existing user session and a new guest session.
+	 *
+	 * 1. Logs in, adds product A to cart, saves session (simulates previous device)
+	 * 2. Adds product B to cart as guest (simulates new device)
+	 * 3. Logs in again with the guest session — triggers session transfer
+	 * 4. Returns tokens for querying the resulting cart
+	 *
+	 * @param FunctionalTester $I       Tester instance.
+	 * @param string           $setting The session_transfer_behavior setting value.
+	 *
+	 * @return array{ auth_token: string, session_token: string }
+	 */
+	private function setupSessionTransferScenario( FunctionalTester $I, string $setting ): array {
+		$I->setupStoreAndUsers();
+
+		// Set the session transfer behavior setting.
+		$existing = $I->grabOptionFromDatabase( 'woographql_settings' );
+		$I->haveOptionInDatabase(
+			'woographql_settings',
+			array_merge(
+				is_array( $existing ) ? $existing : [],
+				[ 'session_transfer_behavior' => $setting ]
+			)
+		);
+
+		/**
+		 * Step 1: Add t-shirt as guest, then log in with that session.
+		 */
+		$add_old = $I->addToCart(
+			[
+				'clientMutationId' => 'addOld',
+				'productId'        => $this->product_catalog['t-shirt'],
+				'quantity'         => 1,
+			]
+		);
+
+		$I->assertQuerySuccessful(
+			$add_old,
+			[ $I->expectField( 'addToCart.cartItem.key', Signal::NOT_NULL ) ]
+		);
+
+		$old_session = $I->grabHttpHeader( 'woocommerce-session' );
+
+		// Log in with the guest session — transfers t-shirt cart to user.
+		$login_1 = $I->login(
+			[
+				'clientMutationId' => 'login1',
+				'username'         => 'jimbo1234@example.com',
+				'password'         => 'password',
+			],
+			[
+				'woocommerce-session' => "Session {$old_session}",
+			]
+		);
+
+		$I->assertQuerySuccessful(
+			$login_1,
+			[ $I->expectField( 'login.authToken', Signal::NOT_NULL ) ]
+		);
+
+		/**
+		 * Step 2: Add jeans as a new guest (no session headers — fresh session).
+		 */
+		$guest_add = $I->addToCart(
+			[
+				'clientMutationId' => 'addNew',
+				'productId'        => $this->product_catalog['jeans'],
+				'quantity'         => 2,
+			]
+		);
+
+		$I->assertQuerySuccessful(
+			$guest_add,
+			[ $I->expectField( 'addToCart.cartItem.key', Signal::NOT_NULL ) ]
+		);
+
+		$guest_session = $I->grabHttpHeader( 'woocommerce-session' );
+
+		/**
+		 * Step 3: Log in again with the guest session — triggers session transfer.
+		 */
+		$login_2 = $I->login(
+			[
+				'clientMutationId' => 'login2',
+				'username'         => 'jimbo1234@example.com',
+				'password'         => 'password',
+			],
+			[
+				'woocommerce-session' => "Session {$guest_session}",
+			]
+		);
+
+		$I->assertQuerySuccessful(
+			$login_2,
+			[ $I->expectField( 'login.authToken', Signal::NOT_NULL ) ]
+		);
+
+		return [
+			'auth_token'    => $I->lodashGet( $login_2, 'data.login.authToken' ),
+			'session_token' => $I->grabHttpHeader( 'woocommerce-session' ),
+		];
+	}
+
+	/**
+	 * Helper: Queries the cart and returns product database IDs.
+	 */
+	private function getCartProductIds( FunctionalTester $I, string $auth_token, string $session_token ): array {
+		$response = $I->sendGraphQLRequest(
+			'query { cart { contents { nodes { product { node { databaseId } } } } } }',
+			[],
+			[
+				'Authorization'       => "Bearer {$auth_token}",
+				'woocommerce-session' => "Session {$session_token}",
+			]
+		);
+
+		$nodes = $I->lodashGet( $response, 'data.cart.contents.nodes', [] );
+
+		return array_map(
+			static function ( $item ) {
+				return $item['product']['node']['databaseId'];
+			},
+			$nodes
+		);
+	}
+
+	/**
+	 * Test 'keep_new' — only the current guest session data is kept, old session discarded.
+	 */
+	public function testKeepNewSessionTransfer( FunctionalTester $I ) {
+		$tokens      = $this->setupSessionTransferScenario( $I, 'keep_new' );
+		$product_ids = $this->getCartProductIds( $I, $tokens['auth_token'], $tokens['session_token'] );
+
+		$I->assertContains(
+			$this->product_catalog['jeans'],
+			$product_ids,
+			'Jeans from guest session should be in cart.'
+		);
+		$I->assertNotContains(
+			$this->product_catalog['t-shirt'],
+			$product_ids,
+			'T-shirt from previous session should NOT be in cart with keep_new.'
+		);
+	}
+
+	/**
+	 * Test 'keep_old' — the previously saved user session data is restored.
+	 */
+	public function testKeepOldSessionTransfer( FunctionalTester $I ) {
+		$tokens      = $this->setupSessionTransferScenario( $I, 'keep_old' );
+		$product_ids = $this->getCartProductIds( $I, $tokens['auth_token'], $tokens['session_token'] );
+
+		$I->assertContains(
+			$this->product_catalog['t-shirt'],
+			$product_ids,
+			'T-shirt from previous session should be in cart with keep_old.'
+		);
+		$I->assertNotContains(
+			$this->product_catalog['jeans'],
+			$product_ids,
+			'Jeans from guest session should NOT be in cart with keep_old.'
+		);
+	}
+
+	/**
+	 * Test 'keep_new_fallback_old' (default) — keeps new if non-empty, falls back to old.
+	 */
+	public function testKeepNewFallbackOldSessionTransfer( FunctionalTester $I ) {
+		$tokens      = $this->setupSessionTransferScenario( $I, 'keep_new_fallback_old' );
+		$product_ids = $this->getCartProductIds( $I, $tokens['auth_token'], $tokens['session_token'] );
+
+		// Guest session had items (hoodie), so new data is kept.
+		$I->assertContains(
+			$this->product_catalog['jeans'],
+			$product_ids,
+			'Jeans from guest session should be in cart (new data non-empty).'
+		);
+		$I->assertNotContains(
+			$this->product_catalog['t-shirt'],
+			$product_ids,
+			'T-shirt from previous session should NOT be in cart when new data is non-empty.'
+		);
+	}
+}


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side).
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side).
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------

Adds a new "Session Transfer Behavior" setting to the WooGraphQL settings page (under General) that controls how cart/session data is handled when a user logs in with an existing session from another device.

### Options
- **Keep new, fallback to old (default)** — keeps the current guest session data. If the guest session is empty, falls back to the previously saved user session.
- **Keep new** — always keeps the current guest session data, discarding any previously saved user session.
- **Keep old** — restores the previously saved user session data, discarding the current guest session.

### Implementation
- New setting registered in `Admin\General::get_fields()` as a select dropdown
- Session transfer logic in `QL_Session_Handler::init_session_token()` reads the setting via `woographql_setting('session_transfer_behavior', 'keep_new_fallback_old')` and switches behavior accordingly
- Default behavior (`keep_new_fallback_old`) matches the existing behavior for backwards compatibility

### Test coverage
- **SessionTransferCest** (3 functional/e2e tests):
  - `testKeepNewSessionTransfer` — verifies only guest cart items are kept
  - `testKeepOldSessionTransfer` — verifies previous user cart items are restored
  - `testKeepNewFallbackOldSessionTransfer` — verifies default behavior (new if non-empty, old as fallback)

Does this close any currently open issues?
------------------------------------------

Resolves #909

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

N/A

Any other comments?
-------------------

A future enhancement could add a "Merge" option that combines cart items from both sessions at the WooCommerce cart level (deserializing cart contents, merging items, re-serializing). This was scoped out of this PR since session data is stored serialized and a simple `array_merge` at the session data level would just overwrite the cart key entirely.