### PR TITLE
fix: CI coverage merge with Docker container paths

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -264,6 +264,9 @@ jobs:
           echo "Coverage files structure:"
           find coverage-files/ -name "*.cov" -type f 2>/dev/null || echo "No coverage files found"
           if find coverage-files/ -name "*.cov" -type f | grep -q .; then
+            # Symlink Docker container path to CI checkout so phpcov can read source files.
+            sudo mkdir -p /var/www/html/wp-content/plugins
+            sudo ln -s "$GITHUB_WORKSPACE" /var/www/html/wp-content/plugins/wp-graphql-woocommerce
             phpcov merge --clover=tests/_output/coverage.xml coverage-files
           else
             echo "No serialized coverage files to merge"


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the CI coverage merge step that was producing empty Clover XML reports. The `.cov` files contain Docker container paths (`/var/www/html/wp-content/plugins/...`) but phpcov's Clover writer needs to read actual source files to build the report. Creates a symlink from the Docker path to the CI workspace before merging.

Does this close any currently open issues?
------------------------------------------
N/A (CI infrastructure fix)

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A