### PR TITLE
fix: address WordPress.org plugin review (rename + prefixing + headers)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-=== WPGraphQL for eCommerce ===
+=== GraphQL for eCommerce ===
 Contributors: kidunot89, ranaaterning, jasonbahl, saleebm
 Tags: GraphQL, WooCommerce, WPGraphQL
 Requires at least: 6.3

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: kidunot89, ranaaterning, jasonbahl, saleebm
 Tags: GraphQL, WooCommerce, WPGraphQL
 Requires at least: 6.3
-Tested up to: 6.8
+Tested up to: 7.0
 Requires PHP: 8.1
 Requires WooCommerce: 9.0.0
 Requires WPGraphQL: 2.0.0

--- a/access-functions.php
+++ b/access-functions.php
@@ -177,7 +177,7 @@ if ( ! function_exists( 'wc_graphql_price_range' ) ) {
 
 		$price = sprintf(
 			/* translators: 1: price from 2: price to */
-			_x( '%1$s %2$s %3$s', 'Price range: from-to', 'wp-graphql-woocommerce' ),
+			_x( '%1$s %2$s %3$s', 'Price range: from-to', 'graphql-for-ecommerce' ),
 			is_numeric( $from ) ? wc_graphql_price( $from ) : $from,
 			apply_filters( 'graphql_woocommerce_format_price_range_separator', '-', $from, $to ),
 			is_numeric( $to ) ? wc_graphql_price( $to ) : $to

--- a/composer.json
+++ b/composer.json
@@ -27,31 +27,12 @@
     "require-dev": {
         "axepress/wp-graphql-cs": "^2.0.0-beta",
         "axepress/wp-graphql-stubs": "^1.27.1",
-        "behat/gherkin": "^4.8 <4.12",
         "brainmaestro/composer-git-hooks": "^2.8.5",
-        "codeception/lib-asserts": "*",
-        "codeception/module-asserts": "*",
-        "codeception/module-rest": "*",
-        "codeception/util-universalframework": "*",
-        "fakerphp/faker": "^1.24",
-        "johnpbloch/wordpress": "*",
-        "lucatume/wp-browser": ">3.1 <3.5",
         "php-stubs/woocommerce-stubs": "9.1.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpdoc-parser": "^1.22.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.6",
-        "stripe/stripe-php": "^20.2",
-        "szepeviktor/phpstan-wordpress": "^1.3",
-        "wp-cli/wp-cli-bundle": "*",
-        "wp-graphql/wp-graphql-jwt-authentication": "^0.7.2",
-        "wp-graphql/wp-graphql-testcase": "^3.2",
-        "wpackagist-plugin/elementor": "^4.1",
-        "wpackagist-plugin/hcaptcha-for-forms-and-more": "^5.0",
-        "wpackagist-plugin/woocommerce": "^10.8",
-        "wpackagist-plugin/woocommerce-gateway-stripe": "^10.8",
-        "wpackagist-plugin/wp-graphql": "^2.16",
-        "wpackagist-theme/twentytwentyone": "^2.8"
+        "szepeviktor/phpstan-wordpress": "^1.3"
     },
     "config": {
         "optimize-autoloader": true,
@@ -60,8 +41,7 @@
         "allow-plugins": {
             "johnpbloch/wordpress-core-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true,
-            "composer/installers": true
+            "phpstan/extension-installer": true
         }
     },
     "autoload": {
@@ -157,18 +137,6 @@
             "post-merge": [
                 "composer install"
             ]
-        },
-        "wordpress-install-dir": "local/public",
-        "installer-paths": {
-            "local/public/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
-            "local/public/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
-            "local/public/wp-content/themes/{$name}/": ["type:wordpress-theme"]
-        }
-    },
-    "repositories": {
-        "wpackagist": {
-            "type": "composer",
-            "url": "https://wpackagist.org"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -108,8 +108,6 @@
             "/codeception.dist.yml",
             "/codeception.yml",
             "/codeclimate.yml",
-            "/composer.json",
-            "/composer.lock",
             "/docker-compose.yml",
             "/Dockerfile",
             "/netlify.toml",

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,31 @@
     "require-dev": {
         "axepress/wp-graphql-cs": "^2.0.0-beta",
         "axepress/wp-graphql-stubs": "^1.27.1",
+        "behat/gherkin": "^4.8 <4.12",
         "brainmaestro/composer-git-hooks": "^2.8.5",
+        "codeception/lib-asserts": "*",
+        "codeception/module-asserts": "*",
+        "codeception/module-rest": "*",
+        "codeception/util-universalframework": "*",
+        "fakerphp/faker": "^1.24",
+        "johnpbloch/wordpress": "*",
+        "lucatume/wp-browser": ">3.1 <3.5",
         "php-stubs/woocommerce-stubs": "9.1.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpdoc-parser": "^1.22.0",
         "phpstan/phpstan": "^1.10",
-        "szepeviktor/phpstan-wordpress": "^1.3"
+        "phpunit/phpunit": "^9.6",
+        "stripe/stripe-php": "^20.2",
+        "szepeviktor/phpstan-wordpress": "^1.3",
+        "wp-cli/wp-cli-bundle": "*",
+        "wp-graphql/wp-graphql-jwt-authentication": "^0.7.2",
+        "wp-graphql/wp-graphql-testcase": "^3.2",
+        "wpackagist-plugin/elementor": "^4.1",
+        "wpackagist-plugin/hcaptcha-for-forms-and-more": "^5.0",
+        "wpackagist-plugin/woocommerce": "^10.8",
+        "wpackagist-plugin/woocommerce-gateway-stripe": "^10.8",
+        "wpackagist-plugin/wp-graphql": "^2.16",
+        "wpackagist-theme/twentytwentyone": "^2.8"
     },
     "config": {
         "optimize-autoloader": true,
@@ -41,7 +60,8 @@
         "allow-plugins": {
             "johnpbloch/wordpress-core-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "composer/installers": true
         }
     },
     "autoload": {
@@ -137,6 +157,18 @@
             "post-merge": [
                 "composer install"
             ]
+        },
+        "wordpress-install-dir": "local/public",
+        "installer-paths": {
+            "local/public/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+            "local/public/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+            "local/public/wp-content/themes/{$name}/": ["type:wordpress-theme"]
+        }
+    },
+    "repositories": {
+        "wpackagist": {
+            "type": "composer",
+            "url": "https://wpackagist.org"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52c0e5c7327026f3726997264931cab3",
+    "content-hash": "368f55c5f0ddcebd7fbe9b5e2269097e",
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v7.0.4",
+            "version": "v7.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "e41f1bd7dbe3c5455c3f72d4338cfeb083b71931"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/e41f1bd7dbe3c5455c3f72d4338cfeb083b71931",
-                "reference": "e41f1bd7dbe3c5455c3f72d4338cfeb083b71931",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
                 "shasum": ""
             },
             "require": {
@@ -26,6 +26,7 @@
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
                 "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -34,7 +35,8 @@
             },
             "suggest": {
                 "ext-sodium": "Support EdDSA (Ed25519) signatures",
-                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
             },
             "type": "library",
             "autoload": {
@@ -59,16 +61,16 @@
                 }
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
+            "homepage": "https://github.com/googleapis/php-jwt",
             "keywords": [
                 "jwt",
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v7.0.4"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
             },
-            "time": "2026-03-27T21:17:19+00:00"
+            "time": "2026-06-11T17:54:14+00:00"
         }
     ],
     "packages-dev": [
@@ -309,16 +311,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -401,7 +403,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "php-stubs/woocommerce-stubs",
@@ -449,16 +451,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.1",
+            "version": "v6.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
                 "shasum": ""
             },
             "conflict": {
@@ -468,7 +470,7 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
+                "php-stubs/generator": "^0.8.6",
                 "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
@@ -495,9 +497,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
             },
-            "time": "2026-02-03T19:29:21+00:00"
+            "time": "2026-05-01T20:36:01+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1389,16 +1391,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -1411,7 +1413,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1436,7 +1438,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1448,24 +1450,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -1515,7 +1521,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1535,20 +1541,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -1597,7 +1603,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -1617,20 +1623,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -1682,7 +1688,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -1702,20 +1708,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -1767,7 +1773,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -1787,11 +1793,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -1847,7 +1853,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1871,16 +1877,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -1931,7 +1937,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1951,20 +1957,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -1982,7 +1988,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -2018,7 +2024,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -2038,20 +2044,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.34",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432"
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/2adaf4106f2ef4c67271971bde6d3fe0a6936432",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432",
+                "url": "https://api.github.com/repos/symfony/string/zipball/62e3c927de664edadb5bef260987eb047a17a113",
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113",
                 "shasum": ""
             },
             "require": {
@@ -2107,7 +2113,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.34"
+                "source": "https://github.com/symfony/string/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -2127,7 +2133,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-08T20:44:54+00:00"
+            "time": "2026-05-12T11:44:19+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",

--- a/includes/admin/class-general.php
+++ b/includes/admin/class-general.php
@@ -70,87 +70,87 @@ class General extends Section {
 		return [
 			[
 				'name'     => 'disable_ql_session_handler',
-				'label'    => __( 'Disable QL Session Handler', 'wp-graphql-woocommerce' ),
-				'desc'     => __( 'The QL Session Handler takes over management of WooCommerce Session Management on WPGraphQL request replacing the usage of HTTP Cookies with JSON Web Tokens.', 'wp-graphql-woocommerce' )
-					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'    => __( 'Disable QL Session Handler', 'graphql-for-ecommerce' ),
+				'desc'     => __( 'The QL Session Handler takes over management of WooCommerce Session Management on WPGraphQL request replacing the usage of HTTP Cookies with JSON Web Tokens.', 'graphql-for-ecommerce' )
+					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'     => 'checkbox',
 				'value'    => defined( 'NO_QL_SESSION_HANDLER' ) ? 'on' : woographql_setting( 'disable_ql_session_handler', 'off' ),
 				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
 			],
 			[
 				'name'     => 'enable_ql_session_handler_on_ajax',
-				'label'    => __( 'Enable QL Session Handler on WC AJAX requests.', 'wp-graphql-woocommerce' ),
-				'desc'     => __( 'Enabling this will enable JSON Web Tokens usage on WC AJAX requests.', 'wp-graphql-woocommerce' )
-					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'    => __( 'Enable QL Session Handler on WC AJAX requests.', 'graphql-for-ecommerce' ),
+				'desc'     => __( 'Enabling this will enable JSON Web Tokens usage on WC AJAX requests.', 'graphql-for-ecommerce' )
+					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'     => 'checkbox',
 				'value'    => defined( 'NO_QL_SESSION_HANDLER' ) ? 'off' : woographql_setting( 'enable_ql_session_handler_on_ajax', 'off' ),
 				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
 			],
 			[
 				'name'     => 'enable_ql_session_handler_on_rest',
-				'label'    => __( 'Enable QL Session Handler on WP REST requests.', 'wp-graphql-woocommerce' ),
-				'desc'     => __( 'Enabling this will enable JSON Web Tokens usage on WP REST requests.', 'wp-graphql-woocommerce' )
-					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'    => __( 'Enable QL Session Handler on WP REST requests.', 'graphql-for-ecommerce' ),
+				'desc'     => __( 'Enabling this will enable JSON Web Tokens usage on WP REST requests.', 'graphql-for-ecommerce' )
+					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'     => 'checkbox',
 				'value'    => defined( 'NO_QL_SESSION_HANDLER' ) ? 'off' : woographql_setting( 'enable_ql_session_handler_on_rest', 'off' ),
 				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
 			],
 			[
 				'name'     => 'set_session_token_type',
-				'label'    => __( 'Session Token Type', 'wp-graphql-woocommerce' ),
-				'desc'     => __( 'Choose which session token type(s) to generate. "Legacy" uses GraphQL session tokens only. "Store API" uses WooCommerce Blocks Cart-Token only (requires WooCommerce 5.5.0+). "Both" generates both token types for maximum compatibility with headless implementations using WooCommerce Blocks.', 'wp-graphql-woocommerce' )
-					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'    => __( 'Session Token Type', 'graphql-for-ecommerce' ),
+				'desc'     => __( 'Choose which session token type(s) to generate. "Legacy" uses GraphQL session tokens only. "Store API" uses WooCommerce Blocks Cart-Token only (requires WooCommerce 5.5.0+). "Both" generates both token types for maximum compatibility with headless implementations using WooCommerce Blocks.', 'graphql-for-ecommerce' )
+					. ( defined( 'NO_QL_SESSION_HANDLER' ) ? __( ' This setting is disabled. The "NO_QL_SESSION_HANDLER" flag has been triggered with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'     => 'select',
 				'options'  => [
-					'legacy'    => __( 'Legacy (GraphQL Session Token only)', 'wp-graphql-woocommerce' ),
-					'store-api' => __( 'Store API (Cart-Token only)', 'wp-graphql-woocommerce' ),
-					'both'      => __( 'Both (GraphQL + Store API)', 'wp-graphql-woocommerce' ),
+					'legacy'    => __( 'Legacy (GraphQL Session Token only)', 'graphql-for-ecommerce' ),
+					'store-api' => __( 'Store API (Cart-Token only)', 'graphql-for-ecommerce' ),
+					'both'      => __( 'Both (GraphQL + Store API)', 'graphql-for-ecommerce' ),
 				],
 				'default'  => 'legacy',
 				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
 			],
 			[
 				'name'     => 'session_transfer_behavior',
-				'label'    => __( 'Session Transfer Behavior', 'wp-graphql-woocommerce' ),
-				'desc'     => __( 'Controls how cart data is handled when a user logs in with an existing session from another device. "Keep new" keeps the current session data (default). "Keep old" restores the previously saved session data. "Merge" combines cart items from both sessions.', 'wp-graphql-woocommerce' ),
+				'label'    => __( 'Session Transfer Behavior', 'graphql-for-ecommerce' ),
+				'desc'     => __( 'Controls how cart data is handled when a user logs in with an existing session from another device. "Keep new" keeps the current session data (default). "Keep old" restores the previously saved session data. "Merge" combines cart items from both sessions.', 'graphql-for-ecommerce' ),
 				'type'     => 'select',
 				'options'  => [
-					'keep_new_fallback_old' => __( 'Keep new, fallback to old (default)', 'wp-graphql-woocommerce' ),
-					'keep_new'              => __( 'Keep new (always use current session)', 'wp-graphql-woocommerce' ),
-					'keep_old'              => __( 'Keep old (restore previously saved session)', 'wp-graphql-woocommerce' ),
+					'keep_new_fallback_old' => __( 'Keep new, fallback to old (default)', 'graphql-for-ecommerce' ),
+					'keep_new'              => __( 'Keep new (always use current session)', 'graphql-for-ecommerce' ),
+					'keep_old'              => __( 'Keep old (restore previously saved session)', 'graphql-for-ecommerce' ),
 				],
 				'default'  => 'keep_new_fallback_old',
 				'disabled' => defined( 'NO_QL_SESSION_HANDLER' ),
 			],
 			[
 				'name'     => 'enable_transliteration',
-				'label'    => __( 'Transliterate non-latin characters', 'wp-graphql-woocommerce' ),
-				'desc'     => __( 'Converts non-latin characters (Cyrillic, Chinese, Arabic, etc.) to their latin equivalents in GraphQL type and enum names. Enable this if your WooCommerce tax classes, product attributes, or taxonomies use non-latin names. Requires the PHP intl extension.', 'wp-graphql-woocommerce' )
-					. ( ! function_exists( 'transliterator_transliterate' ) ? __( ' <strong>Warning:</strong> The PHP intl extension is not available. This setting will have no effect.', 'wp-graphql-woocommerce' ) : '' ),
+				'label'    => __( 'Transliterate non-latin characters', 'graphql-for-ecommerce' ),
+				'desc'     => __( 'Converts non-latin characters (Cyrillic, Chinese, Arabic, etc.) to their latin equivalents in GraphQL type and enum names. Enable this if your WooCommerce tax classes, product attributes, or taxonomies use non-latin names. Requires the PHP intl extension.', 'graphql-for-ecommerce' )
+					. ( ! function_exists( 'transliterator_transliterate' ) ? __( ' <strong>Warning:</strong> The PHP intl extension is not available. This setting will have no effect.', 'graphql-for-ecommerce' ) : '' ),
 				'type'     => 'checkbox',
 				'default'  => 'off',
 				'disabled' => ! function_exists( 'transliterator_transliterate' ),
 			],
 			[
 				'name'    => 'enable_unsupported_product_type',
-				'label'   => __( 'Enable Unsupported types', 'wp-graphql-woocommerce' ),
-				'desc'    => __( 'Substitute unsupported product types with SimpleProduct', 'wp-graphql-woocommerce' ),
+				'label'   => __( 'Enable Unsupported types', 'graphql-for-ecommerce' ),
+				'desc'    => __( 'Substitute unsupported product types with SimpleProduct', 'graphql-for-ecommerce' ),
 				'type'    => 'checkbox',
 				'default' => 'off',
 			],
 			[
 				'name'              => 'enable_authorizing_url_fields',
-				'label'             => __( 'Enable User Session transferring URLs', 'wp-graphql-woocommerce' ),
-				'desc'              => __( 'URL fields to add to the <strong>Customer</strong> type.', 'wp-graphql-woocommerce' )
-					. ( $enable_auth_urls_hardcoded ? __( ' This setting is disabled. The "WPGRAPHQL_WOOCOMMERCE_ENABLE_AUTH_URLS" flag has been triggered with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'             => __( 'Enable User Session transferring URLs', 'graphql-for-ecommerce' ),
+				'desc'              => __( 'URL fields to add to the <strong>Customer</strong> type.', 'graphql-for-ecommerce' )
+					. ( $enable_auth_urls_hardcoded ? __( ' This setting is disabled. The "WPGRAPHQL_WOOCOMMERCE_ENABLE_AUTH_URLS" flag has been triggered with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'              => 'multicheck',
 				'options'           => apply_filters(
 					'woographql_settings_enable_authorizing_url_options',
 					[
-						'cart_url'               => __( 'Cart URL. Field name: <strong>cartUrl</strong>', 'wp-graphql-woocommerce' ),
-						'checkout_url'           => __( 'Checkout URL. Field name: <strong>checkoutUrl</strong>', 'wp-graphql-woocommerce' ),
-						'account_url'            => __( 'Account URL. Field name: <strong>accountUrl</strong>', 'wp-graphql-woocommerce' ),
-						'add_payment_method_url' => __( 'Add Payment Method URL. Field name: <strong>addPaymentMethodUrl</strong>', 'wp-graphql-woocommerce' ),
+						'cart_url'               => __( 'Cart URL. Field name: <strong>cartUrl</strong>', 'graphql-for-ecommerce' ),
+						'checkout_url'           => __( 'Checkout URL. Field name: <strong>checkoutUrl</strong>', 'graphql-for-ecommerce' ),
+						'account_url'            => __( 'Account URL. Field name: <strong>accountUrl</strong>', 'graphql-for-ecommerce' ),
+						'add_payment_method_url' => __( 'Add Payment Method URL. Field name: <strong>addPaymentMethodUrl</strong>', 'graphql-for-ecommerce' ),
 					]
 				),
 				'value'             => $enable_auth_urls_hardcoded ? $all_urls_checked : woographql_setting( 'enable_authorizing_url_fields', [] ),
@@ -165,10 +165,10 @@ class General extends Section {
 			],
 			[
 				'name'     => 'authorizing_url_endpoint',
-				'label'    => __( 'Endpoint for Authorizing URLs', 'wp-graphql-woocommerce' ),
+				'label'    => __( 'Endpoint for Authorizing URLs', 'graphql-for-ecommerce' ),
 				'desc'     => sprintf(
 					/* translators: %1$s: Site URL, %2$s: WooGraphQL Auth Endpoint */
-					__( 'The endpoint (path) for transferring user sessions on the site. <a target="_blank" href="%1$s/%2$s">%1$s/%2$s</a>.', 'wp-graphql-woocommerce' ),
+					__( 'The endpoint (path) for transferring user sessions on the site. <a target="_blank" href="%1$s/%2$s">%1$s/%2$s</a>.', 'graphql-for-ecommerce' ),
 					site_url(),
 					woographql_setting( 'authorizing_url_endpoint', 'transfer-session' )
 				),
@@ -178,9 +178,9 @@ class General extends Section {
 			],
 			[
 				'name'              => 'cart_url_nonce_param',
-				'label'             => __( 'Cart URL nonce name', 'wp-graphql-woocommerce' ),
-				'desc'              => __( 'Query parameter name of the nonce included in the "cartUrl" field', 'wp-graphql-woocommerce' )
-					. ( $cart_url_hardcoded ? __( ' This setting is disabled. The "CART_URL_NONCE_PARAM" flag has been set with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'             => __( 'Cart URL nonce name', 'graphql-for-ecommerce' ),
+				'desc'              => __( 'Query parameter name of the nonce included in the "cartUrl" field', 'graphql-for-ecommerce' )
+					. ( $cart_url_hardcoded ? __( ' This setting is disabled. The "CART_URL_NONCE_PARAM" flag has been set with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'              => 'text',
 				'value'             => $cart_url_hardcoded ? constant( 'CART_URL_NONCE_PARAM' ) : woographql_setting( 'cart_url_nonce_param', '_wc_cart' ),
 				'disabled'          => defined( 'CART_URL_NONCE_PARAM' ) || ! in_array( 'cart_url', $enabled_authorizing_url_fields, true ),
@@ -190,7 +190,7 @@ class General extends Section {
 						add_settings_error(
 							'cart_url_nonce_param',
 							'unique',
-							__( 'The <strong>Cart URL nonce name</strong> field must be unique', 'wp-graphql-woocommerce' ),
+							__( 'The <strong>Cart URL nonce name</strong> field must be unique', 'graphql-for-ecommerce' ),
 							'error'
 						);
 
@@ -202,9 +202,9 @@ class General extends Section {
 			],
 			[
 				'name'              => 'checkout_url_nonce_param',
-				'label'             => __( 'Checkout URL nonce name', 'wp-graphql-woocommerce' ),
-				'desc'              => __( 'Query parameter name of the nonce included in the "checkoutUrl" field', 'wp-graphql-woocommerce' )
-					. ( $checkout_url_hardcoded ? __( ' This setting is disabled. The "CHECKOUT_URL_NONCE_PARAM" flag has been set with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'             => __( 'Checkout URL nonce name', 'graphql-for-ecommerce' ),
+				'desc'              => __( 'Query parameter name of the nonce included in the "checkoutUrl" field', 'graphql-for-ecommerce' )
+					. ( $checkout_url_hardcoded ? __( ' This setting is disabled. The "CHECKOUT_URL_NONCE_PARAM" flag has been set with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'              => 'text',
 				'value'             => $checkout_url_hardcoded ? constant( 'CHECKOUT_URL_NONCE_PARAM' ) : woographql_setting( 'checkout_url_nonce_param', '_wc_checkout' ),
 				'disabled'          => defined( 'CHECKOUT_URL_NONCE_PARAM' ) || ! in_array( 'checkout_url', $enabled_authorizing_url_fields, true ),
@@ -214,7 +214,7 @@ class General extends Section {
 						add_settings_error(
 							'checkout_url_nonce_param',
 							'unique',
-							__( 'The <strong>Checkout URL nonce name</strong> field must be unique', 'wp-graphql-woocommerce' ),
+							__( 'The <strong>Checkout URL nonce name</strong> field must be unique', 'graphql-for-ecommerce' ),
 							'error'
 						);
 
@@ -226,9 +226,9 @@ class General extends Section {
 			],
 			[
 				'name'              => 'account_url_nonce_param',
-				'label'             => __( 'Account URL nonce name', 'wp-graphql-woocommerce' ),
-				'desc'              => __( 'Query parameter name of the nonce included in the "accountUrl" field', 'wp-graphql-woocommerce' )
-					. ( $account_url_hardcoded ? __( ' This setting is disabled. The "ACCOUNT_URL_NONCE_PARAM" flag has been set with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'             => __( 'Account URL nonce name', 'graphql-for-ecommerce' ),
+				'desc'              => __( 'Query parameter name of the nonce included in the "accountUrl" field', 'graphql-for-ecommerce' )
+					. ( $account_url_hardcoded ? __( ' This setting is disabled. The "ACCOUNT_URL_NONCE_PARAM" flag has been set with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'              => 'text',
 				'value'             => $account_url_hardcoded ? constant( 'ACCOUNT_URL_NONCE_PARAM' ) : woographql_setting( 'account_url_nonce_param', '_wc_account' ),
 				'disabled'          => defined( 'ACCOUNT_URL_NONCE_PARAM' ) || ! in_array( 'account_url', $enabled_authorizing_url_fields, true ),
@@ -238,7 +238,7 @@ class General extends Section {
 						add_settings_error(
 							'account_url_nonce_param',
 							'unique',
-							__( 'The <strong>Account URL nonce name</strong> field must be unique', 'wp-graphql-woocommerce' ),
+							__( 'The <strong>Account URL nonce name</strong> field must be unique', 'graphql-for-ecommerce' ),
 							'error'
 						);
 
@@ -250,9 +250,9 @@ class General extends Section {
 			],
 			[
 				'name'              => 'add_payment_method_url_nonce_param',
-				'label'             => __( 'Add Payment Method URL nonce name', 'wp-graphql-woocommerce' ),
-				'desc'              => __( 'Query parameter name of the nonce included in the "addPaymentMethodUrl" field', 'wp-graphql-woocommerce' )
-					. ( $add_payment_method_url_hardcoded ? __( ' This setting is disabled. The "ADD_PAYMENT_METHOD_URL_NONCE_PARAM" flag has been set with code', 'wp-graphql-woocommerce' ) : '' ),
+				'label'             => __( 'Add Payment Method URL nonce name', 'graphql-for-ecommerce' ),
+				'desc'              => __( 'Query parameter name of the nonce included in the "addPaymentMethodUrl" field', 'graphql-for-ecommerce' )
+					. ( $add_payment_method_url_hardcoded ? __( ' This setting is disabled. The "ADD_PAYMENT_METHOD_URL_NONCE_PARAM" flag has been set with code', 'graphql-for-ecommerce' ) : '' ),
 				'type'              => 'text',
 				'value'             => $add_payment_method_url_hardcoded ? constant( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) : woographql_setting( 'add_payment_method_url_nonce_param', '_wc_payment' ),
 				'disabled'          => defined( 'ADD_PAYMENT_METHOD_URL_NONCE_PARAM' ) || ! in_array( 'add_payment_method_url', $enabled_authorizing_url_fields, true ),
@@ -262,7 +262,7 @@ class General extends Section {
 						add_settings_error(
 							'add_payment_method_url_nonce_param',
 							'unique',
-							__( 'The <strong>Add Payment Method URL nonce name</strong> field must be unique', 'wp-graphql-woocommerce' ),
+							__( 'The <strong>Add Payment Method URL nonce name</strong> field must be unique', 'graphql-for-ecommerce' ),
 							'error'
 						);
 
@@ -274,15 +274,15 @@ class General extends Section {
 			],
 			[
 				'name'    => 'enable_pre_auth_download_urls',
-				'label'   => __( 'Enable pre-authenticated download URLs', 'wp-graphql-woocommerce' ),
-				'desc'    => __( 'Adds a "preAuthDownloadUrl" field to downloadable items that generates a tokenized URL allowing downloads without cookie-based authentication. Useful for headless frontends where users cannot be redirected through the session transfer endpoint.', 'wp-graphql-woocommerce' ),
+				'label'   => __( 'Enable pre-authenticated download URLs', 'graphql-for-ecommerce' ),
+				'desc'    => __( 'Adds a "preAuthDownloadUrl" field to downloadable items that generates a tokenized URL allowing downloads without cookie-based authentication. Useful for headless frontends where users cannot be redirected through the session transfer endpoint.', 'graphql-for-ecommerce' ),
 				'type'    => 'checkbox',
 				'default' => 'off',
 			],
 			[
 				'name'    => 'download_url_nonce_param',
-				'label'   => __( 'Download URL nonce name', 'wp-graphql-woocommerce' ),
-				'desc'    => __( 'Query parameter name of the nonce included in the "downloadUrl" field on downloadable items.', 'wp-graphql-woocommerce' ),
+				'label'   => __( 'Download URL nonce name', 'graphql-for-ecommerce' ),
+				'desc'    => __( 'Query parameter name of the nonce included in the "downloadUrl" field on downloadable items.', 'graphql-for-ecommerce' ),
 				'type'    => 'text',
 				'default' => '_wc_download',
 			],

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -31,7 +31,7 @@ class Admin {
 	public function register_settings( Settings $manager ) {
 		$manager->settings_api->register_section(
 			'woographql_settings',
-			[ 'title' => __( 'WooCommerce', 'wp-graphql-woocommerce' ) ]
+			[ 'title' => __( 'WooCommerce', 'graphql-for-ecommerce' ) ]
 		);
 
 		$manager->settings_api->register_fields(

--- a/includes/class-compatibility.php
+++ b/includes/class-compatibility.php
@@ -220,13 +220,13 @@ class Compatibility {
 				'authToken'    => [
 					'type'        => $type_registry->get_type( 'String' ),
 					'description' => static function () {
-						return __( 'JWT Token that can be used in future requests for Authentication', 'wp-graphql-woocommerce' );
+						return __( 'JWT Token that can be used in future requests for Authentication', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $payload ) {
 						$user = get_user_by( 'ID', $payload['id'] );
 
 						if ( ! $user ) {
-							throw new UserError( __( 'User not found.', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'User not found.', 'graphql-for-ecommerce' ) );
 						}
 
 						return self::get_auth_token( $user );
@@ -235,13 +235,13 @@ class Compatibility {
 				'refreshToken' => [
 					'type'        => $type_registry->get_type( 'String' ),
 					'description' => static function () {
-						return __( 'A JWT token that can be used in future requests to get a refreshed jwtAuthToken. If the refresh token used in a request is revoked or otherwise invalid, a valid Auth token will NOT be issued in the response headers.', 'wp-graphql-woocommerce' );
+						return __( 'A JWT token that can be used in future requests to get a refreshed jwtAuthToken. If the refresh token used in a request is revoked or otherwise invalid, a valid Auth token will NOT be issued in the response headers.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $payload ) {
 						$user = get_user_by( 'ID', $payload['id'] );
 
 						if ( ! $user ) {
-							throw new UserError( __( 'User not found.', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'User not found.', 'graphql-for-ecommerce' ) );
 						}
 
 						return self::get_refresh_token( $user );
@@ -263,7 +263,7 @@ class Compatibility {
 			[
 				'type'        => 'Customer',
 				'description' => static function () {
-					return __( 'Customer object of authenticated user.', 'wp-graphql-woocommerce' );
+					return __( 'Customer object of authenticated user.', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					$id = $payload['id'];
@@ -281,7 +281,7 @@ class Compatibility {
 					[
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' );
+							return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function () {
 							/** @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session */
@@ -299,7 +299,7 @@ class Compatibility {
 					[
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' );
+							return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function () {
 							/** @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session */

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -357,7 +357,7 @@ class Post_Types {
 			throw new UserError(
 				sprintf(
 					/* translators: %s: Post type slug */
-					__( 'The "%s" post type is not a valid product type.', 'wp-graphql-woocommerce' ),
+					__( 'The "%s" post type is not a valid product type.', 'graphql-for-ecommerce' ),
 					$value->post_type
 				)
 			);
@@ -378,7 +378,7 @@ class Post_Types {
 		throw new UserError(
 			sprintf(
 			/* translators: %s: Product type */
-				__( 'The "%s" product type is not supported by the core WPGraphQL for WooCommerce (WooGraphQL) schema.', 'wp-graphql-woocommerce' ),
+				__( 'The "%s" product type is not supported by the core GraphQL for eCommerce schema.', 'graphql-for-ecommerce' ),
 				$product_model->type
 			)
 		);
@@ -405,7 +405,7 @@ class Post_Types {
 		throw new UserError(
 			sprintf(
 			/* translators: %s: Product type */
-				__( 'The "%s" product variation type is not supported by the core WPGraphQL for WooCommerce (WooGraphQL) schema.', 'wp-graphql-woocommerce' ),
+				__( 'The "%s" product variation type is not supported by the core GraphQL for eCommerce schema.', 'graphql-for-ecommerce' ),
 				$value->type
 			)
 		);

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -81,7 +81,7 @@ class WooCommerce {
 			return $label;
 		}
 
-		return apply_filters( 'graphql_woocommerce_order_attribution_origin_label', __( 'GraphQL', 'wp-graphql-woocommerce' ), $source, $formatted_source );
+		return apply_filters( 'graphql_woocommerce_order_attribution_origin_label', __( 'GraphQL', 'graphql-for-ecommerce' ), $source, $formatted_source );
 	}
 
 	/**

--- a/includes/class-wp-graphql-woocommerce.php
+++ b/includes/class-wp-graphql-woocommerce.php
@@ -138,7 +138,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 		 */
 		public function __clone() {
 			// Cloning instances of the class is forbidden.
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'WP_GraphQL_WooCommerce class should not be cloned.', 'wp-graphql-woocommerce' ), '0.0.1' );
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'WP_GraphQL_WooCommerce class should not be cloned.', 'graphql-for-ecommerce' ), '0.0.1' );
 		}
 
 		/**
@@ -148,7 +148,7 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 		 */
 		public function __wakeup() {
 			// De-serializing instances of the class is forbidden.
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WP_GraphQL_WooCommerce class is not allowed', 'wp-graphql-woocommerce' ), '0.0.1' );
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WP_GraphQL_WooCommerce class is not allowed', 'graphql-for-ecommerce' ), '0.0.1' );
 		}
 
 		/**
@@ -457,8 +457,8 @@ if ( ! class_exists( '\WPGraphQL\WooCommerce\WP_GraphQL_WooCommerce' ) ) :
 								'<p>%s</p>' .
 								'</div>',
 								esc_html__(
-									'WPGraphQL for WooCommerce appears to have been installed without it\'s dependencies. It will not work properly until dependencies are installed. This likely means you have cloned WPGraphQL from Github and need to run the command `composer install`.',
-									'wp-graphql-woocommerce'
+									'GraphQL for eCommerce appears to have been installed without its dependencies. It will not work properly until dependencies are installed. This likely means you have cloned the plugin from Github and need to run the command `composer install`.',
+									'graphql-for-ecommerce'
 								)
 							);
 						}

--- a/includes/connection/class-comments.php
+++ b/includes/connection/class-comments.php
@@ -33,7 +33,7 @@ class Comments extends Comments_Core {
 						'averageRating' => [
 							'type'        => 'Float',
 							'description' => static function () {
-								return __( 'Average review rating for this product.', 'wp-graphql-woocommerce' );
+								return __( 'Average review rating for this product.', 'graphql-for-ecommerce' );
 							},
 							'resolve'     => static function ( $source ) {
 								if ( empty( $source['edges'] ) ) {
@@ -48,7 +48,7 @@ class Comments extends Comments_Core {
 						'rating' => [
 							'type'        => 'Float',
 							'description' => static function () {
-								return __( 'Review rating', 'wp-graphql-woocommerce' );
+								return __( 'Review rating', 'graphql-for-ecommerce' );
 							},
 							'resolve'     => static function ( $source ) {
 								$review = $source['node'];
@@ -81,7 +81,7 @@ class Comments extends Comments_Core {
 						'isCustomerNote' => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Is this a customer note?', 'wp-graphql-woocommerce' );
+								return __( 'Is this a customer note?', 'graphql-for-ecommerce' );
 							},
 							'resolve'     => static function ( $source ) {
 								$note = $source['node'];

--- a/includes/connection/class-coupons.php
+++ b/includes/connection/class-coupons.php
@@ -88,7 +88,7 @@ class Coupons {
 				'code' => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Limit result set to resources with a specific code.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to resources with a specific code.', 'graphql-for-ecommerce' );
 					},
 				],
 			]

--- a/includes/connection/class-customers.php
+++ b/includes/connection/class-customers.php
@@ -96,37 +96,37 @@ class Customers {
 			'search'  => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit results to those matching a string.', 'wp-graphql-woocommerce' );
+					return __( 'Limit results to those matching a string.', 'graphql-for-ecommerce' );
 				},
 			],
 			'exclude' => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Ensure result set excludes specific IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Ensure result set excludes specific IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'include' => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Limit result set to specific ids.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to specific ids.', 'graphql-for-ecommerce' );
 				},
 			],
 			'email'   => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit result set to resources with a specific email.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to resources with a specific email.', 'graphql-for-ecommerce' );
 				},
 			],
 			'orderby' => [
 				'type'        => 'CustomerConnectionOrderbyEnum',
 				'description' => static function () {
-					return __( 'Order results by a specific field.', 'wp-graphql-woocommerce' );
+					return __( 'Order results by a specific field.', 'graphql-for-ecommerce' );
 				},
 			],
 			'order'   => [
 				'type'        => 'OrderEnum',
 				'description' => static function () {
-					return __( 'Order of results.', 'wp-graphql-woocommerce' );
+					return __( 'Order of results.', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/connection/class-orders.php
+++ b/includes/connection/class-orders.php
@@ -162,37 +162,37 @@ class Orders {
 						'statuses'     => [
 							'type'        => [ 'list_of' => 'OrderStatusEnum' ],
 							'description' => static function () {
-								return __( 'Limit result set to orders assigned a specific status.', 'wp-graphql-woocommerce' );
+								return __( 'Limit result set to orders assigned a specific status.', 'graphql-for-ecommerce' );
 							},
 						],
 						'customerId'   => [
 							'type'        => 'Int',
 							'description' => static function () {
-								return __( 'Limit result set to orders assigned a specific customer.', 'wp-graphql-woocommerce' );
+								return __( 'Limit result set to orders assigned a specific customer.', 'graphql-for-ecommerce' );
 							},
 						],
 						'customersIn'  => [
 							'type'        => [ 'list_of' => 'Int' ],
 							'description' => static function () {
-								return __( 'Limit result set to orders assigned a specific group of customers.', 'wp-graphql-woocommerce' );
+								return __( 'Limit result set to orders assigned a specific group of customers.', 'graphql-for-ecommerce' );
 							},
 						],
 						'productId'    => [
 							'type'        => 'Int',
 							'description' => static function () {
-								return __( 'Limit result set to orders assigned a specific product.', 'wp-graphql-woocommerce' );
+								return __( 'Limit result set to orders assigned a specific product.', 'graphql-for-ecommerce' );
 							},
 						],
 						'orderby'      => [
 							'type'        => [ 'list_of' => 'OrdersOrderbyInput' ],
 							'description' => static function () {
-								return __( 'What paramater to use to order the objects by.', 'wp-graphql-woocommerce' );
+								return __( 'What paramater to use to order the objects by.', 'graphql-for-ecommerce' );
 							},
 						],
 						'billingEmail' => [
 							'type'        => 'String',
 							'description' => static function () {
-								return __( 'Limit result set to orders assigned a specific billing email.', 'wp-graphql-woocommerce' );
+								return __( 'Limit result set to orders assigned a specific billing email.', 'graphql-for-ecommerce' );
 							},
 						],
 					]
@@ -206,31 +206,31 @@ class Orders {
 						'statuses'  => [
 							'type'        => [ 'list_of' => 'OrderStatusEnum' ],
 							'description' => static function () {
-								return __( 'Limit result set to orders assigned a specific status.', 'wp-graphql-woocommerce' );
+								return __( 'Limit result set to orders assigned a specific status.', 'graphql-for-ecommerce' );
 							},
 						],
 						'productId' => [
 							'type'        => 'Int',
 							'description' => static function () {
-								return __( 'Limit result set to orders assigned a specific product.', 'wp-graphql-woocommerce' );
+								return __( 'Limit result set to orders assigned a specific product.', 'graphql-for-ecommerce' );
 							},
 						],
 						'orderby'   => [
 							'type'        => [ 'list_of' => 'OrdersOrderbyInput' ],
 							'description' => static function () {
-								return __( 'What paramater to use to order the objects by.', 'wp-graphql-woocommerce' );
+								return __( 'What paramater to use to order the objects by.', 'graphql-for-ecommerce' );
 							},
 						],
 						'search'    => [
 							'type'        => 'String',
 							'description' => static function () {
-								return __( 'Limit results to those matching a string.', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to those matching a string.', 'graphql-for-ecommerce' );
 							},
 						],
 						'dateQuery' => [
 							'type'        => 'DateQueryInput',
 							'description' => static function () {
-								return __( 'Filter the connection based on dates.', 'wp-graphql-woocommerce' );
+								return __( 'Filter the connection based on dates.', 'graphql-for-ecommerce' );
 							},
 						],
 					]
@@ -250,13 +250,13 @@ class Orders {
 				'statuses' => [
 					'type'        => [ 'list_of' => 'String' ],
 					'description' => static function () {
-						return __( 'Limit result set to refunds assigned a specific status.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to refunds assigned a specific status.', 'graphql-for-ecommerce' );
 					},
 				],
 				'orderIn'  => [
 					'type'        => [ 'list_of' => 'Int' ],
 					'description' => static function () {
-						return __( 'Limit result set to refunds from a specific group of order IDs.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to refunds from a specific group of order IDs.', 'graphql-for-ecommerce' );
 					},
 				],
 			]

--- a/includes/connection/class-payment-gateways.php
+++ b/includes/connection/class-payment-gateways.php
@@ -60,7 +60,7 @@ class Payment_Gateways {
 			'all' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Include disabled payment gateways?', 'wp-graphql-woocommerce' );
+					return __( 'Include disabled payment gateways?', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/connection/class-product-attributes.php
+++ b/includes/connection/class-product-attributes.php
@@ -59,11 +59,11 @@ class Product_Attributes {
 	 */
 	public static function get_connection_config( $args = [] ): array {
 		if ( ! isset( $args['fromType'] ) ) {
-			throw new Error( __( 'The "fromType" is required for the ProductAttributes connection.', 'wp-graphql-woocommerce' ) );
+			throw new Error( __( 'The "fromType" is required for the ProductAttributes connection.', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( ! isset( $args['toType'] ) ) {
-			throw new Error( __( 'The "toType" is required for the ProductAttributes connection.', 'wp-graphql-woocommerce' ) );
+			throw new Error( __( 'The "toType" is required for the ProductAttributes connection.', 'graphql-for-ecommerce' ) );
 		}
 
 		return array_merge(

--- a/includes/connection/class-products.php
+++ b/includes/connection/class-products.php
@@ -127,7 +127,7 @@ class Products {
 							'shuffle' => [
 								'type'        => 'Boolean',
 								'description' => static function () {
-									return __( 'Shuffle results? (Pagination currently not support by this argument)', 'wp-graphql-woocommerce' );
+									return __( 'Shuffle results? (Pagination currently not support by this argument)', 'graphql-for-ecommerce' );
 								},
 							],
 						]
@@ -209,7 +209,7 @@ class Products {
 				'toType'        => 'Product',
 				'fromFieldName' => 'parent',
 				'description'   => static function () {
-					return __( 'The parent of the node. The parent object can be of various types', 'wp-graphql-woocommerce' );
+					return __( 'The parent of the node. The parent object can be of various types', 'graphql-for-ecommerce' );
 				},
 				'oneToOne'      => true,
 				'queryClass'    => '\WC_Product_Query',
@@ -352,7 +352,7 @@ class Products {
 			'found' => [
 				'type'        => 'Integer',
 				'description' => static function () {
-					return __( 'Total products founds', 'wp-graphql-woocommerce' );
+					return __( 'Total products founds', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return ! empty( $source['pageInfo']['found'] ) ? $source['pageInfo']['found'] : null;
@@ -371,219 +371,219 @@ class Products {
 			'slugIn'              => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Limit result set to products with specific slugs.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with specific slugs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'status'              => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific status.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific status.', 'graphql-for-ecommerce' );
 				},
 			],
 			'sku'                 => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit result set to products with specific SKU(s). Use commas to separate.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with specific SKU(s). Use commas to separate.', 'graphql-for-ecommerce' );
 				},
 			],
 			'featured'            => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Limit result set to featured products.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to featured products.', 'graphql-for-ecommerce' );
 				},
 			],
 			'category'            => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific category name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific category name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'categoryIn'          => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Limit result set to products assigned to a group of specific categories by name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned to a group of specific categories by name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'categoryNotIn'       => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Limit result set to products not assigned to a group of specific categories by name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products not assigned to a group of specific categories by name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'categoryId'          => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific category name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific category name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'categoryIdIn'        => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Limit result set to products assigned to a specific group of category IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned to a specific group of category IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'categoryIdNotIn'     => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Limit result set to products not assigned to a specific group of category IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products not assigned to a specific group of category IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'tag'                 => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific tag name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific tag name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'tagIn'               => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Limit result set to products assigned to a specific group of tags by name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned to a specific group of tags by name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'tagNotIn'            => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Limit result set to products not assigned to a specific group of tags by name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products not assigned to a specific group of tags by name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'tagId'               => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific tag ID.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific tag ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'tagIdIn'             => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Limit result set to products assigned to a specific group of tag IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned to a specific group of tag IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'tagIdNotIn'          => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Limit result set to products not assigned to a specific group of tag IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products not assigned to a specific group of tag IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productBrand'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific brand name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific brand name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productBrandIn'      => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Limit result set to products assigned to a specific group of brands by name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned to a specific group of brands by name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productBrandNotIn'   => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Limit result set to products not assigned to a specific group of brands by name.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products not assigned to a specific group of brands by name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productBrandId'      => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific brand ID.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific brand ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productBrandIdIn'    => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Limit result set to products assigned to a specific group of brand IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned to a specific group of brand IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productBrandIdNotIn' => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Limit result set to products not assigned to a specific group of brand IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products not assigned to a specific group of brand IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingClassId'     => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Limit result set to products assigned a specific shipping class ID.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products assigned a specific shipping class ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'attributes'          => [
 				'type'        => 'ProductAttributeQueryInput',
 				'description' => static function () {
-					return __( 'Limit result set to products with selected global attribute queries.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with selected global attribute queries.', 'graphql-for-ecommerce' );
 				},
 			],
 			'attribute'           => [
 				'type'              => 'String',
 				'description'       => static function () {
-					return __( 'Limit result set to products with a specific global product attribute', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with a specific global product attribute', 'graphql-for-ecommerce' );
 				},
 				'deprecationReason' => 'Use attributes instead.',
 			],
 			'attributeTerm'       => [
 				'type'              => 'String',
 				'description'       => static function () {
-					return __( 'Limit result set to products with a specific global product attribute term ID (required an assigned attribute).', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with a specific global product attribute term ID (required an assigned attribute).', 'graphql-for-ecommerce' );
 				},
 				'deprecationReason' => 'Use attributes instead.',
 			],
 			'stockStatus'         => [
 				'type'        => [ 'list_of' => 'StockStatusEnum' ],
 				'description' => static function () {
-					return __( 'Limit result set to products in stock or out of stock.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products in stock or out of stock.', 'graphql-for-ecommerce' );
 				},
 			],
 			'onSale'              => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Limit result set to products on sale.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products on sale.', 'graphql-for-ecommerce' );
 				},
 			],
 			'minPrice'            => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Limit result set to products based on a minimum price.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products based on a minimum price.', 'graphql-for-ecommerce' );
 				},
 			],
 			'maxPrice'            => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Limit result set to products based on a maximum price.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products based on a maximum price.', 'graphql-for-ecommerce' );
 				},
 			],
 			'search'              => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Limit result set to products based on a keyword search.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products based on a keyword search.', 'graphql-for-ecommerce' );
 				},
 			],
 			'visibility'          => [
 				'type'        => 'CatalogVisibilityEnum',
 				'description' => static function () {
-					return __( 'Limit result set to products with a specific visibility level.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with a specific visibility level.', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxonomyFilter'      => [
 				'type'        => 'ProductTaxonomyInput',
 				'description' => static function () {
-					return __( 'Limit result set with complex set of taxonomy filters.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set with complex set of taxonomy filters.', 'graphql-for-ecommerce' );
 				},
 			],
 			'orderby'             => [
 				'type'        => [ 'list_of' => 'ProductsOrderbyInput' ],
 				'description' => static function () {
-					return __( 'What paramater to use to order the objects by.', 'wp-graphql-woocommerce' );
+					return __( 'What paramater to use to order the objects by.', 'graphql-for-ecommerce' );
 				},
 			],
 			'supportedTypesOnly'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Limit result types to types supported by WooGraphQL.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result types to types supported by WooGraphQL.', 'graphql-for-ecommerce' );
 				},
 			],
 			'rating'              => [
 				'type'        => [ 'list_of' => 'Integer' ],
 				'description' => static function () {
-					return __( 'Limit result set to products with a specific average rating. Must be between 1 and 5', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with a specific average rating. Must be between 1 and 5', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -592,7 +592,7 @@ class Products {
 			$args['taxClass'] = [
 				'type'        => 'TaxClassEnum',
 				'description' => static function () {
-					return __( 'Limit result set to products with a specific tax class.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to products with a specific tax class.', 'graphql-for-ecommerce' );
 				},
 			];
 		}
@@ -612,19 +612,19 @@ class Products {
 				'type'      => [
 					'type'        => 'ProductTypesEnum',
 					'description' => static function () {
-						return __( 'Limit result set to products assigned a specific type.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to products assigned a specific type.', 'graphql-for-ecommerce' );
 					},
 				],
 				'typeIn'    => [
 					'type'        => [ 'list_of' => 'ProductTypesEnum' ],
 					'description' => static function () {
-						return __( 'Limit result set to products assigned to a group of specific types.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to products assigned to a group of specific types.', 'graphql-for-ecommerce' );
 					},
 				],
 				'typeNotIn' => [
 					'type'        => [ 'list_of' => 'ProductTypesEnum' ],
 					'description' => static function () {
-						return __( 'Limit result set to products not assigned to a group of specific types.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to products not assigned to a group of specific types.', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -643,25 +643,25 @@ class Products {
 				'type'              => [
 					'type'        => 'ProductTypesWithVariationsEnum',
 					'description' => static function () {
-						return __( 'Limit result set to products assigned a specific type.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to products assigned a specific type.', 'graphql-for-ecommerce' );
 					},
 				],
 				'typeIn'            => [
 					'type'        => [ 'list_of' => 'ProductTypesWithVariationsEnum' ],
 					'description' => static function () {
-						return __( 'Limit result set to products assigned to a group of specific types.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to products assigned to a group of specific types.', 'graphql-for-ecommerce' );
 					},
 				],
 				'typeNotIn'         => [
 					'type'        => [ 'list_of' => 'ProductTypesWithVariationsEnum' ],
 					'description' => static function () {
-						return __( 'Limit result set to products not assigned to a group of specific types.', 'wp-graphql-woocommerce' );
+						return __( 'Limit result set to products not assigned to a group of specific types.', 'graphql-for-ecommerce' );
 					},
 				],
 				'includeVariations' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Include variations in the result set.', 'wp-graphql-woocommerce' );
+						return __( 'Include variations in the result set.', 'graphql-for-ecommerce' );
 					},
 				],
 			]

--- a/includes/connection/class-tax-rates.php
+++ b/includes/connection/class-tax-rates.php
@@ -62,25 +62,25 @@ class Tax_Rates {
 			'class'      => [
 				'type'        => 'TaxClassEnum',
 				'description' => static function () {
-					return __( 'Sort by tax class.', 'wp-graphql-woocommerce' );
+					return __( 'Sort by tax class.', 'graphql-for-ecommerce' );
 				},
 			],
 			'postCode'   => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Filter results by a post code.', 'wp-graphql-woocommerce' );
+					return __( 'Filter results by a post code.', 'graphql-for-ecommerce' );
 				},
 			],
 			'postCodeIn' => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Filter results by a group of post codes.', 'wp-graphql-woocommerce' );
+					return __( 'Filter results by a group of post codes.', 'graphql-for-ecommerce' );
 				},
 			],
 			'orderby'    => [
 				'type'        => [ 'list_of' => 'TaxRateConnectionOrderbyInput' ],
 				'description' => static function () {
-					return __( 'What paramater to use to order the objects by.', 'wp-graphql-woocommerce' );
+					return __( 'What paramater to use to order the objects by.', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/connection/class-wc-terms.php
+++ b/includes/connection/class-wc-terms.php
@@ -31,7 +31,7 @@ class WC_Terms extends TermObjects {
 		// From Coupons to ProductCategory connections.
 		$tax_object = get_taxonomy( 'product_cat' );
 		if ( ! $tax_object ) {
-			throw new \Exception( __( '"product_cat" taxonomy not found', 'wp-graphql-woocommerce' ) );
+			throw new \Exception( __( '"product_cat" taxonomy not found', 'graphql-for-ecommerce' ) );
 		}
 
 		register_graphql_connection(
@@ -80,14 +80,14 @@ class WC_Terms extends TermObjects {
 						'orderby' => [
 							'type'        => 'ProductAttributesConnectionOrderbyEnum',
 							'description' => static function () {
-								return __( 'Field(s) to order terms by. Defaults to \'name\'.', 'wp-graphql-woocommerce' );
+								return __( 'Field(s) to order terms by. Defaults to \'name\'.', 'graphql-for-ecommerce' );
 							},
 						],
 					]
 				),
 				'resolve'        => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 					if ( ! $source->is_taxonomy() ) {
-						throw new UserError( __( 'Invalid product attribute', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'Invalid product attribute', 'graphql-for-ecommerce' ) );
 					}
 
 					$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $source->get_name() );

--- a/includes/connection/wc-cpt-connection-args.php
+++ b/includes/connection/wc-cpt-connection-args.php
@@ -18,49 +18,49 @@ function get_wc_cpt_connection_args(): array {
 		'search'      => [
 			'type'        => 'String',
 			'description' => static function () {
-					return __( 'Limit results to those matching a string.', 'wp-graphql-woocommerce' );
+					return __( 'Limit results to those matching a string.', 'graphql-for-ecommerce' );
 			},
 		],
 		'exclude'     => [
 			'type'        => [ 'list_of' => 'Int' ],
 			'description' => static function () {
-					return __( 'Ensure result set excludes specific IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Ensure result set excludes specific IDs.', 'graphql-for-ecommerce' );
 			},
 		],
 		'include'     => [
 			'type'        => [ 'list_of' => 'Int' ],
 			'description' => static function () {
-					return __( 'Limit result set to specific ids.', 'wp-graphql-woocommerce' );
+					return __( 'Limit result set to specific ids.', 'graphql-for-ecommerce' );
 			},
 		],
 		'orderby'     => [
 			'type'        => [ 'list_of' => 'PostTypeOrderbyInput' ],
 			'description' => static function () {
-					return __( 'What paramater to use to order the objects by.', 'wp-graphql-woocommerce' );
+					return __( 'What paramater to use to order the objects by.', 'graphql-for-ecommerce' );
 			},
 		],
 		'dateQuery'   => [
 			'type'        => 'DateQueryInput',
 			'description' => static function () {
-					return __( 'Filter the connection based on dates.', 'wp-graphql-woocommerce' );
+					return __( 'Filter the connection based on dates.', 'graphql-for-ecommerce' );
 			},
 		],
 		'parent'      => [
 			'type'        => 'Int',
 			'description' => static function () {
-					return __( 'Use ID to return only children. Use 0 to return only top-level items.', 'wp-graphql-woocommerce' );
+					return __( 'Use ID to return only children. Use 0 to return only top-level items.', 'graphql-for-ecommerce' );
 			},
 		],
 		'parentIn'    => [
 			'type'        => [ 'list_of' => 'Int' ],
 			'description' => static function () {
-					return __( 'Specify objects whose parent is in an array.', 'wp-graphql-woocommerce' );
+					return __( 'Specify objects whose parent is in an array.', 'graphql-for-ecommerce' );
 			},
 		],
 		'parentNotIn' => [
 			'type'        => [ 'list_of' => 'Int' ],
 			'description' => static function () {
-					return __( 'Specify objects whose parent is not in an array.', 'wp-graphql-woocommerce' );
+					return __( 'Specify objects whose parent is not in an array.', 'graphql-for-ecommerce' );
 			},
 		],
 	];

--- a/includes/data/class-factory.php
+++ b/includes/data/class-factory.php
@@ -86,7 +86,7 @@ class Factory {
 		if ( is_a( $item, \WC_Order_Item::class ) ) {
 			return new Order_Item( $item );
 		} else {
-			throw new UserError( __( 'Object provided to order item resolver is an invalid type', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Object provided to order item resolver is an invalid type', 'graphql-for-ecommerce' ) );
 		}
 	}
 
@@ -121,7 +121,7 @@ class Factory {
 		if ( empty( $methods[ $id ] ) ) {
 			throw new UserError(
 				/* translators: shipping method ID */
-				sprintf( __( 'No Shipping Method assigned to ID %s was found ', 'wp-graphql-woocommerce' ), $id )
+				sprintf( __( 'No Shipping Method assigned to ID %s was found ', 'graphql-for-ecommerce' ), $id )
 			);
 		}
 

--- a/includes/data/connection/class-order-connection-resolver.php
+++ b/includes/data/connection/class-order-connection-resolver.php
@@ -206,7 +206,7 @@ class Order_Connection_Resolver extends AbstractConnectionResolver {
 		$query      = new \WC_Order_Query( $query_args );
 
 		if ( true === $query->get( 'suppress_filters', false ) ) {
-			throw new InvariantViolation( __( 'WC_Order_Query has been modified by a plugin or theme to suppress_filters, which will cause issues with WPGraphQL Execution. If you need to suppress filters for a specific reason within GraphQL, consider registering a custom field to the WPGraphQL Schema with a custom resolver.', 'wp-graphql-woocommerce' ) );
+			throw new InvariantViolation( __( 'WC_Order_Query has been modified by a plugin or theme to suppress_filters, which will cause issues with WPGraphQL Execution. If you need to suppress filters for a specific reason within GraphQL, consider registering a custom field to the WPGraphQL Schema with a custom resolver.', 'graphql-for-ecommerce' ) );
 		}
 
 		return $query;

--- a/includes/data/connection/class-payment-gateway-connection-resolver.php
+++ b/includes/data/connection/class-payment-gateway-connection-resolver.php
@@ -33,7 +33,7 @@ class Payment_Gateway_Connection_Resolver {
 	public function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		if ( ( ! empty( $args['where']['all'] ) ) && true === $args['where']['all'] ) {
 			if ( ! current_user_can( 'edit_theme_options' ) ) {
-				throw new UserError( __( 'Not authorized to view these settings', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Not authorized to view these settings', 'graphql-for-ecommerce' ) );
 			}
 			$gateways = \WC()->payment_gateways()->payment_gateways();
 		} else {

--- a/includes/data/connection/class-product-attribute-connection-resolver.php
+++ b/includes/data/connection/class-product-attribute-connection-resolver.php
@@ -142,7 +142,7 @@ class Product_Attribute_Connection_Resolver {
 					);
 					break;
 				default:
-					throw new UserError( __( 'Invalid product attribute type provided', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'Invalid product attribute type provided', 'graphql-for-ecommerce' ) );
 			}
 		}//end if
 

--- a/includes/data/connection/class-product-connection-resolver.php
+++ b/includes/data/connection/class-product-connection-resolver.php
@@ -535,7 +535,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 		// Filter by attribute and term.
 		if ( ! empty( $where_args['attribute'] ) && ! empty( $where_args['attributeTerm'] ) ) {
 			graphql_debug(
-				__( 'The "attribute" and "attributeTerm" arguments have been deprecated. Please use the "attributes" argument instead.', 'wp-graphql-woocommerce' ),
+				__( 'The "attribute" and "attributeTerm" arguments have been deprecated. Please use the "attributes" argument instead.', 'graphql-for-ecommerce' ),
 			);
 			if ( in_array( $where_args['attribute'], \wc_get_attribute_taxonomy_names(), true ) ) {
 				$tax_query[] = [
@@ -588,7 +588,7 @@ class Product_Connection_Resolver extends AbstractConnectionResolver {
 			if ( 1 < count( $att_queries ) ) {
 				$relation = ! empty( $where_args['attributes']['relation'] ) ? $where_args['attributes']['relation'] : 'AND';
 				if ( 'NOT_IN' === $relation ) {
-					graphql_debug( __( 'The "NOT_IN" relation is not supported for attributes. Please use "IN" or "AND" instead.', 'wp-graphql-woocommerce' ) );
+					graphql_debug( __( 'The "NOT_IN" relation is not supported for attributes. Please use "IN" or "AND" instead.', 'graphql-for-ecommerce' ) );
 					$relation = 'IN';
 				}
 

--- a/includes/data/connection/class-shipping-method-connection-resolver.php
+++ b/includes/data/connection/class-shipping-method-connection-resolver.php
@@ -34,7 +34,7 @@ class Shipping_Method_Connection_Resolver extends AbstractConnectionResolver {
 	 */
 	public function should_execute() {
 		if ( ! wc_rest_check_manager_permissions( 'shipping_methods', 'read' ) ) {
-			graphql_debug( __( 'Permission denied.', 'wp-graphql-woocommerce' ) );
+			graphql_debug( __( 'Permission denied.', 'graphql-for-ecommerce' ) );
 			return false;
 		}
 		return true;

--- a/includes/data/connection/class-shipping-zone-connection-resolver.php
+++ b/includes/data/connection/class-shipping-zone-connection-resolver.php
@@ -33,12 +33,12 @@ class Shipping_Zone_Connection_Resolver extends AbstractConnectionResolver {
 	 */
 	public function should_execute() {
 		if ( ! \wc_shipping_enabled() ) {
-			graphql_debug( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ) );
+			graphql_debug( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ) );
 			return false;
 		}
 
 		if ( ! \wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			graphql_debug( __( 'Permission denied.', 'wp-graphql-woocommerce' ) );
+			graphql_debug( __( 'Permission denied.', 'graphql-for-ecommerce' ) );
 			return false;
 		}
 		return true;

--- a/includes/data/connection/class-tax-class-connection-resolver.php
+++ b/includes/data/connection/class-tax-class-connection-resolver.php
@@ -33,7 +33,7 @@ class Tax_Class_Connection_Resolver extends AbstractConnectionResolver {
 	public function should_execute() {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
 			graphql_debug(
-				__( 'User does not have permission to view tax classes.', 'wp-graphql-woocommerce' )
+				__( 'User does not have permission to view tax classes.', 'graphql-for-ecommerce' )
 			);
 			return false;
 		}
@@ -60,7 +60,7 @@ class Tax_Class_Connection_Resolver extends AbstractConnectionResolver {
 		// Add standard class.
 		$tax_classes[] = [
 			'slug' => 'standard',
-			'name' => __( 'Standard rate', 'wp-graphql-woocommerce' ),
+			'name' => __( 'Standard rate', 'graphql-for-ecommerce' ),
 		];
 
 		$classes = \WC_Tax::get_tax_classes();

--- a/includes/data/connection/class-tax-rate-connection-resolver.php
+++ b/includes/data/connection/class-tax-rate-connection-resolver.php
@@ -37,7 +37,7 @@ class Tax_Rate_Connection_Resolver extends AbstractConnectionResolver {
 	public function should_execute() {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
 			graphql_debug(
-				__( 'User does not have permission to view tax rates.', 'wp-graphql-woocommerce' )
+				__( 'User does not have permission to view tax rates.', 'graphql-for-ecommerce' )
 			);
 			return false;
 		}

--- a/includes/data/loader/class-wc-cpt-loader.php
+++ b/includes/data/loader/class-wc-cpt-loader.php
@@ -64,7 +64,7 @@ class WC_CPT_Loader extends AbstractDataLoader {
 				}
 
 				/* translators: no model assigned error message */
-				throw new UserError( sprintf( __( 'No Model is register to the custom post-type "%s"', 'wp-graphql-woocommerce' ), $post_type ) );
+				throw new UserError( sprintf( __( 'No Model is register to the custom post-type "%s"', 'graphql-for-ecommerce' ), $post_type ) );
 		}//end switch
 	}
 
@@ -138,7 +138,7 @@ class WC_CPT_Loader extends AbstractDataLoader {
 
 			if ( ! in_array( $post_type, $wc_post_types, true ) && ! OrderUtil::is_order( $key, wc_get_order_types() ) ) {
 				/* translators: invalid post-type error message */
-				throw new UserError( sprintf( __( '%s is not a valid WooCommerce post-type', 'wp-graphql-woocommerce' ), $post_type ) );
+				throw new UserError( sprintf( __( '%s is not a valid WooCommerce post-type', 'graphql-for-ecommerce' ), $post_type ) );
 			}
 
 			$post_object = get_post( (int) $key );

--- a/includes/data/loader/class-wc-db-loader.php
+++ b/includes/data/loader/class-wc-db-loader.php
@@ -92,7 +92,7 @@ class WC_Db_Loader extends AbstractDataLoader {
 				if ( empty( $loader ) ) {
 					throw new \Exception(
 						/* translators: %s: Loader Type */
-						sprintf( __( 'Loader type invalid: %s', 'wp-graphql-woocommerce' ), $this->loader_type )
+						sprintf( __( 'Loader type invalid: %s', 'graphql-for-ecommerce' ), $this->loader_type )
 					);
 				}
 		}//end switch
@@ -144,7 +144,7 @@ class WC_Db_Loader extends AbstractDataLoader {
 		if ( 'standard' === $slug ) {
 			return [
 				'slug' => 'standard',
-				'name' => __( 'Standard rate', 'wp-graphql-woocommerce' ),
+				'name' => __( 'Standard rate', 'graphql-for-ecommerce' ),
 			];
 		} else {
 			$tax_class = \WC_Tax::get_tax_class_by( 'slug', $slug );
@@ -244,7 +244,7 @@ class WC_Db_Loader extends AbstractDataLoader {
 		if ( empty( $methods[ $id ] ) ) {
 			throw new UserError(
 			/* translators: shipping method ID */
-				sprintf( __( 'No Shipping Method assigned to ID %s was found ', 'wp-graphql-woocommerce' ), $id )
+				sprintf( __( 'No Shipping Method assigned to ID %s was found ', 'graphql-for-ecommerce' ), $id )
 			);
 		}
 

--- a/includes/data/mutation/class-cart-mutation.php
+++ b/includes/data/mutation/class-cart-mutation.php
@@ -48,11 +48,11 @@ class Cart_Mutation {
 	 */
 	public static function prepare_cart_item( $input, $context, $info ) {
 		if ( empty( $input['productId'] ) ) {
-			throw new UserError( __( 'No product ID provided', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'No product ID provided', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( ! \wc_get_product( $input['productId'] ) ) {
-			throw new UserError( __( 'No product found matching the ID provided', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'No product found matching the ID provided', 'graphql-for-ecommerce' ) );
 		}
 
 		$cart_item_args   = [ $input['productId'] ];
@@ -84,7 +84,7 @@ class Cart_Mutation {
 			throw new UserError(
 				sprintf(
 					/* translators: %s: product ID */
-					__( 'No product found matching the ID provided: %s', 'wp-graphql-woocommerce' ),
+					__( 'No product found matching the ID provided: %s', 'graphql-for-ecommerce' ),
 					$product_id
 				)
 			);
@@ -101,7 +101,7 @@ class Cart_Mutation {
 				throw new UserError(
 					sprintf(
 						/* translators: %1$s: attribute name, %2$s: product name */
-						__( '%1$s is not a valid attribute of the product: %2$s.', 'wp-graphql-woocommerce' ),
+						__( '%1$s is not a valid attribute of the product: %2$s.', 'graphql-for-ecommerce' ),
 						$attribute_name,
 						$product->get_name()
 					)
@@ -143,7 +143,7 @@ class Cart_Mutation {
 				$item = \WC()->cart->get_cart_item( $key );
 				if ( empty( $item ) ) {
 					/* translators: Cart item not found message */
-					throw new UserError( sprintf( __( 'No cart item found with the key: %s', 'wp-graphql-woocommerce' ), $key ) );
+					throw new UserError( sprintf( __( 'No cart item found with the key: %s', 'graphql-for-ecommerce' ), $key ) );
 				}
 				$items[] = $item;
 			}
@@ -186,7 +186,7 @@ class Cart_Mutation {
 
 		// Prevent adding coupons by post ID.
 		if ( is_numeric( $code ) && strtoupper( $the_coupon->get_code() ) !== strtoupper( $code ) ) {
-			$reason = __( 'No coupon found with the code provided', 'wp-graphql-woocommerce' );
+			$reason = __( 'No coupon found with the code provided', 'graphql-for-ecommerce' );
 			return false;
 		}
 
@@ -200,7 +200,7 @@ class Cart_Mutation {
 
 		// Check if applied.
 		if ( \WC()->cart->has_discount( $code ) ) {
-			$reason = __( 'This coupon has already been applied to the cart', 'wp-graphql-woocommerce' );
+			$reason = __( 'This coupon has already been applied to the cart', 'graphql-for-ecommerce' );
 			return false;
 		}
 
@@ -225,7 +225,7 @@ class Cart_Mutation {
 		if ( ! isset( $available_packages[ $index ] ) ) {
 			$reason = sprintf(
 				/* translators: %d: Package index */
-				__( 'No shipping packages available for corresponding index %d', 'wp-graphql-woocommerce' ),
+				__( 'No shipping packages available for corresponding index %d', 'graphql-for-ecommerce' ),
 				$index
 			);
 
@@ -249,7 +249,7 @@ class Cart_Mutation {
 
 		$reason = sprintf(
 			/* translators: %1$s: shipping method ID, %2$s: package contents */
-			__( '"%1$s" is not an available shipping method for shipping package "%2$s"', 'wp-graphql-woocommerce' ),
+			__( '"%1$s" is not an available shipping method for shipping package "%2$s"', 'graphql-for-ecommerce' ),
 			$shipping_method,
 			implode( ', ', $product_names )
 		);

--- a/includes/data/mutation/class-checkout-mutation.php
+++ b/includes/data/mutation/class-checkout-mutation.php
@@ -421,11 +421,11 @@ class Checkout_Mutation {
 						switch ( $country ) {
 							case 'IE':
 								/* translators: %1$s: field name, %2$s finder.eircode.ie URL */
-								$postcode_validation_notice = sprintf( __( '%1$s is not valid. You can look up the correct Eircode. %2$s', 'wp-graphql-woocommerce' ), $field_label, 'https://finder.eircode.ie' );
+								$postcode_validation_notice = sprintf( __( '%1$s is not valid. You can look up the correct Eircode. %2$s', 'graphql-for-ecommerce' ), $field_label, 'https://finder.eircode.ie' );
 								break;
 							default:
 								/* translators: %s: field name */
-								$postcode_validation_notice = sprintf( __( '%s is not a valid postcode / ZIP.', 'wp-graphql-woocommerce' ), $field_label );
+								$postcode_validation_notice = sprintf( __( '%s is not a valid postcode / ZIP.', 'graphql-for-ecommerce' ), $field_label );
 						}
 						// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 						throw new UserError( apply_filters( 'woocommerce_checkout_postcode_validation_notice', $postcode_validation_notice, $country, $data[ $key ] ) );
@@ -435,7 +435,7 @@ class Checkout_Mutation {
 				if ( \str_ends_with( $key, 'phone' ) ) {
 					if ( $validate_fieldset && '' !== $data[ $key ] && ! \WC_Validation::is_phone( $data[ $key ] ) ) {
 						/* translators: %s: phone number */
-						throw new UserError( sprintf( __( '%s is not a valid phone number.', 'wp-graphql-woocommerce' ), $field_label ) );
+						throw new UserError( sprintf( __( '%s is not a valid phone number.', 'graphql-for-ecommerce' ), $field_label ) );
 					}
 				}
 
@@ -445,7 +445,7 @@ class Checkout_Mutation {
 
 					if ( $validate_fieldset && ! $email_is_valid ) {
 						/* translators: %s: email address */
-						throw new UserError( sprintf( __( '%s is not a valid email address.', 'wp-graphql-woocommerce' ), $field_label ) );
+						throw new UserError( sprintf( __( '%s is not a valid email address.', 'graphql-for-ecommerce' ), $field_label ) );
 					}
 				}
 
@@ -464,7 +464,7 @@ class Checkout_Mutation {
 
 						if ( $validate_fieldset && ! in_array( $data[ $key ], $valid_state_values, true ) ) {
 							/* translators: 1: state field 2: valid states */
-							throw new UserError( sprintf( __( '%1$s is not valid. Please enter one of the following: %2$s', 'wp-graphql-woocommerce' ), $field_label, implode( ', ', $valid_states ) ) );
+							throw new UserError( sprintf( __( '%1$s is not valid. Please enter one of the following: %2$s', 'graphql-for-ecommerce' ), $field_label, implode( ', ', $valid_states ) ) );
 						}
 					}
 				}
@@ -487,20 +487,20 @@ class Checkout_Mutation {
 		WC()->checkout()->check_cart_items();
 
 		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $data['terms-field'] ) ) {
-			$errors->add( 'terms', __( 'Please read and accept the terms and conditions to proceed with your order.', 'wp-graphql-woocommerce' ) );
+			$errors->add( 'terms', __( 'Please read and accept the terms and conditions to proceed with your order.', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( WC()->cart->needs_shipping() ) {
 			$shipping_country = WC()->customer->get_shipping_country();
 
 			if ( empty( $shipping_country ) ) {
-				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'wp-graphql-woocommerce' ) );
+				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'graphql-for-ecommerce' ) );
 			} elseif ( ! in_array( WC()->customer->get_shipping_country(), array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
 				$errors->add(
 					'shipping',
 					sprintf(
 						/* translators: %s: shipping location */
-						__( 'Unfortunately, we do not ship %s. Please enter an alternative shipping address.', 'wp-graphql-woocommerce' ),
+						__( 'Unfortunately, we do not ship %s. Please enter an alternative shipping address.', 'graphql-for-ecommerce' ),
 						WC()->countries->shipping_to_prefix() . ' ' . WC()->customer->get_shipping_country()
 					)
 				);
@@ -509,7 +509,7 @@ class Checkout_Mutation {
 
 				foreach ( WC()->shipping()->get_packages() as $i => $package ) {
 					if ( ! isset( $chosen_shipping_methods[ $i ], $package['rates'][ $chosen_shipping_methods[ $i ] ] ) ) {
-						$errors->add( 'shipping', __( 'No shipping method has been selected. Please double check your address, or contact us if you need any help.', 'wp-graphql-woocommerce' ) );
+						$errors->add( 'shipping', __( 'No shipping method has been selected. Please double check your address, or contact us if you need any help.', 'graphql-for-ecommerce' ) );
 					}
 				}
 			}
@@ -518,7 +518,7 @@ class Checkout_Mutation {
 		if ( WC()->cart->needs_payment() ) {
 			$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 			if ( ! isset( $available_gateways[ $data['payment_method'] ] ) ) {
-				$errors->add( 'payment', __( 'Invalid payment method.', 'wp-graphql-woocommerce' ) );
+				$errors->add( 'payment', __( 'Invalid payment method.', 'graphql-for-ecommerce' ) );
 			} else {
 				$available_gateways[ $data['payment_method'] ]->validate_fields();
 			}
@@ -543,7 +543,7 @@ class Checkout_Mutation {
 		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! isset( $available_gateways[ $payment_method ] ) ) {
-			throw new UserError( __( 'Cannot process invalid payment method.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Cannot process invalid payment method.', 'graphql-for-ecommerce' ) );
 		}
 
 		// Store Order ID in session so it can be re-used after payment failure.
@@ -573,7 +573,7 @@ class Checkout_Mutation {
 	protected static function process_order_without_payment( $order_id, $transaction_id = '' ) {
 		$order = wc_get_order( $order_id );
 		if ( ! is_object( $order ) || ! is_a( $order, \WC_Order::class ) ) {
-			throw new \Exception( __( 'Failed to retrieve order.', 'wp-graphql-woocommerce' ) );
+			throw new \Exception( __( 'Failed to retrieve order.', 'graphql-for-ecommerce' ) );
 		}
 
 		$order->payment_complete( $transaction_id );
@@ -605,7 +605,7 @@ class Checkout_Mutation {
 		do_action( 'woocommerce_before_checkout_process' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		if ( WC()->cart->is_empty() ) {
-			throw new UserError( __( 'Sorry, no session found.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Sorry, no session found.', 'graphql-for-ecommerce' ) );
 		}
 
 		do_action( 'woocommerce_checkout_process', $data, $context, $info ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
@@ -634,7 +634,7 @@ class Checkout_Mutation {
 		}
 
 		if ( 0 < wc_notice_count( 'error' ) ) {
-			throw new UserError( __( 'Failed to validate checkout', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Failed to validate checkout', 'graphql-for-ecommerce' ) );
 		}
 
 		self::process_customer( $data );
@@ -646,7 +646,7 @@ class Checkout_Mutation {
 		}
 
 		if ( ! is_object( $order ) || ! is_a( $order, \WC_Order::class ) ) {
-			throw new UserError( __( 'Unable to create order.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Unable to create order.', 'graphql-for-ecommerce' ) );
 		}
 
 		// Override the "created via" source when provided. WC_Checkout::create_order() hardcodes it to "checkout".
@@ -664,7 +664,7 @@ class Checkout_Mutation {
 			$order = wc_get_order( $order_id );
 
 			if ( ! is_object( $order ) || ! is_a( $order, \WC_Order::class ) ) {
-				throw new UserError( __( 'Failed to get order with updated meta.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to get order with updated meta.', 'graphql-for-ecommerce' ) );
 			}
 		}
 
@@ -782,7 +782,7 @@ class Checkout_Mutation {
 	public static function update_order_meta( $order_id, $meta_data, $input, $context, $info ) {
 		$order = \WC_Order_Factory::get_order( $order_id );
 		if ( ! is_object( $order ) ) {
-			throw new \Exception( __( 'Failed to retrieve order.', 'wp-graphql-woocommerce' ) );
+			throw new \Exception( __( 'Failed to retrieve order.', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( $meta_data ) {

--- a/includes/data/mutation/class-order-mutation.php
+++ b/includes/data/mutation/class-order-mutation.php
@@ -53,7 +53,7 @@ class Order_Mutation {
 			throw new UserError(
 				sprintf(
 					/* translators: %d: Order ID */
-					__( 'Failed to find order with ID of %d.', 'wp-graphql-woocommerce' ),
+					__( 'Failed to find order with ID of %d.', 'graphql-for-ecommerce' ),
 					$order_id
 				)
 			);
@@ -61,7 +61,7 @@ class Order_Mutation {
 
 		$post_type = get_post_type( $order_id );
 		if ( false === $post_type ) {
-			throw new UserError( __( 'Failed to identify the post type of the order.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Failed to identify the post type of the order.', 'graphql-for-ecommerce' ) );
 		}
 
 		// Return true if user is owner or admin.
@@ -244,7 +244,7 @@ class Order_Mutation {
 			$product_id = self::get_product_id( $args );
 			$product    = ! empty( $product_id ) ? wc_get_product( $product_id ) : null;
 			if ( ! is_object( $product ) ) {
-				throw new \Exception( __( 'Failed to retrieve product connected to order item.', 'wp-graphql-woocommerce' ) );
+				throw new \Exception( __( 'Failed to retrieve product connected to order item.', 'graphql-for-ecommerce' ) );
 			}
 
 			$total            = wc_get_price_excluding_tax( $product, [ 'qty' => $args['quantity'] ?? 1 ] );
@@ -332,7 +332,7 @@ class Order_Mutation {
 		} elseif ( ! empty( $data['product_id'] ) ) {
 			$product_id = (int) $data['product_id'];
 		} else {
-			throw new UserError( __( 'Product ID or SKU is required.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Product ID or SKU is required.', 'graphql-for-ecommerce' ) );
 		}
 
 		return $product_id;

--- a/includes/data/mutation/class-product-mutation.php
+++ b/includes/data/mutation/class-product-mutation.php
@@ -66,7 +66,7 @@ class Product_Mutation {
 			} else {
 				graphql_debug(
 					/* translators: %s: Shipping class */
-					sprintf( __( 'Invalid shipping class: %s', 'wp-graphql-woocommerce' ), $shippingClass )
+					sprintf( __( 'Invalid shipping class: %s', 'graphql-for-ecommerce' ), $shippingClass )
 				);
 			}
 		}
@@ -310,7 +310,7 @@ class Product_Mutation {
 				if ( ! wp_attachment_is_image( $attachment_id ) ) {
 					throw new UserError(
 						/* translators: %s: Attachment ID */
-						sprintf( __( '#%s is an invalid image ID.', 'wp-graphql-woocommerce' ), $attachment_id )
+						sprintf( __( '#%s is an invalid image ID.', 'graphql-for-ecommerce' ), $attachment_id )
 					);
 				}
 
@@ -385,7 +385,7 @@ class Product_Mutation {
 		);
 
 		if ( is_wp_error( $attribute ) || is_null( $attribute ) ) {
-			throw new UserError( __( 'Invalid attribute ID.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Invalid attribute ID.', 'graphql-for-ecommerce' ) );
 		}
 
 		return $attribute;

--- a/includes/data/mutation/class-settings-mutation.php
+++ b/includes/data/mutation/class-settings-mutation.php
@@ -40,7 +40,7 @@ class Settings_Mutation {
 		if ( array_key_exists( $value, $setting['options'] ) ) {
 			return $value;
 		} else {
-			throw new UserError( __( 'An invalid setting value was passed.', 'wp-graphql-woocommerce' ), 400 );
+			throw new UserError( __( 'An invalid setting value was passed.', 'graphql-for-ecommerce' ), 400 );
 		}
 	}
 
@@ -60,7 +60,7 @@ class Settings_Mutation {
 		}
 
 		if ( ! is_array( $values ) ) {
-			throw new UserError( __( 'An invalid setting value was passed.', 'wp-graphql-woocommerce' ), 400 );
+			throw new UserError( __( 'An invalid setting value was passed.', 'graphql-for-ecommerce' ), 400 );
 		}
 
 		$final_values = [];
@@ -85,7 +85,7 @@ class Settings_Mutation {
 	 */
 	public static function validate_setting_image_width_field( $values, $setting ) {
 		if ( ! is_array( $values ) ) {
-			throw new UserError( __( 'An invalid setting value was passed.', 'wp-graphql-woocommerce' ), 400 );
+			throw new UserError( __( 'An invalid setting value was passed.', 'graphql-for-ecommerce' ), 400 );
 		}
 
 		$current = $setting['value'];
@@ -132,7 +132,7 @@ class Settings_Mutation {
 			$value = isset( $setting['default'] ) ? $setting['default'] : 'no';
 			return $value;
 		} else {
-			throw new UserError( __( 'An invalid setting value was passed.', 'wp-graphql-woocommerce' ), 400 );
+			throw new UserError( __( 'An invalid setting value was passed.', 'graphql-for-ecommerce' ), 400 );
 		}
 	}
 

--- a/includes/model/class-order.php
+++ b/includes/model/class-order.php
@@ -112,7 +112,7 @@ class Order extends Model {
 
 		// Check if order is valid.
 		if ( ! $data instanceof \WC_Abstract_Order ) {
-			throw new \Exception( __( 'Failed to retrieve order data source', 'wp-graphql-woocommerce' ) );
+			throw new \Exception( __( 'Failed to retrieve order data source', 'graphql-for-ecommerce' ) );
 		}
 
 		$this->data                = $data;
@@ -363,7 +363,7 @@ class Order extends Model {
 			throw new UserError(
 				__(
 					'User does not have the capabilities necessary to delete this object.',
-					'wp-graphql-woocommerce'
+					'graphql-for-ecommerce'
 				)
 			);
 		}

--- a/includes/model/class-product-variation.php
+++ b/includes/model/class-product-variation.php
@@ -77,7 +77,7 @@ class Product_Variation extends WC_Post {
 
 		// Check if product variation is valid.
 		if ( ! is_object( $data ) ) {
-			throw new \Exception( __( 'Failed to retrieve product variation data source', 'wp-graphql-woocommerce' ) );
+			throw new \Exception( __( 'Failed to retrieve product variation data source', 'graphql-for-ecommerce' ) );
 		}
 
 		parent::__construct( $data );

--- a/includes/model/class-product.php
+++ b/includes/model/class-product.php
@@ -131,7 +131,7 @@ class Product extends WC_Post {
 
 		// Check if product is valid.
 		if ( ! is_object( $data ) ) {
-			throw new \Exception( __( 'Failed to retrieve product data source', 'wp-graphql-woocommerce' ) );
+			throw new \Exception( __( 'Failed to retrieve product data source', 'graphql-for-ecommerce' ) );
 		}
 
 		parent::__construct( $data );

--- a/includes/model/class-wc-post.php
+++ b/includes/model/class-wc-post.php
@@ -45,7 +45,7 @@ abstract class WC_Post extends Post {
 
 		// Check if product is valid.
 		if ( ! is_object( $post ) ) {
-			throw new \Exception( __( 'Failed to retrieve data source post object', 'wp-graphql-woocommerce' ) );
+			throw new \Exception( __( 'Failed to retrieve data source post object', 'graphql-for-ecommerce' ) );
 		}
 
 		// Add $allowed_restricted_fields.
@@ -132,7 +132,7 @@ abstract class WC_Post extends Post {
 			throw new UserError(
 				__(
 					'Post type object not found.',
-					'wp-graphql-woocommerce'
+					'graphql-for-ecommerce'
 				)
 			);
 		}
@@ -141,7 +141,7 @@ abstract class WC_Post extends Post {
 			throw new UserError(
 				__(
 					'User does not have the capabilities necessary to delete this object.',
-					'wp-graphql-woocommerce'
+					'graphql-for-ecommerce'
 				)
 			);
 		}

--- a/includes/mutation/class-cart-add-fee.php
+++ b/includes/mutation/class-cart-add-fee.php
@@ -45,25 +45,25 @@ class Cart_Add_Fee {
 			'name'     => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Unique name for the fee.', 'wp-graphql-woocommerce' );
+					return __( 'Unique name for the fee.', 'graphql-for-ecommerce' );
 				},
 			],
 			'amount'   => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Fee amount', 'wp-graphql-woocommerce' );
+					return __( 'Fee amount', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxable'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Is the fee taxable?', 'wp-graphql-woocommerce' );
+					return __( 'Is the fee taxable?', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxClass' => [
 				'type'        => 'TaxClassEnum',
 				'description' => static function () {
-					return __( 'The tax class for the fee if taxable.', 'wp-graphql-woocommerce' );
+					return __( 'The tax class for the fee if taxable.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -97,15 +97,15 @@ class Cart_Add_Fee {
 			Cart_Mutation::check_session_token();
 
 			if ( ! current_user_can( 'edit_shop_orders' ) ) {
-				throw new UserError( __( 'You do not have the appropriate capabilities to perform this action.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'You do not have the appropriate capabilities to perform this action.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( empty( $input['name'] ) ) {
-				throw new UserError( __( 'No name provided for fee.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No name provided for fee.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( ! isset( $input['amount'] ) ) {
-				throw new UserError( __( 'No amount set for the fee.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No amount set for the fee.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Get cart fee args.

--- a/includes/mutation/class-cart-add-item.php
+++ b/includes/mutation/class-cart-add-item.php
@@ -45,31 +45,31 @@ class Cart_Add_Item {
 			'productId'   => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Cart item product database ID or global ID', 'wp-graphql-woocommerce' );
+					return __( 'Cart item product database ID or global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'quantity'    => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Cart item quantity', 'wp-graphql-woocommerce' );
+					return __( 'Cart item quantity', 'graphql-for-ecommerce' );
 				},
 			],
 			'variationId' => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Cart item product variation database ID or global ID', 'wp-graphql-woocommerce' );
+					return __( 'Cart item product variation database ID or global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'variation'   => [
 				'type'        => [ 'list_of' => 'ProductAttributeInput' ],
 				'description' => static function () {
-					return __( 'Cart item product variation attributes', 'wp-graphql-woocommerce' );
+					return __( 'Cart item product variation attributes', 'graphql-for-ecommerce' );
 				},
 			],
 			'extraData'   => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'JSON string representation of extra cart item data', 'wp-graphql-woocommerce' );
+					return __( 'JSON string representation of extra cart item data', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -124,7 +124,7 @@ class Cart_Add_Item {
 				\wc_clear_notices();
 				throw new UserError( $cart_error_messages );
 			} else {
-				throw new UserError( __( 'Failed to add cart item. Please check input.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to add cart item. Please check input.', 'graphql-for-ecommerce' ) );
 			}
 		};
 	}

--- a/includes/mutation/class-cart-add-items.php
+++ b/includes/mutation/class-cart-add-items.php
@@ -45,7 +45,7 @@ class Cart_Add_Items {
 			'items' => [
 				'type'        => [ 'list_of' => 'CartItemInput' ],
 				'description' => static function () {
-					return __( 'Cart items to be added', 'wp-graphql-woocommerce' );
+					return __( 'Cart items to be added', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -104,7 +104,7 @@ class Cart_Add_Items {
 
 			// Throw error, if no cart item data provided.
 			if ( empty( $input['items'] ) ) {
-				throw new UserError( __( 'No cart item data provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No cart item data provided', 'graphql-for-ecommerce' ) );
 			}
 
 			// Validate cart item input.
@@ -132,7 +132,7 @@ class Cart_Add_Items {
 
 						$failure[] = compact( 'cart_item_data', 'reasons' );
 					} else {
-						$reason    = __( 'Failed to add cart item. Please check input.', 'wp-graphql-woocommerce' );
+						$reason    = __( 'Failed to add cart item. Please check input.', 'graphql-for-ecommerce' );
 						$failure[] = compact( 'cart_item_data', 'reason' );
 					}
 				} catch ( \Throwable $e ) {
@@ -151,7 +151,7 @@ class Cart_Add_Items {
 
 			// Throw error, if no items added.
 			if ( empty( $added ) ) {
-				throw new UserError( __( 'Failed to add any cart items. Please check input.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to add any cart items. Please check input.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Return payload.

--- a/includes/mutation/class-cart-apply-coupon.php
+++ b/includes/mutation/class-cart-apply-coupon.php
@@ -43,7 +43,7 @@ class Cart_Apply_Coupon {
 			'code' => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Code of coupon being applied', 'wp-graphql-woocommerce' );
+					return __( 'Code of coupon being applied', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -96,7 +96,7 @@ class Cart_Apply_Coupon {
 			}
 
 			// Throw for unknown failure.
-			throw new UserError( __( 'Failed to apply coupon. Check for an individual-use coupon on cart.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Failed to apply coupon. Check for an individual-use coupon on cart.', 'graphql-for-ecommerce' ) );
 		};
 	}
 }

--- a/includes/mutation/class-cart-empty.php
+++ b/includes/mutation/class-cart-empty.php
@@ -67,7 +67,7 @@ class Cart_Empty {
 			$cloned_cart = clone \WC()->cart;
 
 			if ( $cloned_cart->is_empty() ) {
-				throw new UserError( __( 'Cart is empty', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Cart is empty', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-cart-fill.php
+++ b/includes/mutation/class-cart-fill.php
@@ -46,19 +46,19 @@ class Cart_Fill {
 			'shippingMethods' => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Shipping methods to be used.', 'wp-graphql-woocommerce' );
+					return __( 'Shipping methods to be used.', 'graphql-for-ecommerce' );
 				},
 			],
 			'coupons'         => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Coupons to be applied to the cart', 'wp-graphql-woocommerce' );
+					return __( 'Coupons to be applied to the cart', 'graphql-for-ecommerce' );
 				},
 			],
 			'items'           => [
 				'type'        => [ 'list_of' => 'CartItemInput' ],
 				'description' => static function () {
-					return __( 'Cart items to be added', 'wp-graphql-woocommerce' );
+					return __( 'Cart items to be added', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -161,7 +161,7 @@ class Cart_Fill {
 
 			// Throw error, if no cart item data provided.
 			if ( empty( $input['items'] ) ) {
-				throw new UserError( __( 'No cart item data provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No cart item data provided', 'graphql-for-ecommerce' ) );
 			}
 
 			// Validate cart item input.
@@ -189,7 +189,7 @@ class Cart_Fill {
 
 						$invalid_cart_items[] = compact( 'cart_item_data', 'reasons' );
 					} else {
-						$reason               = __( 'Failed to add cart item. Please check input.', 'wp-graphql-woocommerce' );
+						$reason               = __( 'Failed to add cart item. Please check input.', 'graphql-for-ecommerce' );
 						$invalid_cart_items[] = compact( 'cart_item_data', 'reason' );
 					}
 				} catch ( \Throwable $e ) {
@@ -208,7 +208,7 @@ class Cart_Fill {
 
 			// Throw error, if no items added.
 			if ( empty( $added ) ) {
-				throw new UserError( __( 'Failed to add any cart items. Please check input.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to add any cart items. Please check input.', 'graphql-for-ecommerce' ) );
 			}
 
 			$applied         = [];
@@ -231,7 +231,7 @@ class Cart_Fill {
 
 					// Throw any capture errors.
 					if ( empty( $reason ) ) {
-						$reason = __( 'Failed to apply coupon. Check for an individual-use coupon on cart.', 'wp-graphql-woocommerce' );
+						$reason = __( 'Failed to apply coupon. Check for an individual-use coupon on cart.', 'graphql-for-ecommerce' );
 					}
 
 					$invalid_coupons[] = compact( 'code', 'reason' );

--- a/includes/mutation/class-cart-remove-coupons.php
+++ b/includes/mutation/class-cart-remove-coupons.php
@@ -43,7 +43,7 @@ class Cart_Remove_Coupons {
 			'codes' => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Code of coupon being applied', 'wp-graphql-woocommerce' );
+					return __( 'Code of coupon being applied', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -71,20 +71,20 @@ class Cart_Remove_Coupons {
 
 			// Retrieve product database ID if relay ID provided.
 			if ( empty( $input['codes'] ) ) {
-				throw new UserError( __( 'No coupon codes provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No coupon codes provided', 'graphql-for-ecommerce' ) );
 			}
 
 			foreach ( $input['codes'] as $code ) {
 
 				// Check if applied.
 				if ( ! \WC()->cart->has_discount( $code ) ) {
-					throw new UserError( __( 'This coupon has not been applied to the cart.', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'This coupon has not been applied to the cart.', 'graphql-for-ecommerce' ) );
 				}
 
 				// Get cart item for payload.
 				$success = \WC()->cart->remove_coupon( $code );
 				if ( true !== $success ) {
-					throw new UserError( __( 'Failed to remove coupon.', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'Failed to remove coupon.', 'graphql-for-ecommerce' ) );
 				}
 			}
 

--- a/includes/mutation/class-cart-remove-items.php
+++ b/includes/mutation/class-cart-remove-items.php
@@ -45,13 +45,13 @@ class Cart_Remove_Items {
 			'keys' => [
 				'type'        => [ 'list_of' => 'ID' ],
 				'description' => static function () {
-					return __( 'Item keys of the items being removed', 'wp-graphql-woocommerce' );
+					return __( 'Item keys of the items being removed', 'graphql-for-ecommerce' );
 				},
 			],
 			'all'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Remove all cart items', 'wp-graphql-woocommerce' );
+					return __( 'Remove all cart items', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -84,11 +84,11 @@ class Cart_Remove_Items {
 			Cart_Mutation::check_session_token();
 
 			if ( \WC()->cart->is_empty() ) {
-				throw new UserError( __( 'No items in cart to remove.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No items in cart to remove.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( empty( $input['keys'] ) && empty( $input['all'] ) ) {
-				throw new UserError( __( 'No cart item keys provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No cart item keys provided', 'graphql-for-ecommerce' ) );
 			}
 
 			$cart_items = Cart_Mutation::retrieve_cart_items( $input, $context, $info, 'remove' );
@@ -96,7 +96,7 @@ class Cart_Remove_Items {
 				$success = \WC()->cart->remove_cart_item( $item['key'] );
 				if ( false === $success ) {
 					/* translators: Cart item removal failure message */
-					throw new UserError( sprintf( __( 'Failed to remove item %s from cart.', 'wp-graphql-woocommerce' ), $item['key'] ) );
+					throw new UserError( sprintf( __( 'Failed to remove item %s from cart.', 'graphql-for-ecommerce' ), $item['key'] ) );
 				}
 			}
 

--- a/includes/mutation/class-cart-restore-items.php
+++ b/includes/mutation/class-cart-restore-items.php
@@ -45,7 +45,7 @@ class Cart_Restore_Items {
 			'keys' => [
 				'type'        => [ 'list_of' => 'ID' ],
 				'description' => static function () {
-					return __( 'Cart item key of the item being removed', 'wp-graphql-woocommerce' );
+					return __( 'Cart item key of the item being removed', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -70,7 +70,7 @@ class Cart_Restore_Items {
 			Cart_Mutation::check_session_token();
 
 			if ( empty( $input['keys'] ) ) {
-				throw new UserError( __( 'No cart item keys provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No cart item keys provided', 'graphql-for-ecommerce' ) );
 			}
 
 			// Restore cart items.
@@ -78,7 +78,7 @@ class Cart_Restore_Items {
 				$success = \WC()->cart->restore_cart_item( $key );
 				if ( false === $success ) {
 					/* translators: Cart item not found message */
-					throw new UserError( sprintf( __( 'Failed to restore cart item with the key: %s', 'wp-graphql-woocommerce' ), $key ) );
+					throw new UserError( sprintf( __( 'Failed to restore cart item with the key: %s', 'graphql-for-ecommerce' ), $key ) );
 				}
 			}
 

--- a/includes/mutation/class-cart-update-item-quantities.php
+++ b/includes/mutation/class-cart-update-item-quantities.php
@@ -46,7 +46,7 @@ class Cart_Update_Item_Quantities {
 			'items' => [
 				'type'        => [ 'list_of' => 'CartItemQuantityInput' ],
 				'description' => static function () {
-					return __( 'Cart item being updated', 'wp-graphql-woocommerce' );
+					return __( 'Cart item being updated', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -102,12 +102,12 @@ class Cart_Update_Item_Quantities {
 
 			// Confirm "items" exists.
 			if ( empty( $input['items'] ) ) {
-				throw new UserError( __( 'No item data provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No item data provided', 'graphql-for-ecommerce' ) );
 			}
 
 			// Confirm "items" is value.
 			if ( ! is_array( $input['items'] ) ) {
-				throw new UserError( __( 'Provided "items" invalid', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Provided "items" invalid', 'graphql-for-ecommerce' ) );
 			}
 
 			do_action( 'graphql_woocommerce_before_set_item_quantities', $input['items'], $input, $context, $info );
@@ -149,7 +149,7 @@ class Cart_Update_Item_Quantities {
 					throw new Exception(
 						sprintf(
 							/* translators: %s: Cart item keys */
-							__( 'Cart items identified with keys %s failed to update', 'wp-graphql-woocommerce' ),
+							__( 'Cart items identified with keys %s failed to update', 'graphql-for-ecommerce' ),
 							implode( ', ', $errors )
 						)
 					);

--- a/includes/mutation/class-cart-update-shipping-method.php
+++ b/includes/mutation/class-cart-update-shipping-method.php
@@ -67,7 +67,7 @@ class Cart_Update_Shipping_Method {
 			Cart_Mutation::check_session_token();
 
 			if ( empty( $input['shippingMethods'] ) ) {
-				throw new UserError( __( 'No shipping method provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No shipping method provided', 'graphql-for-ecommerce' ) );
 			}
 
 			$chosen_shipping_methods = Cart_Mutation::prepare_shipping_methods( $input['shippingMethods'] );

--- a/includes/mutation/class-checkout.php
+++ b/includes/mutation/class-checkout.php
@@ -114,7 +114,7 @@ class Checkout {
 			'createdVia'             => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Source of the order. Useful when WooCommerce is driven from multiple sources. Defaults to "checkout".', 'wp-graphql-woocommerce' );
+					return __( 'Source of the order. Useful when WooCommerce is driven from multiple sources. Defaults to "checkout".', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/mutation/class-checkout.php
+++ b/includes/mutation/class-checkout.php
@@ -48,67 +48,67 @@ class Checkout {
 			'paymentMethod'          => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Payment method ID.', 'wp-graphql-woocommerce' );
+					return __( 'Payment method ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingMethod'         => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Order shipping method', 'wp-graphql-woocommerce' );
+					return __( 'Order shipping method', 'graphql-for-ecommerce' );
 				},
 			],
 			'shipToDifferentAddress' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Ship to a separate address', 'wp-graphql-woocommerce' );
+					return __( 'Ship to a separate address', 'graphql-for-ecommerce' );
 				},
 			],
 			'billing'                => [
 				'type'        => 'CustomerAddressInput',
 				'description' => static function () {
-					return __( 'Order billing address', 'wp-graphql-woocommerce' );
+					return __( 'Order billing address', 'graphql-for-ecommerce' );
 				},
 			],
 			'shipping'               => [
 				'type'        => 'CustomerAddressInput',
 				'description' => static function () {
-					return __( 'Order shipping address', 'wp-graphql-woocommerce' );
+					return __( 'Order shipping address', 'graphql-for-ecommerce' );
 				},
 			],
 			'account'                => [
 				'type'        => 'CreateAccountInput',
 				'description' => static function () {
-					return __( 'Create new customer account', 'wp-graphql-woocommerce' );
+					return __( 'Create new customer account', 'graphql-for-ecommerce' );
 				},
 			],
 			'transactionId'          => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Order transaction ID', 'wp-graphql-woocommerce' );
+					return __( 'Order transaction ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'isPaid'                 => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'wp-graphql-woocommerce' );
+					return __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'graphql-for-ecommerce' );
 				},
 			],
 			'metaData'               => [
 				'type'        => [ 'list_of' => 'MetaDataInput' ],
 				'description' => static function () {
-					return __( 'Order meta data', 'wp-graphql-woocommerce' );
+					return __( 'Order meta data', 'graphql-for-ecommerce' );
 				},
 			],
 			'customerNote'           => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Order customer note', 'wp-graphql-woocommerce' );
+					return __( 'Order customer note', 'graphql-for-ecommerce' );
 				},
 			],
 			'fees'                   => [
 				'type'        => [ 'list_of' => 'FeeInput' ],
 				'description' => static function () {
-					return __( 'Fees to add to the order.', 'wp-graphql-woocommerce' );
+					return __( 'Fees to add to the order.', 'graphql-for-ecommerce' );
 				},
 			],
 			'createdVia'             => [
@@ -154,7 +154,7 @@ class Checkout {
 			'notices'  => [
 				'type'        => [ 'list_of' => 'CartNotice' ],
 				'description' => static function () {
-					return __( 'WooCommerce notices generated during checkout', 'wp-graphql-woocommerce' );
+					return __( 'WooCommerce notices generated during checkout', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					return $payload['notices'] ?? [];
@@ -193,7 +193,7 @@ class Checkout {
 				$order = \WC_Order_Factory::get_order( $order_id );
 
 				if ( ! is_object( $order ) ) {
-					throw new UserError( __( 'Failed to retrieve order after checkout', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'Failed to retrieve order after checkout', 'graphql-for-ecommerce' ) );
 				}//end if
 
 				// Capture any non-error notices for successful checkouts.

--- a/includes/mutation/class-coupon-create.php
+++ b/includes/mutation/class-coupon-create.php
@@ -47,121 +47,121 @@ class Coupon_Create {
 			'code'                      => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Coupon code.', 'wp-graphql-woocommerce' );
+					return __( 'Coupon code.', 'graphql-for-ecommerce' );
 				},
 			],
 			'amount'                    => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'The amount of discount. Should always be numeric, even if setting a percentage.', 'wp-graphql-woocommerce' );
+					return __( 'The amount of discount. Should always be numeric, even if setting a percentage.', 'graphql-for-ecommerce' );
 				},
 			],
 			'discountType'              => [
 				'type'        => 'DiscountTypeEnum',
 				'description' => static function () {
-					return __( 'Determines the type of discount that will be applied.', 'wp-graphql-woocommerce' );
+					return __( 'Determines the type of discount that will be applied.', 'graphql-for-ecommerce' );
 				},
 			],
 			'description'               => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Coupon description.', 'wp-graphql-woocommerce' );
+					return __( 'Coupon description.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateExpires'               => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'The date the coupon expires, in the site\'s timezone.', 'wp-graphql-woocommerce' );
+					return __( 'The date the coupon expires, in the site\'s timezone.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateExpiresGmt'            => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'The date the coupon expires, as GMT.', 'wp-graphql-woocommerce' );
+					return __( 'The date the coupon expires, as GMT.', 'graphql-for-ecommerce' );
 				},
 			],
 			'individualUse'             => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'If true, the coupon can only be used individually. Other applied coupons will be removed from the cart.', 'wp-graphql-woocommerce' );
+					return __( 'If true, the coupon can only be used individually. Other applied coupons will be removed from the cart.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productIds'                => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'List of product IDs the coupon can be used on.', 'wp-graphql-woocommerce' );
+					return __( 'List of product IDs the coupon can be used on.', 'graphql-for-ecommerce' );
 				},
 			],
 			'excludedProductIds'        => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'List of product IDs the coupon cannot be used on.', 'wp-graphql-woocommerce' );
+					return __( 'List of product IDs the coupon cannot be used on.', 'graphql-for-ecommerce' );
 				},
 			],
 			'usageLimit'                => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'How many times the coupon can be used in total.', 'wp-graphql-woocommerce' );
+					return __( 'How many times the coupon can be used in total.', 'graphql-for-ecommerce' );
 				},
 			],
 			'usageLimitPerUser'         => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'How many times the coupon can be used per customer.', 'wp-graphql-woocommerce' );
+					return __( 'How many times the coupon can be used per customer.', 'graphql-for-ecommerce' );
 				},
 			],
 			'limitUsageToXItems'        => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Max number of items in the cart the coupon can be applied to.', 'wp-graphql-woocommerce' );
+					return __( 'Max number of items in the cart the coupon can be applied to.', 'graphql-for-ecommerce' );
 				},
 			],
 			'freeShipping'              => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'If true and if the free shipping method requires a coupon, this coupon will enable free shipping.', 'wp-graphql-woocommerce' );
+					return __( 'If true and if the free shipping method requires a coupon, this coupon will enable free shipping.', 'graphql-for-ecommerce' );
 				},
 			],
 			'productCategories'         => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'List of category IDs the coupon applies to.', 'wp-graphql-woocommerce' );
+					return __( 'List of category IDs the coupon applies to.', 'graphql-for-ecommerce' );
 				},
 			],
 			'excludedProductCategories' => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'List of category IDs the coupon does not apply to.', 'wp-graphql-woocommerce' );
+					return __( 'List of category IDs the coupon does not apply to.', 'graphql-for-ecommerce' );
 				},
 			],
 			'excludeSaleItems'          => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'If true, this coupon will not be applied to items that have sale prices.', 'wp-graphql-woocommerce' );
+					return __( 'If true, this coupon will not be applied to items that have sale prices.', 'graphql-for-ecommerce' );
 				},
 			],
 			'minimumAmount'             => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Minimum order amount that needs to be in the cart before coupon applies.', 'wp-graphql-woocommerce' );
+					return __( 'Minimum order amount that needs to be in the cart before coupon applies.', 'graphql-for-ecommerce' );
 				},
 			],
 			'maximumAmount'             => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Maximum order amount allowed when using the coupon.', 'wp-graphql-woocommerce' );
+					return __( 'Maximum order amount allowed when using the coupon.', 'graphql-for-ecommerce' );
 				},
 			],
 			'emailRestrictions'         => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'List of email addresses that can use this coupon.', 'wp-graphql-woocommerce' );
+					return __( 'List of email addresses that can use this coupon.', 'graphql-for-ecommerce' );
 				},
 			],
 			'metaData'                  => [
 				'type'        => [ 'list_of' => 'MetaDataInput' ],
 				'description' => static function () {
-					return __( 'Meta data.', 'wp-graphql-woocommerce' );
+					return __( 'Meta data.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -210,17 +210,17 @@ class Coupon_Create {
 		}
 
 		if ( false === $coupon_id ) {
-			throw new UserError( __( 'Coupon ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Coupon ID provided is invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 		}
 
 		$coupon = new \WC_Coupon( $coupon_id );
 
 		if ( 0 === $coupon_id && ! wc_rest_check_post_permissions( 'shop_coupon', 'create' ) ) {
-			throw new UserError( __( 'Sorry, you are not allowed to create resources.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Sorry, you are not allowed to create resources.', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( 0 !== $coupon_id && ! wc_rest_check_post_permissions( 'shop_coupon', 'edit', $coupon_id ) ) {
-			throw new UserError( __( 'Sorry, you are not allowed to edit this resource.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Sorry, you are not allowed to edit this resource.', 'graphql-for-ecommerce' ) );
 		}
 
 		$coupon_args = Coupon_Mutation::prepare_args( $input );
@@ -233,7 +233,7 @@ class Coupon_Create {
 					$id_from_code = wc_get_coupon_id_by_code( $coupon_code, $id );
 
 					if ( $id_from_code ) {
-						throw new UserError( __( 'The coupon code already exists', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'The coupon code already exists', 'graphql-for-ecommerce' ) );
 					}
 
 					$coupon->set_code( $coupon_code );

--- a/includes/mutation/class-coupon-delete.php
+++ b/includes/mutation/class-coupon-delete.php
@@ -46,13 +46,13 @@ class Coupon_Delete {
 			'id'          => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Unique identifier for the object.', 'wp-graphql-woocommerce' );
+					return __( 'Unique identifier for the object.', 'graphql-for-ecommerce' );
 				},
 			],
 			'forceDelete' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Delete the object. Set to "false" by default.', 'wp-graphql-woocommerce' );
+					return __( 'Delete the object. Set to "false" by default.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -93,13 +93,13 @@ class Coupon_Delete {
 		// Retrieve order ID.
 		$coupon_id = Utils::get_database_id_from_id( $input['id'] );
 		if ( empty( $coupon_id ) ) {
-			throw new UserError( __( 'Coupon ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Coupon ID provided is missing or invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 		}
 
 		$coupon = new Coupon( $coupon_id );
 
 		if ( ! $coupon->ID ) {
-			throw new UserError( __( 'Invalid ID.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Invalid ID.', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( ! wc_rest_check_post_permissions( 'shop_coupon', 'delete', $coupon->ID ) ) {
@@ -112,7 +112,7 @@ class Coupon_Delete {
 			throw new UserError(
 				sprintf(
 					/* translators: %s: post type */
-					__( 'Sorry, you are not allowed to delete %s.', 'wp-graphql-woocommerce' ),
+					__( 'Sorry, you are not allowed to delete %s.', 'graphql-for-ecommerce' ),
 					lcfirst( $post_type_object->label )
 				)
 			);

--- a/includes/mutation/class-coupon-update.php
+++ b/includes/mutation/class-coupon-update.php
@@ -42,13 +42,13 @@ class Coupon_Update {
 				'id'   => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'Unique identifier for the object.', 'wp-graphql-woocommerce' );
+						return __( 'Unique identifier for the object.', 'graphql-for-ecommerce' );
 					},
 				],
 				'code' => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Coupon code.', 'wp-graphql-woocommerce' );
+						return __( 'Coupon code.', 'graphql-for-ecommerce' );
 					},
 				],
 			]

--- a/includes/mutation/class-customer-register.php
+++ b/includes/mutation/class-customer-register.php
@@ -50,31 +50,31 @@ class Customer_Register {
 				'billing'               => [
 					'type'        => 'CustomerAddressInput',
 					'description' => static function () {
-						return __( 'Customer billing information', 'wp-graphql-woocommerce' );
+						return __( 'Customer billing information', 'graphql-for-ecommerce' );
 					},
 				],
 				'shipping'              => [
 					'type'        => 'CustomerAddressInput',
 					'description' => static function () {
-						return __( 'Customer shipping address', 'wp-graphql-woocommerce' );
+						return __( 'Customer shipping address', 'graphql-for-ecommerce' );
 					},
 				],
 				'shippingSameAsBilling' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Customer shipping is identical to billing address', 'wp-graphql-woocommerce' );
+						return __( 'Customer shipping is identical to billing address', 'graphql-for-ecommerce' );
 					},
 				],
 				'metaData'              => [
 					'description' => static function () {
-						return __( 'Meta data.', 'wp-graphql-woocommerce' );
+						return __( 'Meta data.', 'graphql-for-ecommerce' );
 					},
 					'type'        => [ 'list_of' => 'MetaDataInput' ],
 				],
 				'authenticate'          => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Set the current user to the newly registered customer. Avoid using in GraphiQL or contexts where a nonce is sent, as it will cause nonce verification to fail.', 'wp-graphql-woocommerce' );
+						return __( 'Set the current user to the newly registered customer. Avoid using in GraphiQL or contexts where a nonce is sent, as it will cause nonce verification to fail.', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -118,7 +118,7 @@ class Customer_Register {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			// Validate input.
 			if ( empty( $input['email'] ) ) {
-				throw new UserError( __( 'Please provide a valid email address.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Please provide a valid email address.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Validate password input.
@@ -126,7 +126,7 @@ class Customer_Register {
 				throw new UserError(
 					__(
 						'A password was not provided and WooCommerce does not automatically generate one for you.',
-						'wp-graphql-woocommerce'
+						'graphql-for-ecommerce'
 					)
 				);
 			}
@@ -149,13 +149,13 @@ class Customer_Register {
 				}
 
 				throw new UserError(
-					__( 'Sorry, an unknown error occured while trying to register customer', 'wp-graphql-woocommerce' )
+					__( 'Sorry, an unknown error occured while trying to register customer', 'graphql-for-ecommerce' )
 				);
 			}
 
 			// If the $post_id is empty, we should throw an exception.
 			if ( empty( $user_id ) ) {
-				throw new UserError( __( 'The object failed to create', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'The object failed to create', 'graphql-for-ecommerce' ) );
 			}
 
 			// Update additional user data.

--- a/includes/mutation/class-customer-update.php
+++ b/includes/mutation/class-customer-update.php
@@ -49,37 +49,37 @@ class Customer_Update {
 				'id'                    => [
 					'type'        => 'ID',
 					'description' => static function () {
-						return __( 'The ID of the user', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the user', 'graphql-for-ecommerce' );
 					},
 				],
 				'billing'               => [
 					'type'        => 'CustomerAddressInput',
 					'description' => static function () {
-						return __( 'Customer billing information', 'wp-graphql-woocommerce' );
+						return __( 'Customer billing information', 'graphql-for-ecommerce' );
 					},
 				],
 				'shipping'              => [
 					'type'        => 'CustomerAddressInput',
 					'description' => static function () {
-						return __( 'Customer shipping address', 'wp-graphql-woocommerce' );
+						return __( 'Customer shipping address', 'graphql-for-ecommerce' );
 					},
 				],
 				'shippingSameAsBilling' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Customer shipping is identical to billing address', 'wp-graphql-woocommerce' );
+						return __( 'Customer shipping is identical to billing address', 'graphql-for-ecommerce' );
 					},
 				],
 				'metaData'              => [
 					'description' => static function () {
-						return __( 'Meta data.', 'wp-graphql-woocommerce' );
+						return __( 'Meta data.', 'graphql-for-ecommerce' );
 					},
 					'type'        => [ 'list_of' => 'MetaDataInput' ],
 				],
 				'isSession'             => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Whether to save changes on the session or in the database', 'wp-graphql-woocommerce' );
+						return __( 'Whether to save changes on the session or in the database', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -125,7 +125,7 @@ class Customer_Update {
 				$payload = $update_user( $input, $context, $info );
 
 				if ( empty( $payload ) ) {
-					throw new UserError( __( 'Failed to update customer.', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'Failed to update customer.', 'graphql-for-ecommerce' ) );
 				}
 			}
 

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -144,7 +144,7 @@ class Order_Create {
 			'createdVia'         => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Source of the order. Useful when WooCommerce is driven from multiple sources. Defaults to "graphql-api".', 'wp-graphql-woocommerce' );
+					return __( 'Source of the order. Useful when WooCommerce is driven from multiple sources. Defaults to "graphql-api".', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/mutation/class-order-create.php
+++ b/includes/mutation/class-order-create.php
@@ -48,97 +48,97 @@ class Order_Create {
 			'parentId'           => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Parent order ID.', 'wp-graphql-woocommerce' );
+					return __( 'Parent order ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'currency'           => [
 				'type'        => 'CurrencyEnum',
 				'description' => static function () {
-					return __( 'Currency the order was created with, in ISO format.', 'wp-graphql-woocommerce' );
+					return __( 'Currency the order was created with, in ISO format.', 'graphql-for-ecommerce' );
 				},
 			],
 			'customerId'         => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Order customer ID', 'wp-graphql-woocommerce' );
+					return __( 'Order customer ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'customerNote'       => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Note left by customer during checkout.', 'wp-graphql-woocommerce' );
+					return __( 'Note left by customer during checkout.', 'graphql-for-ecommerce' );
 				},
 			],
 			'coupons'            => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Coupons codes to be applied to order', 'wp-graphql-woocommerce' );
+					return __( 'Coupons codes to be applied to order', 'graphql-for-ecommerce' );
 				},
 			],
 			'status'             => [
 				'type'        => 'OrderStatusEnum',
 				'description' => static function () {
-					return __( 'Order status', 'wp-graphql-woocommerce' );
+					return __( 'Order status', 'graphql-for-ecommerce' );
 				},
 			],
 			'paymentMethod'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Payment method ID.', 'wp-graphql-woocommerce' );
+					return __( 'Payment method ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'paymentMethodTitle' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Payment method title.', 'wp-graphql-woocommerce' );
+					return __( 'Payment method title.', 'graphql-for-ecommerce' );
 				},
 			],
 			'transactionId'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Order transaction ID', 'wp-graphql-woocommerce' );
+					return __( 'Order transaction ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'billing'            => [
 				'type'        => 'CustomerAddressInput',
 				'description' => static function () {
-					return __( 'Order billing address', 'wp-graphql-woocommerce' );
+					return __( 'Order billing address', 'graphql-for-ecommerce' );
 				},
 			],
 			'shipping'           => [
 				'type'        => 'CustomerAddressInput',
 				'description' => static function () {
-					return __( 'Order shipping address', 'wp-graphql-woocommerce' );
+					return __( 'Order shipping address', 'graphql-for-ecommerce' );
 				},
 			],
 			'lineItems'          => [
 				'type'        => [ 'list_of' => 'LineItemInput' ],
 				'description' => static function () {
-					return __( 'Order line items', 'wp-graphql-woocommerce' );
+					return __( 'Order line items', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingLines'      => [
 				'type'        => [ 'list_of' => 'ShippingLineInput' ],
 				'description' => static function () {
-					return __( 'Order shipping lines', 'wp-graphql-woocommerce' );
+					return __( 'Order shipping lines', 'graphql-for-ecommerce' );
 				},
 			],
 			'feeLines'           => [
 				'type'        => [ 'list_of' => 'FeeLineInput' ],
 				'description' => static function () {
-					return __( 'Order shipping lines', 'wp-graphql-woocommerce' );
+					return __( 'Order shipping lines', 'graphql-for-ecommerce' );
 				},
 			],
 			'metaData'           => [
 				'type'        => [ 'list_of' => 'MetaDataInput' ],
 				'description' => static function () {
-					return __( 'Order meta data', 'wp-graphql-woocommerce' );
+					return __( 'Order meta data', 'graphql-for-ecommerce' );
 				},
 			],
 			'isPaid'             => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'wp-graphql-woocommerce' );
+					return __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'graphql-for-ecommerce' );
 				},
 			],
 			'createdVia'         => [
@@ -181,7 +181,7 @@ class Order_Create {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			// Check if authorized to create this order.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'create', null ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to create an order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to create an order.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Create order.
@@ -191,7 +191,7 @@ class Order_Create {
 				$order    = WC_Order_Factory::get_order( $order_id );
 
 				if ( ! is_object( $order ) ) {
-					throw new UserError( __( 'Order could not be created.', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'Order could not be created.', 'graphql-for-ecommerce' ) );
 				}
 
 				// Make sure gateways are loaded so hooks from gateways fire on save/create.
@@ -199,7 +199,7 @@ class Order_Create {
 
 				// Validate customer ID, if set.
 				if ( ! empty( $input['customerId'] ) && ! Order_Mutation::validate_customer( $input['customerId'] ) ) {
-					throw new UserError( __( 'Customer ID is invalid.', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'Customer ID is invalid.', 'graphql-for-ecommerce' ) );
 				}
 
 				// Set all props, address, items, and meta on the order and save once.

--- a/includes/mutation/class-order-delete-items.php
+++ b/includes/mutation/class-order-delete-items.php
@@ -48,20 +48,20 @@ class Order_Delete_Items {
 				'id'      => [
 					'type'        => 'ID',
 					'description' => static function () {
-						return __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' );
+						return __( 'Database ID or global ID of the order', 'graphql-for-ecommerce' );
 					},
 				],
 				'orderId' => [
 					'type'              => 'Int',
 					'description'       => static function () {
-						return __( 'Order WP ID', 'wp-graphql-woocommerce' );
+						return __( 'Order WP ID', 'graphql-for-ecommerce' );
 					},
-					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Use "id" field instead.', 'graphql-for-ecommerce' ),
 				],
 				'itemIds' => [
 					'type'        => [ 'list_of' => 'Int' ],
 					'description' => static function () {
-						return __( 'ID Order items being deleted', 'wp-graphql-woocommerce' );
+						return __( 'ID Order items being deleted', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -98,23 +98,23 @@ class Order_Delete_Items {
 			} elseif ( ! empty( $input['orderId'] ) ) {
 				$order_id = absint( $input['orderId'] );
 			} else {
-				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( ! $order_id ) {
-				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Check if authorized to delete items on this order.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'delete-items', $order_id ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to delete order items.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to delete order items.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Confirm item IDs.
 			if ( empty( $input['itemIds'] ) ) {
-				throw new UserError( __( 'No item IDs provided.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No item IDs provided.', 'graphql-for-ecommerce' ) );
 			} elseif ( ! is_array( $input['itemIds'] ) ) {
-				throw new UserError( __( 'The "itemIds" provided is invalid', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'The "itemIds" provided is invalid', 'graphql-for-ecommerce' ) );
 			}
 			$ids = $input['itemIds'];
 

--- a/includes/mutation/class-order-delete.php
+++ b/includes/mutation/class-order-delete.php
@@ -49,20 +49,20 @@ class Order_Delete {
 				'id'          => [
 					'type'        => 'ID',
 					'description' => static function () {
-						return __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' );
+						return __( 'Database ID or global ID of the order', 'graphql-for-ecommerce' );
 					},
 				],
 				'orderId'     => [
 					'type'              => 'Int',
 					'description'       => static function () {
-						return __( 'Order WP ID', 'wp-graphql-woocommerce' );
+						return __( 'Order WP ID', 'graphql-for-ecommerce' );
 					},
-					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Use "id" field instead.', 'graphql-for-ecommerce' ),
 				],
 				'forceDelete' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Delete or simply place in trash.', 'wp-graphql-woocommerce' );
+						return __( 'Delete or simply place in trash.', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -99,16 +99,16 @@ class Order_Delete {
 			} elseif ( ! empty( $input['orderId'] ) ) {
 				$order_id = absint( $input['orderId'] );
 			} else {
-				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( ! $order_id ) {
-				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Check if authorized to delete this order.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'delete', $order_id ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to delete an order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to delete an order.', 'graphql-for-ecommerce' ) );
 			}
 
 			$force_delete = false;
@@ -147,7 +147,7 @@ class Order_Delete {
 			$order_to_be_deleted = WC_Order_Factory::get_order( $order->get_id() );
 
 			if ( ! is_object( $order_to_be_deleted ) ) {
-				throw new UserError( __( 'Order to be deleted could not be found.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order to be deleted could not be found.', 'graphql-for-ecommerce' ) );
 			}
 
 			$success = Order_Mutation::purge( $order_to_be_deleted, $force_delete );
@@ -156,7 +156,7 @@ class Order_Delete {
 				throw new UserError(
 					sprintf(
 						/* translators: Deletion failed message */
-						__( 'Removal of Order %d failed', 'wp-graphql-woocommerce' ),
+						__( 'Removal of Order %d failed', 'graphql-for-ecommerce' ),
 						$order->get_id()
 					)
 				);

--- a/includes/mutation/class-order-note-create.php
+++ b/includes/mutation/class-order-note-create.php
@@ -48,19 +48,19 @@ class Order_Note_Create {
 			'orderId'        => [
 				'type'        => 'ID',
 				'description' => static function () {
-					return __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' );
+					return __( 'Database ID or global ID of the order', 'graphql-for-ecommerce' );
 				},
 			],
 			'note'           => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Order note.', 'wp-graphql-woocommerce' );
+					return __( 'Order note.', 'graphql-for-ecommerce' );
 				},
 			],
 			'isCustomerNote' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Shows/define if the note is only for reference or for the customer (the user will be notified).', 'wp-graphql-woocommerce' );
+					return __( 'Shows/define if the note is only for reference or for the customer (the user will be notified).', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -99,12 +99,12 @@ class Order_Note_Create {
 			$order_id = Utils::get_database_id_from_id( $input['orderId'] );
 
 			if ( ! $order_id ) {
-				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Check if authorized to create order notes.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'create', $order_id ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to create an order note.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to create an order note.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -115,12 +115,12 @@ class Order_Note_Create {
 			$order = new Order( $order_id );
 
 			if ( ! $order ) {
-				throw new UserError( __( 'Invalid order ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid order ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$note_content = ! empty( $input['note'] ) ? $input['note'] : '';
 			if ( empty( $note_content ) ) {
-				throw new UserError( __( 'Order note content is required.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order note content is required.', 'graphql-for-ecommerce' ) );
 			}
 
 			$is_customer_note = ! empty( $input['isCustomerNote'] ) ? $input['isCustomerNote'] : false;
@@ -129,14 +129,14 @@ class Order_Note_Create {
 			$note_id = $order->add_order_note( $note_content, $is_customer_note );
 
 			if ( ! $note_id ) {
-				throw new UserError( __( 'Unable to create order note.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Unable to create order note.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Get the created note.
 			$note = get_comment( $note_id );
 
 			if ( ! $note ) {
-				throw new UserError( __( 'Unable to retrieve created order note.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Unable to retrieve created order note.', 'graphql-for-ecommerce' ) );
 			}
 
 			return [

--- a/includes/mutation/class-order-note-delete.php
+++ b/includes/mutation/class-order-note-delete.php
@@ -48,19 +48,19 @@ class Order_Note_Delete {
 			'id'      => [
 				'type'        => 'ID',
 				'description' => static function () {
-					return __( 'Database ID or global ID of the order note', 'wp-graphql-woocommerce' );
+					return __( 'Database ID or global ID of the order note', 'graphql-for-ecommerce' );
 				},
 			],
 			'orderId' => [
 				'type'        => 'ID',
 				'description' => static function () {
-					return __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' );
+					return __( 'Database ID or global ID of the order', 'graphql-for-ecommerce' );
 				},
 			],
 			'force'   => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Delete or simply place in trash.', 'wp-graphql-woocommerce' );
+					return __( 'Delete or simply place in trash.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -99,16 +99,16 @@ class Order_Note_Delete {
 			$order_id = Utils::get_database_id_from_id( $input['orderId'] );
 
 			if ( ! $order_id ) {
-				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Check if authorized to delete this order note.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'delete', $order_id ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to delete an order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to delete an order.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( isset( $input['forceDelete'] ) && false === $input['forceDelete'] ) {
-				throw new UserError( __( 'woocommerce_rest_trash_not_supported', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'woocommerce_rest_trash_not_supported', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -119,25 +119,25 @@ class Order_Note_Delete {
 			$order = new Order( $order_id );
 
 			if ( ! $order ) {
-				throw new UserError( __( 'Invalid order ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid order ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$id = Utils::get_database_id_from_id( $input['id'] );
 			if ( ! $id ) {
-				throw new UserError( __( 'Order note ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order note ID provided is invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			$note = get_comment( $id );
 
 			if ( empty( $note ) || intval( $note->comment_post_ID ) !== intval( $order->get_id() ) ) {
-				throw new UserError( __( 'Invalid resource ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid resource ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$comment_id = absint( $note->comment_ID );
 			$result     = wc_delete_order_note( $comment_id );
 
 			if ( ! $result ) {
-				throw new UserError( __( 'Unable to delete order note.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Unable to delete order note.', 'graphql-for-ecommerce' ) );
 			}
 
 			return [

--- a/includes/mutation/class-order-update.php
+++ b/includes/mutation/class-order-update.php
@@ -50,20 +50,20 @@ class Order_Update {
 				'id'         => [
 					'type'        => 'ID',
 					'description' => static function () {
-						return __( 'Database ID or global ID of the order', 'wp-graphql-woocommerce' );
+						return __( 'Database ID or global ID of the order', 'graphql-for-ecommerce' );
 					},
 				],
 				'orderId'    => [
 					'type'              => 'Int',
 					'description'       => static function () {
-						return __( 'Order WP ID', 'wp-graphql-woocommerce' );
+						return __( 'Order WP ID', 'graphql-for-ecommerce' );
 					},
-					'deprecationReason' => __( 'Use "id" field instead.', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Use "id" field instead.', 'graphql-for-ecommerce' ),
 				],
 				'customerId' => [
 					'type'        => 'ID',
 					'description' => static function () {
-						return __( 'Database ID or global ID of the customer for the order', 'wp-graphql-woocommerce' );
+						return __( 'Database ID or global ID of the customer for the order', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -100,16 +100,16 @@ class Order_Update {
 			} elseif ( ! empty( $input['orderId'] ) ) {
 				$order_id = absint( $input['orderId'] );
 			} else {
-				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is missing or invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( ! $order_id ) {
-				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order ID provided is invalid. Please check input and try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Check if authorized to update this order.
 			if ( ! Order_Mutation::authorized( $input, $context, $info, 'update', $order_id ) ) {
-				throw new UserError( __( 'User does not have the capabilities necessary to update an order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'User does not have the capabilities necessary to update an order.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -125,7 +125,7 @@ class Order_Update {
 			$order = WC_Order_Factory::get_order( $order_id );
 
 			if ( ! is_object( $order ) || ! $order->get_id() ) {
-				throw new UserError( __( 'Order not found.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Order not found.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Make sure gateways are loaded so hooks from gateways fire on save/create.
@@ -133,7 +133,7 @@ class Order_Update {
 
 			// Validate customer ID.
 			if ( ! empty( $input['customerId'] ) && ! Order_Mutation::validate_customer( $input['customerId'] ) ) {
-				throw new UserError( __( 'New customer ID is invalid.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'New customer ID is invalid.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Set all props, address, items, and meta on the order and save once.

--- a/includes/mutation/class-payment-method-delete.php
+++ b/includes/mutation/class-payment-method-delete.php
@@ -43,7 +43,7 @@ class Payment_Method_Delete {
 			'tokenId' => [
 				'type'        => [ 'non_null' => 'Integer' ],
 				'description' => static function () {
-					return __( 'Token ID of the payment token being deleted.', 'wp-graphql-woocommerce' );
+					return __( 'Token ID of the payment token being deleted.', 'graphql-for-ecommerce' );
 				},
 
 			],
@@ -60,7 +60,7 @@ class Payment_Method_Delete {
 			'status' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Status of the request', 'wp-graphql-woocommerce' );
+					return __( 'Status of the request', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					return ! empty( $payload['status'] ) ? $payload['status'] : 'FAILED';
@@ -78,18 +78,18 @@ class Payment_Method_Delete {
 		return static function ( $input ) {
 			global $wp;
 			if ( ! is_user_logged_in() ) {
-				throw new UserError( __( 'Must be authenticated to set a default payment method', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Must be authenticated to set a default payment method', 'graphql-for-ecommerce' ) );
 			}
 
 			$token_id = $input['tokenId'];
 			$token    = WC_Payment_Tokens::get( $token_id );
 
 			if ( is_null( $token ) || get_current_user_id() !== $token->get_user_id() ) {
-				throw new UserError( __( 'Invalid payment method.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid payment method.', 'graphql-for-ecommerce' ) );
 			}
 
 			WC_Payment_Tokens::delete( $token_id );
-			wc_add_notice( __( 'Payment method deleted.', 'wp-graphql-woocommerce' ) );
+			wc_add_notice( __( 'Payment method deleted.', 'graphql-for-ecommerce' ) );
 
 			return [ 'status' => 'SUCCESS' ];
 		};

--- a/includes/mutation/class-payment-method-set-default.php
+++ b/includes/mutation/class-payment-method-set-default.php
@@ -43,7 +43,7 @@ class Payment_Method_Set_Default {
 			'tokenId' => [
 				'type'        => [ 'non_null' => 'Integer' ],
 				'description' => static function () {
-					return __( 'Token ID of the payment token being deleted.', 'wp-graphql-woocommerce' );
+					return __( 'Token ID of the payment token being deleted.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -59,7 +59,7 @@ class Payment_Method_Set_Default {
 			'status' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Status of the request', 'wp-graphql-woocommerce' );
+					return __( 'Status of the request', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					return ! empty( $payload['status'] ) ? $payload['status'] : 'FAILED';
@@ -68,7 +68,7 @@ class Payment_Method_Set_Default {
 			'token'  => [
 				'type'        => 'PaymentTokenInterface',
 				'description' => static function () {
-					return __( 'Preferred payment method token', 'wp-graphql-woocommerce' );
+					return __( 'Preferred payment method token', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					return ! empty( $payload['token'] ) ? $payload['token'] : null;
@@ -86,18 +86,18 @@ class Payment_Method_Set_Default {
 		return static function ( $input ) {
 			global $wp;
 			if ( ! is_user_logged_in() ) {
-				throw new UserError( __( 'Must be authenticated to set a default payment method', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Must be authenticated to set a default payment method', 'graphql-for-ecommerce' ) );
 			}
 
 			$token_id = $input['tokenId'];
 			$token    = WC_Payment_Tokens::get( $token_id );
 
 			if ( is_null( $token ) || get_current_user_id() !== $token->get_user_id() ) {
-				throw new UserError( __( 'Invalid payment method.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid payment method.', 'graphql-for-ecommerce' ) );
 			}
 
 			WC_Payment_Tokens::set_users_default( $token->get_user_id(), intval( $token_id ) );
-			wc_add_notice( __( 'This payment method was successfully set as your default.', 'wp-graphql-woocommerce' ) );
+			wc_add_notice( __( 'This payment method was successfully set as your default.', 'graphql-for-ecommerce' ) );
 
 			return [
 				'status' => 'SUCCESS',

--- a/includes/mutation/class-product-attribute-create.php
+++ b/includes/mutation/class-product-attribute-create.php
@@ -45,31 +45,31 @@ class Product_Attribute_Create {
 			'name'        => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Name of the attribute.', 'wp-graphql-woocommerce' );
+					return __( 'Name of the attribute.', 'graphql-for-ecommerce' );
 				},
 			],
 			'slug'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Slug of the attribute.', 'wp-graphql-woocommerce' );
+					return __( 'Slug of the attribute.', 'graphql-for-ecommerce' );
 				},
 			],
 			'type'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Type of the attribute.', 'wp-graphql-woocommerce' );
+					return __( 'Type of the attribute.', 'graphql-for-ecommerce' );
 				},
 			],
 			'orderBy'     => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Order by which the attribute should be sorted.', 'wp-graphql-woocommerce' );
+					return __( 'Order by which the attribute should be sorted.', 'graphql-for-ecommerce' );
 				},
 			],
 			'hasArchives' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the attribute has archives.', 'wp-graphql-woocommerce' );
+					return __( 'Whether the attribute has archives.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -99,7 +99,7 @@ class Product_Attribute_Create {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! wc_rest_check_manager_permissions( 'attributes', 'create' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create attributes.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you are not allowed to create attributes.', 'graphql-for-ecommerce' ) );
 			}
 
 			$attribute_id = wc_create_attribute(

--- a/includes/mutation/class-product-attribute-delete.php
+++ b/includes/mutation/class-product-attribute-delete.php
@@ -45,7 +45,7 @@ class Product_Attribute_Delete {
 			'id' => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Unique identifier for the product.', 'wp-graphql-woocommerce' );
+					return __( 'Unique identifier for the product.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -75,14 +75,14 @@ class Product_Attribute_Delete {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! wc_rest_check_manager_permissions( 'attributes', 'delete' ) ) {
-				throw new UserError( __( 'Sorry, you cannot delete attributes.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you cannot delete attributes.', 'graphql-for-ecommerce' ) );
 			}
 
 			$attribute = Product_Mutation::get_attribute( $input['id'] );
 			$deleted   = wc_delete_attribute( $attribute->attribute_id );
 
 			if ( false === $deleted ) {
-				throw new UserError( __( 'Failed to delete attribute.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to delete attribute.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-product-attribute-term-create.php
+++ b/includes/mutation/class-product-attribute-term-create.php
@@ -44,31 +44,31 @@ class Product_Attribute_Term_Create {
 			'attributeId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the attribute to which the term belongs.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the attribute to which the term belongs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'name'        => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'The name of the term.', 'wp-graphql-woocommerce' );
+					return __( 'The name of the term.', 'graphql-for-ecommerce' );
 				},
 			],
 			'slug'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'The slug of the term.', 'wp-graphql-woocommerce' );
+					return __( 'The slug of the term.', 'graphql-for-ecommerce' );
 				},
 			],
 			'description' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'The description of the term.', 'wp-graphql-woocommerce' );
+					return __( 'The description of the term.', 'graphql-for-ecommerce' );
 				},
 			],
 			'menuOrder'   => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'The order of the term in the menu.', 'wp-graphql-woocommerce' );
+					return __( 'The order of the term in the menu.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -104,17 +104,17 @@ class Product_Attribute_Term_Create {
 	 */
 	public static function mutate_and_get_payload( $input, AppContext $context, ResolveInfo $info ) {
 		if ( ! $input['attributeId'] ) {
-			throw new UserError( __( 'An attributeId is required to create a new product attribute term.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'An attributeId is required to create a new product attribute term.', 'graphql-for-ecommerce' ) );
 		}
 
 		$context  = 'createProductAttributeTerm' === $info->fieldName ? 'create' : 'edit';
 		$taxonomy = wc_attribute_taxonomy_name_by_id( $input['attributeId'] );
 		if ( empty( $taxonomy ) ) {
-			throw new UserError( __( 'Invalid attributeId.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Invalid attributeId.', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( ! wc_rest_check_product_term_permissions( $taxonomy, $context ) ) {
-			throw new UserError( __( 'Sorry, you are not allowed to create product attribute terms.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Sorry, you are not allowed to create product attribute terms.', 'graphql-for-ecommerce' ) );
 		}
 
 		$id   = isset( $input['id'] ) ? $input['id'] : null;
@@ -140,7 +140,7 @@ class Product_Attribute_Term_Create {
 		if ( is_wp_error( $term ) ) {
 			throw new UserError( $term->get_error_message() );
 		} elseif ( $term && ! wc_rest_check_product_term_permissions( $taxonomy, $context, $term->term_id ) ) {
-			throw new UserError( __( 'Sorry, you are not allowed to update this product attribute term.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Sorry, you are not allowed to update this product attribute term.', 'graphql-for-ecommerce' ) );
 		}
 
 		if ( $id ) {
@@ -152,8 +152,8 @@ class Product_Attribute_Term_Create {
 			$updating = 'updateProductAttributeTerm' === $info->fieldName;
 			throw new UserError(
 				$updating
-					? __( 'A name is required to create a new product attribute term.', 'wp-graphql-woocommerce' )
-					: __( 'A valid term "id" and changeable parameter are required to update a product attribute term.', 'wp-graphql-woocommerce' )
+					? __( 'A name is required to create a new product attribute term.', 'graphql-for-ecommerce' )
+					: __( 'A valid term "id" and changeable parameter are required to update a product attribute term.', 'graphql-for-ecommerce' )
 			);
 		}
 
@@ -168,7 +168,7 @@ class Product_Attribute_Term_Create {
 		 */
 		$term = get_term( $term['term_id'], $taxonomy );
 		if ( ! $term ) {
-			throw new UserError( __( 'Failed to retrieve term for modification. Please check input.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Failed to retrieve term for modification. Please check input.', 'graphql-for-ecommerce' ) );
 		} elseif ( is_wp_error( $term ) ) {
 			throw new UserError( $term->get_error_message() );
 		}

--- a/includes/mutation/class-product-attribute-term-delete.php
+++ b/includes/mutation/class-product-attribute-term-delete.php
@@ -44,13 +44,13 @@ class Product_Attribute_Term_Delete {
 			'attributeId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the attribute to which the term belongs.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the attribute to which the term belongs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'id'          => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the term to update.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the term to update.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -80,27 +80,27 @@ class Product_Attribute_Term_Delete {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! $input['attributeId'] ) {
-				throw new UserError( __( 'A valid attributeId is required to create a new product attribute term.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'A valid attributeId is required to create a new product attribute term.', 'graphql-for-ecommerce' ) );
 			}
 
 			$taxonomy = wc_attribute_taxonomy_name_by_id( $input['attributeId'] );
 			if ( empty( $taxonomy ) ) {
-				throw new UserError( __( 'Invalid attribute ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid attribute ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( ! $input['id'] ) {
-				throw new UserError( __( 'A valid term ID is required to delete a product attribute term.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'A valid term ID is required to delete a product attribute term.', 'graphql-for-ecommerce' ) );
 			}
 
 			$term = get_term( $input['id'], $taxonomy );
 			if ( ! $term ) {
-				throw new UserError( __( 'Invalid term ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid term ID.', 'graphql-for-ecommerce' ) );
 			} elseif ( is_wp_error( $term ) ) {
 				throw new UserError( $term->get_error_message() );
 			}
 
 			if ( ! wc_rest_check_product_term_permissions( $taxonomy, 'delete', $term->term_id ) ) {
-				throw new UserError( __( 'You do not have permission to delete this term.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'You do not have permission to delete this term.', 'graphql-for-ecommerce' ) );
 			}
 
 			$menu_order = get_term_meta( $term->term_id, 'order_' . $taxonomy, true );
@@ -116,7 +116,7 @@ class Product_Attribute_Term_Delete {
 
 			$retval = wp_delete_term( $term->term_id, $term->taxonomy );
 			if ( ! $retval ) {
-				throw new UserError( __( 'Failed to delete term.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to delete term.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-product-attribute-term-update.php
+++ b/includes/mutation/class-product-attribute-term-update.php
@@ -42,13 +42,13 @@ class Product_Attribute_Term_Update {
 				'id'   => [
 					'type'        => [ 'non_null' => 'Int' ],
 					'description' => static function () {
-						return __( 'The ID of the term to update.', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the term to update.', 'graphql-for-ecommerce' );
 					},
 				],
 				'name' => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'The name of the term.', 'wp-graphql-woocommerce' );
+						return __( 'The name of the term.', 'graphql-for-ecommerce' );
 					},
 				],
 			]

--- a/includes/mutation/class-product-attribute-update.php
+++ b/includes/mutation/class-product-attribute-update.php
@@ -46,7 +46,7 @@ class Product_Attribute_Update {
 				'id' => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'Unique identifier for the product.', 'wp-graphql-woocommerce' );
+						return __( 'Unique identifier for the product.', 'graphql-for-ecommerce' );
 					},
 				],
 			],
@@ -80,7 +80,7 @@ class Product_Attribute_Update {
 			global $wpdb;
 
 			if ( ! wc_rest_check_manager_permissions( 'attributes', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to edit attributes.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you are not allowed to edit attributes.', 'graphql-for-ecommerce' ) );
 			}
 
 			$id     = (int) $input['id'];

--- a/includes/mutation/class-product-category-create.php
+++ b/includes/mutation/class-product-category-create.php
@@ -45,19 +45,19 @@ class Product_Category_Create {
 			'display'   => [
 				'type'        => 'ProductCategoryDisplay',
 				'description' => static function () {
-					return __( 'Category archive display type.', 'wp-graphql-woocommerce' );
+					return __( 'Category archive display type.', 'graphql-for-ecommerce' );
 				},
 			],
 			'menuOrder' => [
 				'type'        => 'Integer',
 				'description' => static function () {
-					return __( 'Menu order, used to custom sort the category.', 'wp-graphql-woocommerce' );
+					return __( 'Menu order, used to custom sort the category.', 'graphql-for-ecommerce' );
 				},
 			],
 			'imageId'   => [
 				'type'        => 'ID',
 				'description' => static function () {
-					return __( 'The ID of an image attachment to associate with the category.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of an image attachment to associate with the category.', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/mutation/class-product-create.php
+++ b/includes/mutation/class-product-create.php
@@ -46,259 +46,259 @@ class Product_Create {
 			'name'              => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Name of the product.', 'wp-graphql-woocommerce' );
+					return __( 'Name of the product.', 'graphql-for-ecommerce' );
 				},
 			],
 			'slug'              => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product slug.', 'wp-graphql-woocommerce' );
+					return __( 'Product slug.', 'graphql-for-ecommerce' );
 				},
 			],
 			'type'              => [
 				'type'        => 'ProductTypesEnum',
 				'description' => static function () {
-					return __( 'Type of the product.', 'wp-graphql-woocommerce' );
+					return __( 'Type of the product.', 'graphql-for-ecommerce' );
 				},
 			],
 			'status'            => [
 				'type'        => 'PostStatusEnum',
 				'description' => static function () {
-					return __( 'Status of the product.', 'wp-graphql-woocommerce' );
+					return __( 'Status of the product.', 'graphql-for-ecommerce' );
 				},
 			],
 			'featured'          => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Featured product.', 'wp-graphql-woocommerce' );
+					return __( 'Featured product.', 'graphql-for-ecommerce' );
 				},
 			],
 			'catalogVisibility' => [
 				'type'        => 'CatalogVisibilityEnum',
 				'description' => static function () {
-					return __( 'Catalog visibility.', 'wp-graphql-woocommerce' );
+					return __( 'Catalog visibility.', 'graphql-for-ecommerce' );
 				},
 			],
 			'description'       => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product description.', 'wp-graphql-woocommerce' );
+					return __( 'Product description.', 'graphql-for-ecommerce' );
 				},
 			],
 			'shortDescription'  => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product short description.', 'wp-graphql-woocommerce' );
+					return __( 'Product short description.', 'graphql-for-ecommerce' );
 				},
 			],
 			'sku'               => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product SKU.', 'wp-graphql-woocommerce' );
+					return __( 'Product SKU.', 'graphql-for-ecommerce' );
 				},
 			],
 			'regularPrice'      => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Product regular price.', 'wp-graphql-woocommerce' );
+					return __( 'Product regular price.', 'graphql-for-ecommerce' );
 				},
 			],
 			'salePrice'         => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Product sale price.', 'wp-graphql-woocommerce' );
+					return __( 'Product sale price.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateOnSaleFrom'    => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product sale start date.', 'wp-graphql-woocommerce' );
+					return __( 'Product sale start date.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateOnSaleTo'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product sale end date.', 'wp-graphql-woocommerce' );
+					return __( 'Product sale end date.', 'graphql-for-ecommerce' );
 				},
 			],
 			'virtual'           => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Product virtual.', 'wp-graphql-woocommerce' );
+					return __( 'Product virtual.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadable'      => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Product downloadable.', 'wp-graphql-woocommerce' );
+					return __( 'Product downloadable.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloads'         => [
 				'type'        => [ 'list_of' => 'ProductDownloadInput' ],
 				'description' => static function () {
-					return __( 'Product downloads.', 'wp-graphql-woocommerce' );
+					return __( 'Product downloads.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadLimit'     => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Product download limit.', 'wp-graphql-woocommerce' );
+					return __( 'Product download limit.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadExpiry'    => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Number of days until download access expires.', 'wp-graphql-woocommerce' );
+					return __( 'Number of days until download access expires.', 'graphql-for-ecommerce' );
 				},
 			],
 			'externalUrl'       => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product external URL. (External products only)', 'wp-graphql-woocommerce' );
+					return __( 'Product external URL. (External products only)', 'graphql-for-ecommerce' );
 				},
 			],
 			'buttonText'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product button text. (External products only)', 'wp-graphql-woocommerce' );
+					return __( 'Product button text. (External products only)', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxStatus'         => [
 				'type'        => 'TaxStatusEnum',
 				'description' => static function () {
-					return __( 'Tax status.', 'wp-graphql-woocommerce' );
+					return __( 'Tax status.', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxClass'          => [
 				'type'        => 'TaxClassEnum',
 				'description' => static function () {
-					return __( 'Tax class.', 'wp-graphql-woocommerce' );
+					return __( 'Tax class.', 'graphql-for-ecommerce' );
 				},
 			],
 			'manageStock'       => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Manage stock.', 'wp-graphql-woocommerce' );
+					return __( 'Manage stock.', 'graphql-for-ecommerce' );
 				},
 			],
 			'stockQuantity'     => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Stock quantity.', 'wp-graphql-woocommerce' );
+					return __( 'Stock quantity.', 'graphql-for-ecommerce' );
 				},
 			],
 			'stockStatus'       => [
 				'type'        => 'StockStatusEnum',
 				'description' => static function () {
-					return __( 'Stock status.', 'wp-graphql-woocommerce' );
+					return __( 'Stock status.', 'graphql-for-ecommerce' );
 				},
 			],
 			'backorders'        => [
 				'type'        => 'BackordersEnum',
 				'description' => static function () {
-					return __( 'Backorders.', 'wp-graphql-woocommerce' );
+					return __( 'Backorders.', 'graphql-for-ecommerce' );
 				},
 			],
 			'soldIndividually'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Sold individually.', 'wp-graphql-woocommerce' );
+					return __( 'Sold individually.', 'graphql-for-ecommerce' );
 				},
 			],
 			'weight'            => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product weight.', 'wp-graphql-woocommerce' );
+					return __( 'Product weight.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dimensions'        => [
 				'type'        => 'ProductDimensionsInput',
 				'description' => static function () {
-					return __( 'Product dimensions.', 'wp-graphql-woocommerce' );
+					return __( 'Product dimensions.', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingClass'     => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Shipping class.', 'wp-graphql-woocommerce' );
+					return __( 'Shipping class.', 'graphql-for-ecommerce' );
 				},
 			],
 			'reviewsAllowed'    => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Allow reviews. Default is true', 'wp-graphql-woocommerce' );
+					return __( 'Allow reviews. Default is true', 'graphql-for-ecommerce' );
 				},
 			],
 			'upsellIds'         => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Upsell product IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Upsell product IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'crossSellIds'      => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Cross-sell product IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Cross-sell product IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'parentId'          => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Parent product ID.', 'wp-graphql-woocommerce' );
+					return __( 'Parent product ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'purchaseNote'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Purchase note.', 'wp-graphql-woocommerce' );
+					return __( 'Purchase note.', 'graphql-for-ecommerce' );
 				},
 			],
 			'categories'        => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product categories.', 'wp-graphql-woocommerce' );
+					return __( 'Product categories.', 'graphql-for-ecommerce' );
 				},
 			],
 			'tags'              => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product tags.', 'wp-graphql-woocommerce' );
+					return __( 'Product tags.', 'graphql-for-ecommerce' );
 				},
 			],
 			'images'            => [
 				'type'        => [ 'list_of' => 'ProductImageInput' ],
 				'description' => static function () {
-					return __( 'Product images.', 'wp-graphql-woocommerce' );
+					return __( 'Product images.', 'graphql-for-ecommerce' );
 				},
 			],
 			'attributes'        => [
 				'type'        => [ 'list_of' => 'ProductAttributesInput' ],
 				'description' => static function () {
-					return __( 'Product attributes.', 'wp-graphql-woocommerce' );
+					return __( 'Product attributes.', 'graphql-for-ecommerce' );
 				},
 			],
 			'defaultAttributes' => [
 				'type'        => [ 'list_of' => 'ProductAttributeInput' ],
 				'description' => static function () {
-					return __( 'Product default attributes.', 'wp-graphql-woocommerce' );
+					return __( 'Product default attributes.', 'graphql-for-ecommerce' );
 				},
 			],
 			'groupedProducts'   => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => static function () {
-					return __( 'Grouped product IDs.', 'wp-graphql-woocommerce' );
+					return __( 'Grouped product IDs.', 'graphql-for-ecommerce' );
 				},
 			],
 			'menuOrder'         => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Menu order.', 'wp-graphql-woocommerce' );
+					return __( 'Menu order.', 'graphql-for-ecommerce' );
 				},
 			],
 			'metaData'          => [
 				'type'        => [ 'list_of' => 'MetaDataInput' ],
 				'description' => static function () {
-					return __( 'Meta data.', 'wp-graphql-woocommerce' );
+					return __( 'Meta data.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -348,7 +348,7 @@ class Product_Create {
 			 */
 			$product = \wc_get_product( $product_id );
 			if ( $product && ! wc_rest_check_post_permissions( 'product', 'edit', $product->get_id() ) ) {
-				throw new UserError( __( 'You do not have permission to edit this product', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'You do not have permission to edit this product', 'graphql-for-ecommerce' ) );
 			}
 		} else {
 			$classname = \WC_Product_Factory::get_classname_from_product_type( $type );
@@ -366,7 +366,7 @@ class Product_Create {
 			 */
 			$post_type_object = get_post_type_object( 'product' );
 			if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
-				throw new UserError( __( 'You do not have permission to create products', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'You do not have permission to create products', 'graphql-for-ecommerce' ) );
 			}
 		}
 

--- a/includes/mutation/class-product-delete.php
+++ b/includes/mutation/class-product-delete.php
@@ -45,13 +45,13 @@ class Product_Delete {
 			'id'    => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Unique identifier for the product.', 'wp-graphql-woocommerce' );
+					return __( 'Unique identifier for the product.', 'graphql-for-ecommerce' );
 				},
 			],
 			'force' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether to bypass trash and force deletion.', 'wp-graphql-woocommerce' );
+					return __( 'Whether to bypass trash and force deletion.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -87,11 +87,11 @@ class Product_Delete {
 			$object = new Product( $product_id );
 
 			if ( 0 === $object->ID ) {
-				throw new UserError( __( 'Invalid product ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid product ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 'variation' === $object->get_type() ) {
-				throw new UserError( __( 'Variations cannot be deleted with this mutation. Use "deleteProductVariations" instead.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Variations cannot be deleted with this mutation. Use "deleteProductVariations" instead.', 'graphql-for-ecommerce' ) );
 			}
 
 			$supports_trash = EMPTY_TRASH_DAYS > 0 && is_callable( [ $object, 'get_status' ] );
@@ -107,7 +107,7 @@ class Product_Delete {
 			$supports_trash = apply_filters( 'graphql_woocommerce_product_object_trashable', $supports_trash, $object );
 
 			if ( ! wc_rest_check_post_permissions( 'product', 'delete', $object->ID ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete products', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you are not allowed to delete products', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -145,12 +145,12 @@ class Product_Delete {
 			} else {
 				// If we don't support trashing for this type, error out.
 				if ( ! $supports_trash ) {
-					throw new UserError( __( 'This product does not support trashing.', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'This product does not support trashing.', 'graphql-for-ecommerce' ) );
 				}
 
 				if ( is_callable( [ $product_to_be_deleted, 'get_status' ] ) ) {
 					if ( 'trash' === $product_to_be_deleted->get_status() ) {
-						throw new UserError( __( 'Product is already in the trash.', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'Product is already in the trash.', 'graphql-for-ecommerce' ) );
 					}
 
 					$product_to_be_deleted->delete();
@@ -164,7 +164,7 @@ class Product_Delete {
 			}
 
 			if ( ! $result ) {
-				throw new UserError( __( 'Failed to delete product.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to delete product.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 !== $product_to_be_deleted->get_parent_id() ) {

--- a/includes/mutation/class-product-update.php
+++ b/includes/mutation/class-product-update.php
@@ -44,13 +44,13 @@ class Product_Update {
 				'id'   => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'Unique identifier for the product.', 'wp-graphql-woocommerce' );
+						return __( 'Unique identifier for the product.', 'graphql-for-ecommerce' );
 					},
 				],
 				'name' => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Name of the product.', 'wp-graphql-woocommerce' );
+						return __( 'Name of the product.', 'graphql-for-ecommerce' );
 					},
 				],
 			]

--- a/includes/mutation/class-product-variation-create.php
+++ b/includes/mutation/class-product-variation-create.php
@@ -46,157 +46,157 @@ class Product_Variation_Create {
 			'productId'      => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Unique identifier for the product.', 'wp-graphql-woocommerce' );
+					return __( 'Unique identifier for the product.', 'graphql-for-ecommerce' );
 				},
 			],
 			'description'    => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Description of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Description of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'sku'            => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Unique identifier.', 'wp-graphql-woocommerce' );
+					return __( 'Unique identifier.', 'graphql-for-ecommerce' );
 				},
 			],
 			'regularPrice'   => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Regular price of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Regular price of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'salePrice'      => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Sale price of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Sale price of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateOnSaleFrom' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Start date of sale price.', 'wp-graphql-woocommerce' );
+					return __( 'Start date of sale price.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateOnSaleTo'   => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'End date of sale price.', 'wp-graphql-woocommerce' );
+					return __( 'End date of sale price.', 'graphql-for-ecommerce' );
 				},
 			],
 			'visible'        => [
 				'type'        => 'boolean',
 				'description' => static function () {
-					return __( 'Is product variation public?', 'wp-graphql-woocommerce' );
+					return __( 'Is product variation public?', 'graphql-for-ecommerce' );
 				},
 			],
 			'virtual'        => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the product variation is virtual.', 'wp-graphql-woocommerce' );
+					return __( 'Whether the product variation is virtual.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadable'   => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the product variation is downloadable.', 'wp-graphql-woocommerce' );
+					return __( 'Whether the product variation is downloadable.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloads'      => [
 				'type'        => [ 'list_of' => 'ProductDownloadInput' ],
 				'description' => static function () {
-					return __( 'Downloadable files.', 'wp-graphql-woocommerce' );
+					return __( 'Downloadable files.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadLimit'  => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Number of times downloadable files can be downloaded.', 'wp-graphql-woocommerce' );
+					return __( 'Number of times downloadable files can be downloaded.', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadExpiry' => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Number of days until the download expires.', 'wp-graphql-woocommerce' );
+					return __( 'Number of days until the download expires.', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxStatus'      => [
 				'type'        => 'TaxStatusEnum',
 				'description' => static function () {
-					return __( 'Tax status of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Tax status of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxClass'       => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Tax class of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Tax class of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'manageStock'    => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Whether to manage stock. Either "yes", "no", or "parent".', 'wp-graphql-woocommerce' );
+					return __( 'Whether to manage stock. Either "yes", "no", or "parent".', 'graphql-for-ecommerce' );
 				},
 			],
 			'stockQuantity'  => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Stock quantity.', 'wp-graphql-woocommerce' );
+					return __( 'Stock quantity.', 'graphql-for-ecommerce' );
 				},
 			],
 			'stockStatus'    => [
 				'type'        => 'StockStatusEnum',
 				'description' => static function () {
-					return __( 'Stock status of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Stock status of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'backorders'     => [
 				'type'        => 'BackordersEnum',
 				'description' => static function () {
-					return __( 'Backorder status.', 'wp-graphql-woocommerce' );
+					return __( 'Backorder status.', 'graphql-for-ecommerce' );
 				},
 			],
 			'weight'         => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Weight of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Weight of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'dimensions'     => [
 				'type'        => 'ProductDimensionsInput',
 				'description' => static function () {
-					return __( 'Dimensions of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Dimensions of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingClass'  => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Shipping class of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Shipping class of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'image'          => [
 				'type'        => 'ProductImageInput',
 				'description' => static function () {
-					return __( 'Image of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Image of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'attributes'     => [
 				'type'        => [ 'list_of' => 'ProductAttributeInput' ],
 				'description' => static function () {
-					return __( 'Attributes of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Attributes of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'menuOrder'      => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Menu order of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Menu order of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 			'metaData'       => [
 				'type'        => [ 'list_of' => 'MetaDataInput' ],
 				'description' => static function () {
-					return __( 'Meta data of the product variation.', 'wp-graphql-woocommerce' );
+					return __( 'Meta data of the product variation.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -342,7 +342,7 @@ class Product_Variation_Create {
 			$attributes = [];
 			$parent     = wc_get_product( $variation->get_parent_id() );
 			if ( ! $parent ) {
-				throw new UserError( __( 'Parent ID invalid', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Parent ID invalid', 'graphql-for-ecommerce' ) );
 			}
 			$parent_attributes = $parent->get_attributes();
 

--- a/includes/mutation/class-product-variation-delete.php
+++ b/includes/mutation/class-product-variation-delete.php
@@ -45,13 +45,13 @@ class Product_Variation_Delete {
 			'id'    => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Unique identifier for the product.', 'wp-graphql-woocommerce' );
+					return __( 'Unique identifier for the product.', 'graphql-for-ecommerce' );
 				},
 			],
 			'force' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether to bypass trash and force deletion.', 'wp-graphql-woocommerce' );
+					return __( 'Whether to bypass trash and force deletion.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -86,7 +86,7 @@ class Product_Variation_Delete {
 			$result       = false;
 
 			if ( 0 === $object->ID ) {
-				throw new UserError( __( 'Invalid product variation ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid product variation ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$supports_trash = EMPTY_TRASH_DAYS > 0 && is_callable( [ $object, 'get_status' ] );
@@ -102,7 +102,7 @@ class Product_Variation_Delete {
 			$supports_trash = apply_filters( 'graphql_woocommerce_product_variation_object_trashable', $supports_trash, $object );
 
 			if ( ! wc_rest_check_post_permissions( 'product_variation', 'delete', $object->ID ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete product variations', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you are not allowed to delete product variations', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -118,12 +118,12 @@ class Product_Variation_Delete {
 			} else {
 				// If we don't support trashing for this type, error out.
 				if ( ! $supports_trash ) {
-					throw new UserError( __( 'This product variation does not support trashing.', 'wp-graphql-woocommerce' ) );
+					throw new UserError( __( 'This product variation does not support trashing.', 'graphql-for-ecommerce' ) );
 				}
 
 				if ( is_callable( [ $variation_to_be_deleted, 'get_status' ] ) ) {
 					if ( 'trash' === $variation_to_be_deleted->get_status() ) {
-						throw new UserError( __( 'Product variation is already in the trash.', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'Product variation is already in the trash.', 'graphql-for-ecommerce' ) );
 					}
 
 					$variation_to_be_deleted->delete();
@@ -137,7 +137,7 @@ class Product_Variation_Delete {
 			}
 
 			if ( ! $result ) {
-				throw new UserError( __( 'Failed to delete product variation.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to delete product variation.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 !== $variation_to_be_deleted->get_parent_id() ) {

--- a/includes/mutation/class-product-variation-update.php
+++ b/includes/mutation/class-product-variation-update.php
@@ -43,7 +43,7 @@ class Product_Variation_Update {
 				'id' => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'Unique identifier for the product.', 'wp-graphql-woocommerce' );
+						return __( 'Unique identifier for the product.', 'graphql-for-ecommerce' );
 					},
 				],
 			],

--- a/includes/mutation/class-refund-create.php
+++ b/includes/mutation/class-refund-create.php
@@ -45,37 +45,37 @@ class Refund_Create {
 			'orderId'       => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the order to refund.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the order to refund.', 'graphql-for-ecommerce' );
 				},
 			],
 			'amount'        => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Refund amount.', 'wp-graphql-woocommerce' );
+					return __( 'Refund amount.', 'graphql-for-ecommerce' );
 				},
 			],
 			'reason'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Reason for refund.', 'wp-graphql-woocommerce' );
+					return __( 'Reason for refund.', 'graphql-for-ecommerce' );
 				},
 			],
 			'refundPayment' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'When true, the payment gateway API is used to generate the refund.', 'wp-graphql-woocommerce' );
+					return __( 'When true, the payment gateway API is used to generate the refund.', 'graphql-for-ecommerce' );
 				},
 			],
 			'restockItems'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'When true, refunded items are restocked.', 'wp-graphql-woocommerce' );
+					return __( 'When true, refunded items are restocked.', 'graphql-for-ecommerce' );
 				},
 			],
 			'metaData'      => [
 				'type'        => [ 'list_of' => 'MetaDataInput' ],
 				'description' => static function () {
-					return __( 'Meta data.', 'wp-graphql-woocommerce' );
+					return __( 'Meta data.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -114,16 +114,16 @@ class Refund_Create {
 			$order    = \wc_get_order( $order_id );
 
 			if ( ! $order ) {
-				throw new UserError( __( 'Invalid order ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid order ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( ! \wc_rest_check_post_permissions( 'shop_order', 'edit', $order_id ) ) {
-				throw new UserError( __( 'You do not have permission to create refunds for this order.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'You do not have permission to create refunds for this order.', 'graphql-for-ecommerce' ) );
 			}
 
 			$amount = floatval( $input['amount'] );
 			if ( 0 >= $amount ) {
-				throw new UserError( __( 'Refund amount must be greater than zero.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Refund amount must be greater than zero.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -151,7 +151,7 @@ class Refund_Create {
 			}
 
 			if ( ! $refund ) {
-				throw new UserError( __( 'Could not create refund, please try again.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Could not create refund, please try again.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Set meta data.

--- a/includes/mutation/class-refund-delete.php
+++ b/includes/mutation/class-refund-delete.php
@@ -45,13 +45,13 @@ class Refund_Delete {
 			'id'    => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'The ID of the refund to delete.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the refund to delete.', 'graphql-for-ecommerce' );
 				},
 			],
 			'force' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Force delete the refund. Defaults to true.', 'wp-graphql-woocommerce' );
+					return __( 'Force delete the refund. Defaults to true.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -89,18 +89,18 @@ class Refund_Delete {
 			$refund_id = \WPGraphQL\Utils\Utils::get_database_id_from_id( $input['id'] );
 
 			if ( empty( $refund_id ) ) {
-				throw new UserError( __( 'Invalid refund ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid refund ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			/** @var \WC_Order_Refund|false $refund */
 			$refund = \wc_get_order( $refund_id );
 			if ( ! $refund || 'shop_order_refund' !== $refund->get_type() ) {
-				throw new UserError( __( 'Invalid refund ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid refund ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$order_id = $refund->get_parent_id();
 			if ( ! \wc_rest_check_post_permissions( 'shop_order', 'delete', $order_id ) ) {
-				throw new UserError( __( 'You do not have permission to delete this refund.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'You do not have permission to delete this refund.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Capture refund data before deletion for the response.
@@ -121,7 +121,7 @@ class Refund_Delete {
 			$result = $refund->delete( $force );
 
 			if ( ! $result ) {
-				throw new UserError( __( 'Could not delete refund.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Could not delete refund.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-review-delete-restore.php
+++ b/includes/mutation/class-review-delete-restore.php
@@ -61,7 +61,7 @@ class Review_Delete_Restore {
 					'non_null' => 'ID',
 				],
 				'description' => static function () {
-					return __( 'The ID of the target product review', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the target product review', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -70,7 +70,7 @@ class Review_Delete_Restore {
 			$fields['forceDelete'] = [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the product review should be force deleted instead of being moved to the trash', 'wp-graphql-woocommerce' );
+					return __( 'Whether the product review should be force deleted instead of being moved to the trash', 'graphql-for-ecommerce' );
 				},
 			];
 		}
@@ -90,7 +90,7 @@ class Review_Delete_Restore {
 			'rating'     => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'The product rating of the affected product review', 'wp-graphql-woocommerce' );
+					return __( 'The product rating of the affected product review', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					if ( ! isset( $payload['rating'] ) ) {
@@ -103,7 +103,7 @@ class Review_Delete_Restore {
 			'affectedId' => [
 				'type'        => 'Id',
 				'description' => static function () {
-					return __( 'The affected product review ID', 'wp-graphql-woocommerce' );
+					return __( 'The affected product review ID', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					$deleted = (object) $payload['commentObject'];
@@ -114,7 +114,7 @@ class Review_Delete_Restore {
 			'review'     => [
 				'type'        => 'Comment',
 				'description' => static function () {
-					return __( 'The affected product review', 'wp-graphql-woocommerce' );
+					return __( 'The affected product review', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload, $args, AppContext $context ) use ( $restore ) {
 					if ( empty( $payload['commentObject'] ) ) {
@@ -143,7 +143,7 @@ class Review_Delete_Restore {
 			// Retrieve the product review rating for the payload.
 			$id = Utils::get_database_id_from_id( $input['id'] );
 			if ( ! $id ) {
-				throw new UserError( __( 'Invalid Product Review ID provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid Product Review ID provided', 'graphql-for-ecommerce' ) );
 			}
 
 			$rating = get_comment_meta( absint( $id ), 'rating', true );
@@ -159,7 +159,7 @@ class Review_Delete_Restore {
 			}
 
 			if ( empty( $classname ) || ! class_exists( $classname ) ) {
-				throw new UserError( __( 'Failed to find mutation resolver. Please contact site adminstrator', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to find mutation resolver. Please contact site adminstrator', 'graphql-for-ecommerce' ) );
 			}
 
 			// Get the comment mutation resolver.

--- a/includes/mutation/class-review-update.php
+++ b/includes/mutation/class-review-update.php
@@ -48,7 +48,7 @@ class Review_Update {
 				'id' => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'The ID of the review being updated.', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the review being updated.', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -84,7 +84,7 @@ class Review_Update {
 			$payload = [];
 			$id      = Utils::get_database_id_from_id( $input['id'] );
 			if ( ! $id ) {
-				throw new UserError( __( 'Provided review ID missing or invalid ', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Provided review ID missing or invalid ', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( array_intersect_key( $input, $skip ) !== $input ) {

--- a/includes/mutation/class-review-write.php
+++ b/includes/mutation/class-review-write.php
@@ -50,7 +50,7 @@ class Review_Write {
 				'rating' => [
 					'type'        => [ 'non_null' => 'Int' ],
 					'description' => static function () {
-						return __( 'Product rating', 'wp-graphql-woocommerce' );
+						return __( 'Product rating', 'graphql-for-ecommerce' );
 					},
 				],
 			]
@@ -67,7 +67,7 @@ class Review_Write {
 			'rating' => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'The product rating of the review that was created', 'wp-graphql-woocommerce' );
+					return __( 'The product rating of the review that was created', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
@@ -79,7 +79,7 @@ class Review_Write {
 			'review' => [
 				'type'        => 'Comment',
 				'description' => static function () {
-					return __( 'The product review that was created', 'wp-graphql-woocommerce' );
+					return __( 'The product review that was created', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {

--- a/includes/mutation/class-session-update.php
+++ b/includes/mutation/class-session-update.php
@@ -44,7 +44,7 @@ class Session_Update {
 			'sessionData' => [
 				'type'        => [ 'list_of' => 'MetaDataInput' ],
 				'description' => static function () {
-					return __( 'Data to be persisted in the session.', 'wp-graphql-woocommerce' );
+					return __( 'Data to be persisted in the session.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -99,7 +99,7 @@ class Session_Update {
 
 			// Guard against missing input.
 			if ( empty( $input['sessionData'] ) ) {
-				throw new UserError( __( 'No session data provided', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'No session data provided', 'graphql-for-ecommerce' ) );
 			}
 			$session_data_input = $input['sessionData'];
 

--- a/includes/mutation/class-setting-update.php
+++ b/includes/mutation/class-setting-update.php
@@ -43,19 +43,19 @@ class Setting_Update {
 			'group' => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Settings group ID.', 'wp-graphql-woocommerce' );
+					return __( 'Settings group ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'id'    => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Setting ID.', 'wp-graphql-woocommerce' );
+					return __( 'Setting ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'value' => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Setting value.', 'wp-graphql-woocommerce' );
+					return __( 'Setting value.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -71,7 +71,7 @@ class Setting_Update {
 			'setting' => [
 				'type'        => 'WCSetting',
 				'description' => static function () {
-					return __( 'The updated setting.', 'wp-graphql-woocommerce' );
+					return __( 'The updated setting.', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					return $payload['setting'];
@@ -88,7 +88,7 @@ class Setting_Update {
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you cannot update settings.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you cannot update settings.', 'graphql-for-ecommerce' ) );
 			}
 
 			$group_id   = $input['group'];

--- a/includes/mutation/class-settings-update.php
+++ b/includes/mutation/class-settings-update.php
@@ -42,13 +42,13 @@ class Settings_Update {
 			'group'    => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Settings group ID.', 'wp-graphql-woocommerce' );
+					return __( 'Settings group ID.', 'graphql-for-ecommerce' );
 				},
 			],
 			'settings' => [
 				'type'        => [ 'non_null' => [ 'list_of' => 'WCSettingInput' ] ],
 				'description' => static function () {
-					return __( 'Settings to update.', 'wp-graphql-woocommerce' );
+					return __( 'Settings to update.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -64,7 +64,7 @@ class Settings_Update {
 			'settings' => [
 				'type'        => [ 'list_of' => 'WCSetting' ],
 				'description' => static function () {
-					return __( 'The updated settings.', 'wp-graphql-woocommerce' );
+					return __( 'The updated settings.', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $payload ) {
 					return $payload['settings'];
@@ -81,7 +81,7 @@ class Settings_Update {
 	public static function mutate_and_get_payload() {
 		return static function ( $input ) {
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you cannot update settings.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Sorry, you cannot update settings.', 'graphql-for-ecommerce' ) );
 			}
 
 			$group_id   = $input['group'];

--- a/includes/mutation/class-shipping-zone-create.php
+++ b/includes/mutation/class-shipping-zone-create.php
@@ -44,13 +44,13 @@ class Shipping_Zone_Create {
 			'name'  => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Name of the shipping zone.', 'wp-graphql-woocommerce' );
+					return __( 'Name of the shipping zone.', 'graphql-for-ecommerce' );
 				},
 			],
 			'order' => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Order of the shipping zone.', 'wp-graphql-woocommerce' );
+					return __( 'Order of the shipping zone.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -80,11 +80,11 @@ class Shipping_Zone_Create {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create shipping zones.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to create shipping zones.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 
 			$zone = new \WC_Shipping_Zone( null );
@@ -105,7 +105,7 @@ class Shipping_Zone_Create {
 			$zone_id = $zone->save();
 
 			if ( 0 === $zone->get_id() ) {
-				throw new UserError( __( 'Failed to create shipping zone.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to create shipping zone.', 'graphql-for-ecommerce' ) );
 			}
 
 			return [ 'zone_id' => $zone_id ];

--- a/includes/mutation/class-shipping-zone-delete.php
+++ b/includes/mutation/class-shipping-zone-delete.php
@@ -44,7 +44,7 @@ class Shipping_Zone_Delete {
 			'id' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping zone to delete.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping zone to delete.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -74,11 +74,11 @@ class Shipping_Zone_Delete {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'delete' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete shipping zones', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to delete shipping zones', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 
 			$zone_id = $input['id'];
@@ -86,7 +86,7 @@ class Shipping_Zone_Delete {
 			$zone = \WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 			if ( false === $zone ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-shipping-zone-locations-clear.php
+++ b/includes/mutation/class-shipping-zone-locations-clear.php
@@ -44,13 +44,13 @@ class Shipping_Zone_Locations_Clear {
 			'zoneId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping zone to delete.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping zone to delete.', 'graphql-for-ecommerce' );
 				},
 			],
 			'type'   => [
 				'type'        => 'ShippingLocationTypeEnum',
 				'description' => static function () {
-					return __( 'The type of location to remove.', 'wp-graphql-woocommerce' );
+					return __( 'The type of location to remove.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -93,11 +93,11 @@ class Shipping_Zone_Locations_Clear {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'delete' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to remove shipping locations', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to remove shipping locations', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 
 			$zone_id = $input['zoneId'];
@@ -105,11 +105,11 @@ class Shipping_Zone_Locations_Clear {
 			$zone = \WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 			if ( false === $zone ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 === $zone->get_id() ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$types = [ 'postcode', 'state', 'country', 'continent' ];

--- a/includes/mutation/class-shipping-zone-locations-update.php
+++ b/includes/mutation/class-shipping-zone-locations-update.php
@@ -44,13 +44,13 @@ class Shipping_Zone_Locations_Update {
 			'zoneId'    => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping zone to delete.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping zone to delete.', 'graphql-for-ecommerce' );
 				},
 			],
 			'locations' => [
 				'type'        => [ 'list_of' => 'ShippingLocationInput' ],
 				'description' => static function () {
-					return __( 'The locations to add to the shipping zone.', 'wp-graphql-woocommerce' );
+					return __( 'The locations to add to the shipping zone.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -93,11 +93,11 @@ class Shipping_Zone_Locations_Update {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to update shipping location', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to update shipping location', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 
 			$zone_id = $input['zoneId'];
@@ -105,11 +105,11 @@ class Shipping_Zone_Locations_Update {
 			$zone = \WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 			if ( false === $zone ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 === $zone->get_id() ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$raw_locations = ! empty( $input['locations'] ) ? $input['locations'] : [];

--- a/includes/mutation/class-shipping-zone-method-add.php
+++ b/includes/mutation/class-shipping-zone-method-add.php
@@ -46,31 +46,31 @@ class Shipping_Zone_Method_Add {
 			'zoneId'   => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping zone to delete.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping zone to delete.', 'graphql-for-ecommerce' );
 				},
 			],
 			'methodId' => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping method to add.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping method to add.', 'graphql-for-ecommerce' );
 				},
 			],
 			'enabled'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the shipping method is enabled or not.', 'wp-graphql-woocommerce' );
+					return __( 'Whether the shipping method is enabled or not.', 'graphql-for-ecommerce' );
 				},
 			],
 			'order'    => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'The order of the shipping method.', 'wp-graphql-woocommerce' );
+					return __( 'The order of the shipping method.', 'graphql-for-ecommerce' );
 				},
 			],
 			'settings' => [
 				'type'        => [ 'list_of' => 'WCSettingInput' ],
 				'description' => static function () {
-					return __( 'The settings for the shipping method.', 'wp-graphql-woocommerce' );
+					return __( 'The settings for the shipping method.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -110,11 +110,11 @@ class Shipping_Zone_Method_Add {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to add shipping methods', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to add shipping methods', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 
 			$method_id = $input['methodId'];
@@ -123,11 +123,11 @@ class Shipping_Zone_Method_Add {
 			$zone = \WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 			if ( false === $zone ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 === $zone->get_id() ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$instance_id = $zone->add_shipping_method( $method_id );
@@ -141,7 +141,7 @@ class Shipping_Zone_Method_Add {
 			}
 
 			if ( false === $method ) {
-				throw new UserError( __( 'Failed to add shipping method to shipping zone.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to add shipping method to shipping zone.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Update settings.

--- a/includes/mutation/class-shipping-zone-method-remove.php
+++ b/includes/mutation/class-shipping-zone-method-remove.php
@@ -45,13 +45,13 @@ class Shipping_Zone_Method_Remove {
 			'zoneId'     => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping zone to delete.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping zone to delete.', 'graphql-for-ecommerce' );
 				},
 			],
 			'instanceId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Shipping method instance ID', 'wp-graphql-woocommerce' );
+					return __( 'Shipping method instance ID', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -91,11 +91,11 @@ class Shipping_Zone_Method_Remove {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'delete' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to remove shipping methods', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to remove shipping methods', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 
 			$instance_id = $input['instanceId'];
@@ -104,11 +104,11 @@ class Shipping_Zone_Method_Remove {
 			$zone = \WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 			if ( false === $zone ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 === $zone->get_id() ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$methods = $zone->get_shipping_methods();
@@ -122,7 +122,7 @@ class Shipping_Zone_Method_Remove {
 			}
 
 			if ( ! $method ) {
-				throw new UserError( __( 'Invalid shipping method instance ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping method instance ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-shipping-zone-method-update.php
+++ b/includes/mutation/class-shipping-zone-method-update.php
@@ -46,31 +46,31 @@ class Shipping_Zone_Method_Update {
 			'zoneId'     => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping zone to delete.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping zone to delete.', 'graphql-for-ecommerce' );
 				},
 			],
 			'instanceId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Shipping method instance ID', 'wp-graphql-woocommerce' );
+					return __( 'Shipping method instance ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'enabled'    => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the shipping method is enabled or not.', 'wp-graphql-woocommerce' );
+					return __( 'Whether the shipping method is enabled or not.', 'graphql-for-ecommerce' );
 				},
 			],
 			'order'      => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'The order of the shipping method.', 'wp-graphql-woocommerce' );
+					return __( 'The order of the shipping method.', 'graphql-for-ecommerce' );
 				},
 			],
 			'settings'   => [
 				'type'        => [ 'list_of' => 'WCSettingInput' ],
 				'description' => static function () {
-					return __( 'The settings for the shipping method.', 'wp-graphql-woocommerce' );
+					return __( 'The settings for the shipping method.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -110,11 +110,11 @@ class Shipping_Zone_Method_Update {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to edit shipping methods.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to edit shipping methods.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 			$instance_id = $input['instanceId'];
 			$zone_id     = $input['zoneId'];
@@ -122,11 +122,11 @@ class Shipping_Zone_Method_Update {
 			$zone = \WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 			if ( false === $zone ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 === $zone->get_id() ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$methods = $zone->get_shipping_methods();
@@ -140,7 +140,7 @@ class Shipping_Zone_Method_Update {
 			}
 
 			if ( ! $method ) {
-				throw new UserError( __( 'Invalid shipping method instance ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping method instance ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			// Update settings.

--- a/includes/mutation/class-shipping-zone-update.php
+++ b/includes/mutation/class-shipping-zone-update.php
@@ -44,19 +44,19 @@ class Shipping_Zone_Update {
 			'id'    => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the shipping zone to update.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the shipping zone to update.', 'graphql-for-ecommerce' );
 				},
 			],
 			'name'  => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Name of the shipping zone.', 'wp-graphql-woocommerce' );
+					return __( 'Name of the shipping zone.', 'graphql-for-ecommerce' );
 				},
 			],
 			'order' => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Order of the shipping zone.', 'wp-graphql-woocommerce' );
+					return __( 'Order of the shipping zone.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -86,11 +86,11 @@ class Shipping_Zone_Update {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_shipping_enabled() ) {
-				throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+				throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 			}
 
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to edit shipping zones', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to edit shipping zones', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 
 			$zone_id = $input['id'];
@@ -98,11 +98,11 @@ class Shipping_Zone_Update {
 			$zone = \WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 			if ( false === $zone ) {
-				throw new UserError( __( 'Invalid shipping zone ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid shipping zone ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			if ( 0 === $zone->get_id() ) {
-				throw new UserError( __( 'The "locations not covered by your other zones" zone cannot be updated.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'The "locations not covered by your other zones" zone cannot be updated.', 'graphql-for-ecommerce' ) );
 			}
 
 			$zone_changed = false;

--- a/includes/mutation/class-tax-class-create.php
+++ b/includes/mutation/class-tax-class-create.php
@@ -44,13 +44,13 @@ class Tax_Class_Create {
 			'name' => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Name of the tax class.', 'wp-graphql-woocommerce' );
+					return __( 'Name of the tax class.', 'graphql-for-ecommerce' );
 				},
 			],
 			'slug' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Slug of the tax class.', 'wp-graphql-woocommerce' );
+					return __( 'Slug of the tax class.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -80,7 +80,7 @@ class Tax_Class_Create {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'create' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to create tax classes.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to create tax classes.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 			$name = $input['name'];
 			$slug = ! empty( $input['slug'] ) ? $input['slug'] : '';

--- a/includes/mutation/class-tax-class-delete.php
+++ b/includes/mutation/class-tax-class-delete.php
@@ -44,7 +44,7 @@ class Tax_Class_Delete {
 			'slug' => [
 				'type'        => [ 'non_null' => 'String' ],
 				'description' => static function () {
-					return __( 'Slug of the tax class.', 'wp-graphql-woocommerce' );
+					return __( 'Slug of the tax class.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -74,14 +74,14 @@ class Tax_Class_Delete {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'delete' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete tax classes.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to delete tax classes.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 			$slug = $input['slug'];
 
 			/** @var array|false $tax_class */
 			$tax_class = \WC_Tax::get_tax_class_by( 'slug', $slug );
 			if ( ! $tax_class ) {
-				throw new UserError( __( 'Invalid tax class slug.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid tax class slug.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -94,7 +94,7 @@ class Tax_Class_Delete {
 
 			$deleted = \WC_Tax::delete_tax_class_by( 'slug', $slug );
 			if ( ! $deleted ) {
-				throw new UserError( __( 'Failed to delete tax class.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to delete tax class.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-tax-rate-create.php
+++ b/includes/mutation/class-tax-rate-create.php
@@ -45,67 +45,67 @@ class Tax_Rate_Create {
 			'country'   => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Country code for the tax rate.', 'wp-graphql-woocommerce' );
+					return __( 'Country code for the tax rate.', 'graphql-for-ecommerce' );
 				},
 			],
 			'state'     => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'State code for the tax rate.', 'wp-graphql-woocommerce' );
+					return __( 'State code for the tax rate.', 'graphql-for-ecommerce' );
 				},
 			],
 			'postcodes' => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Postcodes for the tax rate.', 'wp-graphql-woocommerce' );
+					return __( 'Postcodes for the tax rate.', 'graphql-for-ecommerce' );
 				},
 			],
 			'cities'    => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Cities for the tax rate.', 'wp-graphql-woocommerce' );
+					return __( 'Cities for the tax rate.', 'graphql-for-ecommerce' );
 				},
 			],
 			'rate'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Tax rate.', 'wp-graphql-woocommerce' );
+					return __( 'Tax rate.', 'graphql-for-ecommerce' );
 				},
 			],
 			'name'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Tax rate name.', 'wp-graphql-woocommerce' );
+					return __( 'Tax rate name.', 'graphql-for-ecommerce' );
 				},
 			],
 			'priority'  => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Tax rate priority.', 'wp-graphql-woocommerce' );
+					return __( 'Tax rate priority.', 'graphql-for-ecommerce' );
 				},
 			],
 			'compound'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the tax rate is compound.', 'wp-graphql-woocommerce' );
+					return __( 'Whether the tax rate is compound.', 'graphql-for-ecommerce' );
 				},
 			],
 			'shipping'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Whether the tax rate is applied to shipping.', 'wp-graphql-woocommerce' );
+					return __( 'Whether the tax rate is applied to shipping.', 'graphql-for-ecommerce' );
 				},
 			],
 			'order'     => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Tax rate order.', 'wp-graphql-woocommerce' );
+					return __( 'Tax rate order.', 'graphql-for-ecommerce' );
 				},
 			],
 			'class'     => [
 				'type'        => 'TaxClassEnum',
 				'description' => static function () {
-					return __( 'Tax rate class.', 'wp-graphql-woocommerce' );
+					return __( 'Tax rate class.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -142,7 +142,7 @@ class Tax_Rate_Create {
 	public static function mutate_and_get_payload( $input, AppContext $context, ResolveInfo $info ) {
 		$id = ! empty( $input['id'] ) ? Utils::get_database_id_from_id( $input['id'] ) : null;
 		if ( false === $id ) {
-			throw new UserError( __( 'Invalid ID provided.', 'wp-graphql-woocommerce' ) );
+			throw new UserError( __( 'Invalid ID provided.', 'graphql-for-ecommerce' ) );
 		}
 		$action     = ! $id ? 'create' : 'update';
 		$permission = ! $id ? 'create' : 'edit';
@@ -150,7 +150,7 @@ class Tax_Rate_Create {
 			throw new UserError(
 				sprintf(
 					/* translators: %s: permission */
-					__( 'Sorry, you are not allowed to %s tax rates.', 'wp-graphql-woocommerce' ),
+					__( 'Sorry, you are not allowed to %s tax rates.', 'graphql-for-ecommerce' ),
 					$permission
 				),
 				\rest_authorization_required_code()

--- a/includes/mutation/class-tax-rate-delete.php
+++ b/includes/mutation/class-tax-rate-delete.php
@@ -45,7 +45,7 @@ class Tax_Rate_Delete {
 			'id' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'The ID of the tax rate to update.', 'wp-graphql-woocommerce' );
+					return __( 'The ID of the tax rate to update.', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -75,17 +75,17 @@ class Tax_Rate_Delete {
 	public static function mutate_and_get_payload() {
 		return static function ( $input, AppContext $context, ResolveInfo $info ) {
 			if ( ! \wc_rest_check_manager_permissions( 'settings', 'delete' ) ) {
-				throw new UserError( __( 'Sorry, you are not allowed to delete tax rates.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+				throw new UserError( __( 'Sorry, you are not allowed to delete tax rates.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 			}
 			global $wpdb;
 			$id = Utils::get_database_id_from_id( $input['id'] );
 			if ( ! $id ) {
-				throw new UserError( __( 'Invalid tax rate ID.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Invalid tax rate ID.', 'graphql-for-ecommerce' ) );
 			}
 
 			$tax = $context->get_loader( 'tax_rate' )->load( $id );
 			if ( ! $tax ) {
-				throw new UserError( __( 'Failed to locate tax rate', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to locate tax rate', 'graphql-for-ecommerce' ) );
 			}
 
 			/**
@@ -98,7 +98,7 @@ class Tax_Rate_Delete {
 
 			\WC_Tax::_delete_tax_rate( $id );
 			if ( 0 === $wpdb->rows_affected ) {
-				throw new UserError( __( 'Failed to delete tax rate.', 'wp-graphql-woocommerce' ) );
+				throw new UserError( __( 'Failed to delete tax rate.', 'graphql-for-ecommerce' ) );
 			}
 
 			/**

--- a/includes/mutation/class-tax-rate-update.php
+++ b/includes/mutation/class-tax-rate-update.php
@@ -44,7 +44,7 @@ class Tax_Rate_Update {
 				'id' => [
 					'type'        => [ 'non_null' => 'Int' ],
 					'description' => static function () {
-						return __( 'The ID of the tax rate to update.', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the tax rate to update.', 'graphql-for-ecommerce' );
 					},
 				],
 			]

--- a/includes/type/enum/class-attribute-operator-enum.php
+++ b/includes/type/enum/class-attribute-operator-enum.php
@@ -22,7 +22,7 @@ class Attribute_Operator_Enum {
 			'AttributeOperatorEnum',
 			[
 				'description' => static function () {
-					return __( 'Collection statistic attributes operators', 'wp-graphql-woocommerce' );
+					return __( 'Collection statistic attributes operators', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'IN'     => [ 'value' => 'IN' ],

--- a/includes/type/enum/class-backorders.php
+++ b/includes/type/enum/class-backorders.php
@@ -28,7 +28,7 @@ class Backorders {
 			'BackordersEnum',
 			[
 				'description' => static function () {
-					return __( 'Product backorder enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product backorder enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-cart-error-type.php
+++ b/includes/type/enum/class-cart-error-type.php
@@ -29,7 +29,7 @@ class Cart_Error_Type {
 			'CartErrorType',
 			[
 				'description' => static function () {
-					return __( 'Cart error type enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Cart error type enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-cart-notice-type.php
+++ b/includes/type/enum/class-cart-notice-type.php
@@ -22,25 +22,25 @@ class Cart_Notice_Type {
 			'CartNoticeTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'WooCommerce notice types', 'wp-graphql-woocommerce' );
+					return __( 'WooCommerce notice types', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'ERROR'   => [
 						'value'       => 'error',
 						'description' => static function () {
-							return __( 'Error notice', 'wp-graphql-woocommerce' );
+							return __( 'Error notice', 'graphql-for-ecommerce' );
 						},
 					],
 					'SUCCESS' => [
 						'value'       => 'success',
 						'description' => static function () {
-							return __( 'Success notice', 'wp-graphql-woocommerce' );
+							return __( 'Success notice', 'graphql-for-ecommerce' );
 						},
 					],
 					'NOTICE'  => [
 						'value'       => 'notice',
 						'description' => static function () {
-							return __( 'General notice', 'wp-graphql-woocommerce' );
+							return __( 'General notice', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/enum/class-catalog-visibility.php
+++ b/includes/type/enum/class-catalog-visibility.php
@@ -29,7 +29,7 @@ class Catalog_Visibility {
 			'CatalogVisibilityEnum',
 			[
 				'description' => static function () {
-					return __( 'Product catalog visibility enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product catalog visibility enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-countries.php
+++ b/includes/type/enum/class-countries.php
@@ -31,7 +31,7 @@ class Countries {
 			'CountriesEnum',
 			[
 				'description' => static function () {
-					return __( 'Countries enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Countries enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $countries,
 			]

--- a/includes/type/enum/class-currency-enum.php
+++ b/includes/type/enum/class-currency-enum.php
@@ -34,7 +34,7 @@ class Currency_Enum {
 			'CurrencyEnum',
 			[
 				'description' => static function () {
-					return __( 'Currencies enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Currencies enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $currencies,
 			]

--- a/includes/type/enum/class-customer-connection-orderby-enum.php
+++ b/includes/type/enum/class-customer-connection-orderby-enum.php
@@ -22,43 +22,43 @@ class Customer_Connection_Orderby_Enum {
 			'CustomerConnectionOrderbyEnum',
 			[
 				'description' => static function () {
-					return __( 'Field to order the connection by', 'wp-graphql-woocommerce' );
+					return __( 'Field to order the connection by', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'ID'              => [
 						'value'       => 'ID',
 						'description' => static function () {
-							return __( 'Order by customer ID', 'wp-graphql-woocommerce' );
+							return __( 'Order by customer ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'INCLUDE'         => [
 						'value'       => 'include',
 						'description' => static function () {
-							return __( 'Order by include field', 'wp-graphql-woocommerce' );
+							return __( 'Order by include field', 'graphql-for-ecommerce' );
 						},
 					],
 					'NAME'            => [
 						'value'       => 'display_name',
 						'description' => static function () {
-							return __( 'Order by customer display name', 'wp-graphql-woocommerce' );
+							return __( 'Order by customer display name', 'graphql-for-ecommerce' );
 						},
 					],
 					'USERNAME'        => [
 						'value'       => 'username',
 						'description' => static function () {
-							return __( 'Order by customer username', 'wp-graphql-woocommerce' );
+							return __( 'Order by customer username', 'graphql-for-ecommerce' );
 						},
 					],
 					'EMAIL'           => [
 						'value'       => 'email',
 						'description' => static function () {
-							return __( 'Order by customer email', 'wp-graphql-woocommerce' );
+							return __( 'Order by customer email', 'graphql-for-ecommerce' );
 						},
 					],
 					'REGISTERED_DATE' => [
 						'value'       => 'registered',
 						'description' => static function () {
-							return __( 'Order by customer registration date', 'wp-graphql-woocommerce' );
+							return __( 'Order by customer registration date', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/enum/class-discount-type.php
+++ b/includes/type/enum/class-discount-type.php
@@ -27,7 +27,7 @@ class Discount_Type {
 			'DiscountTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'Coupon discount type enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Coupon discount type enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-id-type-enums.php
+++ b/includes/type/enum/class-id-type-enums.php
@@ -23,7 +23,7 @@ class Id_Type_Enums {
 			'CouponIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single Coupon. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single Coupon. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -32,7 +32,7 @@ class Id_Type_Enums {
 						'name'        => 'CODE',
 						'value'       => 'code',
 						'description' => static function () {
-							return __( 'Coupon code.', 'wp-graphql-woocommerce' );
+							return __( 'Coupon code.', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -43,7 +43,7 @@ class Id_Type_Enums {
 			'OrderIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single Order. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single Order. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -52,7 +52,7 @@ class Id_Type_Enums {
 						'name'        => 'ORDER_KEY',
 						'value'       => 'order_key',
 						'description' => static function () {
-							return __( 'Order key.', 'wp-graphql-woocommerce' );
+							return __( 'Order key.', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -63,7 +63,7 @@ class Id_Type_Enums {
 			'ProductIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single Product. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single Product. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -73,7 +73,7 @@ class Id_Type_Enums {
 						'name'        => 'SKU',
 						'value'       => 'sku',
 						'description' => static function () {
-							return __( 'Unique store identifier for product.', 'wp-graphql-woocommerce' );
+							return __( 'Unique store identifier for product.', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -84,7 +84,7 @@ class Id_Type_Enums {
 			'ProductVariationIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single ProductVariation. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single ProductVariation. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -97,7 +97,7 @@ class Id_Type_Enums {
 			'RefundIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single Refund. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single Refund. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -110,7 +110,7 @@ class Id_Type_Enums {
 			'ShippingMethodIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single Shipping Method. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single Shipping Method. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -123,7 +123,7 @@ class Id_Type_Enums {
 			'ShippingZoneIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single Shipping Zone. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single Shipping Zone. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -136,7 +136,7 @@ class Id_Type_Enums {
 			'TaxRateIdTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'The Type of Identifier used to fetch a single Tax rate. Default is ID.', 'wp-graphql-woocommerce' );
+					return __( 'The Type of Identifier used to fetch a single Tax rate. Default is ID.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'id'          => self::get_value( 'id' ),
@@ -161,7 +161,7 @@ class Id_Type_Enums {
 					'description' => static function () {
 						return __(
 							'Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier.',
-							'wp-graphql-woocommerce'
+							'graphql-for-ecommerce'
 						);
 					},
 				];
@@ -170,7 +170,7 @@ class Id_Type_Enums {
 					'name'        => 'DATABASE_ID',
 					'value'       => 'database_id',
 					'description' => static function () {
-						return __( 'Identify a resource by the Database ID.', 'wp-graphql-woocommerce' );
+						return __( 'Identify a resource by the Database ID.', 'graphql-for-ecommerce' );
 					},
 				];
 			case 'uri':
@@ -178,7 +178,7 @@ class Id_Type_Enums {
 					'name'        => 'URI',
 					'value'       => 'uri',
 					'description' => static function () {
-						return __( 'Identify a resource by the URI.', 'wp-graphql-woocommerce' );
+						return __( 'Identify a resource by the URI.', 'graphql-for-ecommerce' );
 					},
 				];
 			case 'id':
@@ -187,7 +187,7 @@ class Id_Type_Enums {
 					'name'        => 'ID',
 					'value'       => 'global_id',
 					'description' => static function () {
-						return __( 'Identify a resource by the (hashed) Global ID.', 'wp-graphql-woocommerce' );
+						return __( 'Identify a resource by the (hashed) Global ID.', 'graphql-for-ecommerce' );
 					},
 				];
 		}//end switch

--- a/includes/type/enum/class-manage-stock.php
+++ b/includes/type/enum/class-manage-stock.php
@@ -28,7 +28,7 @@ class Manage_Stock {
 			'ManageStockEnum',
 			[
 				'description' => static function () {
-					return __( 'Product manage stock enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product manage stock enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-order-status.php
+++ b/includes/type/enum/class-order-status.php
@@ -32,7 +32,7 @@ class Order_Status {
 			'OrderStatusEnum',
 			[
 				'description' => static function () {
-					return __( 'Order status enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Order status enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-orders-orderby-enum.php
+++ b/includes/type/enum/class-orders-orderby-enum.php
@@ -33,37 +33,37 @@ class Orders_Orderby_Enum extends Post_Type_Orderby_Enum {
 					'ORDER_KEY'      => [
 						'value'       => '_order_key',
 						'description' => static function () {
-							return __( 'Order by order key', 'wp-graphql-woocommerce' );
+							return __( 'Order by order key', 'graphql-for-ecommerce' );
 						},
 					],
 					'DISCOUNT'       => [
 						'value'       => '_cart_discount',
 						'description' => static function () {
-							return __( 'Order by order discount amount', 'wp-graphql-woocommerce' );
+							return __( 'Order by order discount amount', 'graphql-for-ecommerce' );
 						},
 					],
 					'TOTAL'          => [
 						'value'       => '_order_total',
 						'description' => static function () {
-							return __( 'Order by order total', 'wp-graphql-woocommerce' );
+							return __( 'Order by order total', 'graphql-for-ecommerce' );
 						},
 					],
 					'TAX'            => [
 						'value'       => '_order_tax',
 						'description' => static function () {
-							return __( 'Order by order total', 'wp-graphql-woocommerce' );
+							return __( 'Order by order total', 'graphql-for-ecommerce' );
 						},
 					],
 					'DATE_PAID'      => [
 						'value'       => '_date_paid',
 						'description' => static function () {
-							return __( 'Order by date the order was paid', 'wp-graphql-woocommerce' );
+							return __( 'Order by date the order was paid', 'graphql-for-ecommerce' );
 						},
 					],
 					'DATE_COMPLETED' => [
 						'value'       => '_date_completed',
 						'description' => static function () {
-							return __( 'Order by date the order was completed', 'wp-graphql-woocommerce' );
+							return __( 'Order by date the order was completed', 'graphql-for-ecommerce' );
 						},
 					],
 				]

--- a/includes/type/enum/class-post-type-orderby-enum.php
+++ b/includes/type/enum/class-post-type-orderby-enum.php
@@ -30,49 +30,49 @@ class Post_Type_Orderby_Enum {
 			'NAME'       => [
 				'value'       => 'post_title',
 				'description' => static function () {
-					return __( 'Order by name', 'wp-graphql-woocommerce' );
+					return __( 'Order by name', 'graphql-for-ecommerce' );
 				},
 			],
 			'SLUG'       => [
 				'value'       => 'post_name',
 				'description' => static function () {
-					return __( 'Order by slug', 'wp-graphql-woocommerce' );
+					return __( 'Order by slug', 'graphql-for-ecommerce' );
 				},
 			],
 			'MODIFIED'   => [
 				'value'       => 'post_modified',
 				'description' => static function () {
-					return __( 'Order by last modified date', 'wp-graphql-woocommerce' );
+					return __( 'Order by last modified date', 'graphql-for-ecommerce' );
 				},
 			],
 			'DATE'       => [
 				'value'       => 'post_date',
 				'description' => static function () {
-					return __( 'Order by publish date', 'wp-graphql-woocommerce' );
+					return __( 'Order by publish date', 'graphql-for-ecommerce' );
 				},
 			],
 			'PARENT'     => [
 				'value'       => 'post_parent',
 				'description' => static function () {
-					return __( 'Order by parent ID', 'wp-graphql-woocommerce' );
+					return __( 'Order by parent ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'IN'         => [
 				'value'       => 'post__in',
 				'description' => static function () {
-					return __( 'Preserve the ID order given in the IN array', 'wp-graphql-woocommerce' );
+					return __( 'Preserve the ID order given in the IN array', 'graphql-for-ecommerce' );
 				},
 			],
 			'NAME_IN'    => [
 				'value'       => 'post_name__in',
 				'description' => static function () {
-					return __( 'Preserve slug order given in the NAME_IN array', 'wp-graphql-woocommerce' );
+					return __( 'Preserve slug order given in the NAME_IN array', 'graphql-for-ecommerce' );
 				},
 			],
 			'MENU_ORDER' => [
 				'value'       => 'menu_order',
 				'description' => static function () {
-					return __( 'Order by the menu order value', 'wp-graphql-woocommerce' );
+					return __( 'Order by the menu order value', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -99,7 +99,7 @@ class Post_Type_Orderby_Enum {
 			[
 				'description' => static function () use ( $name ) {
 					/* translators: ordering enumeration description */
-					return sprintf( __( 'Fields to order the %s connection by', 'wp-graphql-woocommerce' ), $name );
+					return sprintf( __( 'Fields to order the %s connection by', 'graphql-for-ecommerce' ), $name );
 				},
 				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 				'values'      => apply_filters( "{$name}_orderby_enum_values", static::values() ),

--- a/includes/type/enum/class-pricing-field-format.php
+++ b/includes/type/enum/class-pricing-field-format.php
@@ -27,7 +27,7 @@ class Pricing_Field_Format {
 			'PricingFieldFormatEnum',
 			[
 				'description' => static function () {
-					return __( 'Pricing field format enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Pricing field format enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-product-attribute-enum.php
+++ b/includes/type/enum/class-product-attribute-enum.php
@@ -44,7 +44,7 @@ class Product_Attribute_Enum {
 			'ProductAttributeEnum',
 			[
 				'description' => static function () {
-					return __( 'Product attribute taxonomies', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute taxonomies', 'graphql-for-ecommerce' );
 				},
 				'values'      => $taxonomy_values,
 			]

--- a/includes/type/enum/class-product-attribute-types.php
+++ b/includes/type/enum/class-product-attribute-types.php
@@ -22,19 +22,19 @@ class Product_Attribute_Types {
 			'ProductAttributeTypesEnum',
 			[
 				'description' => static function () {
-					return __( 'Product attribute type enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute type enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'LOCAL'  => [
 						'value'       => 'local',
 						'description' => static function () {
-							return __( 'A local product attribute', 'wp-graphql-woocommerce' );
+							return __( 'A local product attribute', 'graphql-for-ecommerce' );
 						},
 					],
 					'GLOBAL' => [
 						'value'       => 'global',
 						'description' => static function () {
-							return __( 'A global product attribute', 'wp-graphql-woocommerce' );
+							return __( 'A global product attribute', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/enum/class-product-attributes-connection-orderby-enum.php
+++ b/includes/type/enum/class-product-attributes-connection-orderby-enum.php
@@ -22,55 +22,55 @@ class Product_Attributes_Connection_Orderby_Enum {
 			'ProductAttributesConnectionOrderbyEnum',
 			[
 				'description' => static function () {
-					return __( 'Product attributes connection orderby enum', 'wp-graphql-woocommerce' );
+					return __( 'Product attributes connection orderby enum', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'NAME'        => [
 						'value'       => 'name',
 						'description' => static function () {
-							return __( 'Order the connection by name.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by name.', 'graphql-for-ecommerce' );
 						},
 					],
 					'SLUG'        => [
 						'value'       => 'slug',
 						'description' => static function () {
-							return __( 'Order the connection by slug.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by slug.', 'graphql-for-ecommerce' );
 						},
 					],
 					'TERM_GROUP'  => [
 						'value'       => 'term_group',
 						'description' => static function () {
-							return __( 'Order the connection by term group.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by term group.', 'graphql-for-ecommerce' );
 						},
 					],
 					'TERM_ID'     => [
 						'value'       => 'term_id',
 						'description' => static function () {
-							return __( 'Order the connection by term id.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by term id.', 'graphql-for-ecommerce' );
 						},
 					],
 					'TERM_ORDER'  => [
 						'value'       => 'term_order',
 						'description' => static function () {
-							return __( 'Order the connection by term order.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by term order.', 'graphql-for-ecommerce' );
 						},
 					],
 					'MENU_ORDER'  => [
 						'value'       => 'menu_order',
 						'description' => static function () {
-							return __( 'Order the connection by woocommerce menu order.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by woocommerce menu order.', 'graphql-for-ecommerce' );
 						},
 					],
 					'DESCRIPTION' => [
 						'value'       => 'description',
 						'description' => static function () {
-							return __( 'Order the connection by description.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by description.', 'graphql-for-ecommerce' );
 						},
 					],
 					'COUNT'       => [
 						'value'       => 'count',
 						'description' => static function () {
-							return __( 'Order the connection by item count.', 'wp-graphql-woocommerce' );
+							return __( 'Order the connection by item count.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/enum/class-product-category-display.php
+++ b/includes/type/enum/class-product-category-display.php
@@ -22,31 +22,31 @@ class Product_Category_Display {
 			'ProductCategoryDisplay',
 			[
 				'description' => static function () {
-					return __( 'Product category display type enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product category display type enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'DEFAULT'       => [
 						'value'       => 'default',
 						'description' => static function () {
-							return __( 'Display default content connected to this category.', 'wp-graphql-woocommerce' );
+							return __( 'Display default content connected to this category.', 'graphql-for-ecommerce' );
 						},
 					],
 					'PRODUCTS'      => [
 						'value'       => 'products',
 						'description' => static function () {
-							return __( 'Display products associated with this category.', 'wp-graphql-woocommerce' );
+							return __( 'Display products associated with this category.', 'graphql-for-ecommerce' );
 						},
 					],
 					'SUBCATEGORIES' => [
 						'value'       => 'subcategories',
 						'description' => static function () {
-							return __( 'Display subcategories of this category.', 'wp-graphql-woocommerce' );
+							return __( 'Display subcategories of this category.', 'graphql-for-ecommerce' );
 						},
 					],
 					'BOTH'          => [
 						'value'       => 'both',
 						'description' => static function () {
-							return __( 'Display both products and subcategories of this category.', 'wp-graphql-woocommerce' );
+							return __( 'Display both products and subcategories of this category.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/enum/class-product-taxonomy.php
+++ b/includes/type/enum/class-product-taxonomy.php
@@ -40,7 +40,7 @@ class Product_Taxonomy {
 			'ProductTaxonomyEnum',
 			[
 				'description' => static function () {
-					return __( 'Product taxonomies', 'wp-graphql-woocommerce' );
+					return __( 'Product taxonomies', 'graphql-for-ecommerce' );
 				},
 				'values'      => $taxonomy_values,
 			]

--- a/includes/type/enum/class-product-types.php
+++ b/includes/type/enum/class-product-types.php
@@ -24,31 +24,31 @@ class Product_Types {
 				'SIMPLE'    => [
 					'value'       => 'simple',
 					'description' => static function () {
-						return __( 'A simple product', 'wp-graphql-woocommerce' );
+						return __( 'A simple product', 'graphql-for-ecommerce' );
 					},
 				],
 				'GROUPED'   => [
 					'value'       => 'grouped',
 					'description' => static function () {
-						return __( 'A product group', 'wp-graphql-woocommerce' );
+						return __( 'A product group', 'graphql-for-ecommerce' );
 					},
 				],
 				'EXTERNAL'  => [
 					'value'       => 'external',
 					'description' => static function () {
-						return __( 'An external product', 'wp-graphql-woocommerce' );
+						return __( 'An external product', 'graphql-for-ecommerce' );
 					},
 				],
 				'VARIABLE'  => [
 					'value'       => 'variable',
 					'description' => static function () {
-						return __( 'A variable product', 'wp-graphql-woocommerce' );
+						return __( 'A variable product', 'graphql-for-ecommerce' );
 					},
 				],
 				'VARIATION' => [
 					'value'       => 'variation',
 					'description' => static function () {
-						return __( 'A product variation', 'wp-graphql-woocommerce' );
+						return __( 'A product variation', 'graphql-for-ecommerce' );
 					},
 				],
 
@@ -59,7 +59,7 @@ class Product_Types {
 			$values['UNSUPPORTED'] = [
 				'value'       => 'unsupported',
 				'description' => static function () {
-					return __( 'An unsupported product', 'wp-graphql-woocommerce' );
+					return __( 'An unsupported product', 'graphql-for-ecommerce' );
 				},
 			];
 		}
@@ -68,7 +68,7 @@ class Product_Types {
 			'ProductTypesEnum',
 			[
 				'description' => static function () {
-					return __( 'Product type enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product type enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]
@@ -78,7 +78,7 @@ class Product_Types {
 			'ProductTypesWithVariationsEnum',
 			[
 				'description' => static function () {
-					return __( 'Product type enumeration including variation types', 'wp-graphql-woocommerce' );
+					return __( 'Product type enumeration including variation types', 'graphql-for-ecommerce' );
 				},
 				'values'      => apply_filters(
 					'graphql_product_types_with_variations_enum_values',
@@ -88,7 +88,7 @@ class Product_Types {
 							'VARIATION' => [
 								'value'       => 'variation',
 								'description' => static function () {
-									return __( 'A product variation', 'wp-graphql-woocommerce' );
+									return __( 'A product variation', 'graphql-for-ecommerce' );
 								},
 							],
 						]

--- a/includes/type/enum/class-products-orderby-enum.php
+++ b/includes/type/enum/class-products-orderby-enum.php
@@ -33,61 +33,61 @@ class Products_Orderby_Enum extends Post_Type_Orderby_Enum {
 					'PRICE'         => [
 						'value'       => 'price',
 						'description' => static function () {
-							return __( 'Order by product\'s current price', 'wp-graphql-woocommerce' );
+							return __( 'Order by product\'s current price', 'graphql-for-ecommerce' );
 						},
 					],
 					'REGULAR_PRICE' => [
 						'value'             => 'price',
 						'description'       => static function () {
-							return __( 'Order by product\'s regular price', 'wp-graphql-woocommerce' );
+							return __( 'Order by product\'s regular price', 'graphql-for-ecommerce' );
 						},
-						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version. Use "PRICE" instead.', 'wp-graphql-woocommerce' ),
+						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version. Use "PRICE" instead.', 'graphql-for-ecommerce' ),
 					],
 					'SALE_PRICE'    => [
 						'value'             => 'price',
 						'description'       => static function () {
-							return __( 'Order by product\'s sale price', 'wp-graphql-woocommerce' );
+							return __( 'Order by product\'s sale price', 'graphql-for-ecommerce' );
 						},
-						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version. Use "PRICE" instead.', 'wp-graphql-woocommerce' ),
+						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version. Use "PRICE" instead.', 'graphql-for-ecommerce' ),
 					],
 					'POPULARITY'    => [
 						'value'       => 'popularity',
 						'description' => static function () {
-							return __( 'Order by product popularity', 'wp-graphql-woocommerce' );
+							return __( 'Order by product popularity', 'graphql-for-ecommerce' );
 						},
 					],
 					'REVIEW_COUNT'  => [
 						'value'       => 'comment_count',
 						'description' => static function () {
-							return __( 'Order by number of reviews on product', 'wp-graphql-woocommerce' );
+							return __( 'Order by number of reviews on product', 'graphql-for-ecommerce' );
 						},
 					],
 					'RATING'        => [
 						'value'       => 'rating',
 						'description' => static function () {
-							return __( 'Order by product average rating', 'wp-graphql-woocommerce' );
+							return __( 'Order by product average rating', 'graphql-for-ecommerce' );
 						},
 					],
 					'ON_SALE_FROM'  => [
 						'value'             => 'date',
 						'description'       => static function () {
-							return __( 'Order by date product sale starts', 'wp-graphql-woocommerce' );
+							return __( 'Order by date product sale starts', 'graphql-for-ecommerce' );
 						},
-						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version.', 'wp-graphql-woocommerce' ),
+						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version.', 'graphql-for-ecommerce' ),
 					],
 					'ON_SALE_TO'    => [
 						'value'             => 'date',
 						'description'       => static function () {
-							return __( 'Order by date product sale ends', 'wp-graphql-woocommerce' );
+							return __( 'Order by date product sale ends', 'graphql-for-ecommerce' );
 						},
-						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version.', 'wp-graphql-woocommerce' ),
+						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version.', 'graphql-for-ecommerce' ),
 					],
 					'TOTAL_SALES'   => [
 						'value'             => 'popularity',
 						'description'       => static function () {
-							return __( 'Order by total sales of products sold', 'wp-graphql-woocommerce' );
+							return __( 'Order by total sales of products sold', 'graphql-for-ecommerce' );
 						},
-						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version. Use "POPULARITY" instead', 'wp-graphql-woocommerce' ),
+						'deprecationReason' => __( 'This field is deprecated and will be removed in a future version. Use "POPULARITY" instead', 'graphql-for-ecommerce' ),
 					],
 				]
 			)

--- a/includes/type/enum/class-shipping-location-type-enum.php
+++ b/includes/type/enum/class-shipping-location-type-enum.php
@@ -22,7 +22,7 @@ class Shipping_Location_Type_Enum {
 			'ShippingLocationTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'A Shipping zone location type.', 'wp-graphql-woocommerce' );
+					return __( 'A Shipping zone location type.', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'COUNTRY'   => [ 'value' => 'country' ],

--- a/includes/type/enum/class-stock-status.php
+++ b/includes/type/enum/class-stock-status.php
@@ -22,7 +22,7 @@ class Stock_Status {
 			'StockStatusEnum',
 			[
 				'description' => static function () {
-					return __( 'Product stock status enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product stock status enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => self::get_stock_statuses(),
 			]

--- a/includes/type/enum/class-tax-class.php
+++ b/includes/type/enum/class-tax-class.php
@@ -24,13 +24,13 @@ class Tax_Class {
 			'INHERIT_CART' => [
 				'value'       => 'inherit',
 				'description' => static function () {
-					return __( 'Inherits Tax class from cart', 'wp-graphql-woocommerce' );
+					return __( 'Inherits Tax class from cart', 'graphql-for-ecommerce' );
 				},
 			],
 			'STANDARD'     => [
 				'value'       => '',
 				'description' => static function () {
-					return __( 'Standard Tax rate', 'wp-graphql-woocommerce' );
+					return __( 'Standard Tax rate', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -48,7 +48,7 @@ class Tax_Class {
 			'TaxClassEnum',
 			[
 				'description' => static function () {
-					return __( 'Tax class enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Tax class enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/enum/class-tax-rate-connection-orderby-enum.php
+++ b/includes/type/enum/class-tax-rate-connection-orderby-enum.php
@@ -22,7 +22,7 @@ class Tax_Rate_Connection_Orderby_Enum {
 			'TaxRateConnectionOrderbyEnum',
 			[
 				'description' => static function () {
-					return __( 'Field to order the connection by', 'wp-graphql-woocommerce' );
+					return __( 'Field to order the connection by', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'ID'    => [ 'value' => 'id' ],

--- a/includes/type/enum/class-tax-status.php
+++ b/includes/type/enum/class-tax-status.php
@@ -22,7 +22,7 @@ class Tax_Status {
 			'TaxStatusEnum',
 			[
 				'description' => static function () {
-					return __( 'Product tax status enumeration', 'wp-graphql-woocommerce' );
+					return __( 'Product tax status enumeration', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'TAXABLE'  => [ 'value' => 'taxable' ],

--- a/includes/type/enum/class-taxonomy-operator.php
+++ b/includes/type/enum/class-taxonomy-operator.php
@@ -22,7 +22,7 @@ class Taxonomy_Operator {
 			'TaxonomyOperatorEnum',
 			[
 				'description' => static function () {
-					return __( 'Taxonomy query operators', 'wp-graphql-woocommerce' );
+					return __( 'Taxonomy query operators', 'graphql-for-ecommerce' );
 				},
 				'values'      => [
 					'IN'         => [ 'value' => 'IN' ],

--- a/includes/type/enum/class-wc-setting-type-enum.php
+++ b/includes/type/enum/class-wc-setting-type-enum.php
@@ -39,7 +39,7 @@ class WC_Setting_Type_Enum {
 			'WCSettingTypeEnum',
 			[
 				'description' => static function () {
-					return __( 'Type of WC setting.', 'wp-graphql-woocommerce' );
+					return __( 'Type of WC setting.', 'graphql-for-ecommerce' );
 				},
 				'values'      => $values,
 			]

--- a/includes/type/input/class-cart-item-input.php
+++ b/includes/type/input/class-cart-item-input.php
@@ -22,37 +22,37 @@ class Cart_Item_Input {
 			'CartItemInput',
 			[
 				'description' => static function () {
-					return __( 'Cart item quantity', 'wp-graphql-woocommerce' );
+					return __( 'Cart item quantity', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'productId'   => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => static function () {
-							return __( 'Cart item product database ID or global ID', 'wp-graphql-woocommerce' );
+							return __( 'Cart item product database ID or global ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'quantity'    => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Cart item quantity', 'wp-graphql-woocommerce' );
+							return __( 'Cart item quantity', 'graphql-for-ecommerce' );
 						},
 					],
 					'variationId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Cart item product variation database ID or global ID', 'wp-graphql-woocommerce' );
+							return __( 'Cart item product variation database ID or global ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'variation'   => [
 						'type'        => [ 'list_of' => 'ProductAttributeInput' ],
 						'description' => static function () {
-							return __( 'Cart item product variation attributes', 'wp-graphql-woocommerce' );
+							return __( 'Cart item product variation attributes', 'graphql-for-ecommerce' );
 						},
 					],
 					'extraData'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'JSON string representation of extra cart item data', 'wp-graphql-woocommerce' );
+							return __( 'JSON string representation of extra cart item data', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-cart-item-quantity-input.php
+++ b/includes/type/input/class-cart-item-quantity-input.php
@@ -22,19 +22,19 @@ class Cart_Item_Quantity_Input {
 			'CartItemQuantityInput',
 			[
 				'description' => static function () {
-					return __( 'Cart item quantity', 'wp-graphql-woocommerce' );
+					return __( 'Cart item quantity', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'key'      => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Cart item being updated', 'wp-graphql-woocommerce' );
+							return __( 'Cart item being updated', 'graphql-for-ecommerce' );
 						},
 					],
 					'quantity' => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => static function () {
-							return __( 'Cart item\'s new quantity', 'wp-graphql-woocommerce' );
+							return __( 'Cart item\'s new quantity', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-collection-stats-query-input.php
+++ b/includes/type/input/class-collection-stats-query-input.php
@@ -22,19 +22,19 @@ class Collection_Stats_Query_Input {
 			'CollectionStatsQueryInput',
 			[
 				'description' => static function () {
-					return __( 'Taxonomy query', 'wp-graphql-woocommerce' );
+					return __( 'Taxonomy query', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'taxonomy' => [
 						'type'        => [ 'non_null' => 'ProductAttributeEnum' ],
 						'description' => static function () {
-							return __( 'Product Taxonomy', 'wp-graphql-woocommerce' );
+							return __( 'Product Taxonomy', 'graphql-for-ecommerce' );
 						},
 					],
 					'relation' => [
 						'type'        => 'RelationEnum',
 						'description' => static function () {
-							return __( 'Taxonomy relation to query', 'wp-graphql-woocommerce' );
+							return __( 'Taxonomy relation to query', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-collection-stats-where-args.php
+++ b/includes/type/input/class-collection-stats-where-args.php
@@ -22,127 +22,127 @@ class Collection_Stats_Where_Args {
 			'CollectionStatsWhereArgs',
 			[
 				'description' => static function () {
-					return __( 'Arguments used to filter the collection results', 'wp-graphql-woocommerce' );
+					return __( 'Arguments used to filter the collection results', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'search'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Limit result set to products based on a keyword search.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products based on a keyword search.', 'graphql-for-ecommerce' );
 						},
 					],
 					'slugIn'       => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Limit result set to products with specific slugs.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products with specific slugs.', 'graphql-for-ecommerce' );
 						},
 					],
 					'typeIn'       => [
 						'type'        => [ 'list_of' => 'ProductTypesEnum' ],
 						'description' => static function () {
-							return __( 'Limit result set to products assigned to a group of specific types.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products assigned to a group of specific types.', 'graphql-for-ecommerce' );
 						},
 					],
 					'exclude'      => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'Ensure result set excludes specific IDs.', 'wp-graphql-woocommerce' );
+							return __( 'Ensure result set excludes specific IDs.', 'graphql-for-ecommerce' );
 						},
 					],
 					'include'      => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'Limit result set to specific ids.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to specific ids.', 'graphql-for-ecommerce' );
 						},
 					],
 					'sku'          => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Limit result set to products with specific SKU(s). Use commas to separate.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products with specific SKU(s). Use commas to separate.', 'graphql-for-ecommerce' );
 						},
 					],
 					'featured'     => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Limit result set to featured products.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to featured products.', 'graphql-for-ecommerce' );
 						},
 					],
 					'parentIn'     => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'Specify objects whose parent is in an array.', 'wp-graphql-woocommerce' );
+							return __( 'Specify objects whose parent is in an array.', 'graphql-for-ecommerce' );
 						},
 					],
 					'parentNotIn'  => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'Specify objects whose parent is not in an array.', 'wp-graphql-woocommerce' );
+							return __( 'Specify objects whose parent is not in an array.', 'graphql-for-ecommerce' );
 						},
 					],
 					'categoryIn'   => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Limit result set to products assigned to a group of specific categories by name.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products assigned to a group of specific categories by name.', 'graphql-for-ecommerce' );
 						},
 					],
 					'categoryIdIn' => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'Limit result set to products assigned to a specific group of category IDs.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products assigned to a specific group of category IDs.', 'graphql-for-ecommerce' );
 						},
 					],
 					'tagIn'        => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Limit result set to products assigned to a specific group of tags by name.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products assigned to a specific group of tags by name.', 'graphql-for-ecommerce' );
 						},
 					],
 					'tagIdIn'      => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'Limit result set to products assigned to a specific group of tag IDs.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products assigned to a specific group of tag IDs.', 'graphql-for-ecommerce' );
 						},
 					],
 					'attributes'   => [
 						'type'        => 'ProductAttributeQueryInput',
 						'description' => static function () {
-							return __( 'Limit result set to products with selected global attribute queries.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products with selected global attribute queries.', 'graphql-for-ecommerce' );
 						},
 					],
 					'stockStatus'  => [
 						'type'        => [ 'list_of' => 'StockStatusEnum' ],
 						'description' => static function () {
-							return __( 'Limit result set to products in stock or out of stock.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products in stock or out of stock.', 'graphql-for-ecommerce' );
 						},
 					],
 					'onSale'       => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Limit result set to products on sale.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products on sale.', 'graphql-for-ecommerce' );
 						},
 					],
 					'minPrice'     => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Limit result set to products based on a minimum price.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products based on a minimum price.', 'graphql-for-ecommerce' );
 						},
 					],
 					'maxPrice'     => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Limit result set to products based on a maximum price.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products based on a maximum price.', 'graphql-for-ecommerce' );
 						},
 					],
 					'visibility'   => [
 						'type'        => 'CatalogVisibilityEnum',
 						'description' => static function () {
-							return __( 'Limit result set to products with a specific visibility level.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products with a specific visibility level.', 'graphql-for-ecommerce' );
 						},
 					],
 					'rating'       => [
 						'type'        => [ 'list_of' => 'Integer' ],
 						'description' => static function () {
-							return __( 'Limit result set to products with a specific average rating. Must be between 1 and 5', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products with a specific average rating. Must be between 1 and 5', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-create-account-input.php
+++ b/includes/type/input/class-create-account-input.php
@@ -22,25 +22,25 @@ class Create_Account_Input {
 			'CreateAccountInput',
 			[
 				'description' => static function () {
-					return __( 'Customer account credentials', 'wp-graphql-woocommerce' );
+					return __( 'Customer account credentials', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'username'     => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Customer username', 'wp-graphql-woocommerce' );
+							return __( 'Customer username', 'graphql-for-ecommerce' );
 						},
 					],
 					'password'     => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Customer password', 'wp-graphql-woocommerce' );
+							return __( 'Customer password', 'graphql-for-ecommerce' );
 						},
 					],
 					'authenticate' => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Set the current user to the newly created customer after checkout.', 'wp-graphql-woocommerce' );
+							return __( 'Set the current user to the newly created customer after checkout.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-customer-address-input.php
+++ b/includes/type/input/class-customer-address-input.php
@@ -22,79 +22,79 @@ class Customer_Address_Input {
 			'CustomerAddressInput',
 			[
 				'description' => static function () {
-					return __( 'Customer address information', 'wp-graphql-woocommerce' );
+					return __( 'Customer address information', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'firstName' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'First name', 'wp-graphql-woocommerce' );
+							return __( 'First name', 'graphql-for-ecommerce' );
 						},
 					],
 					'lastName'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Last name', 'wp-graphql-woocommerce' );
+							return __( 'Last name', 'graphql-for-ecommerce' );
 						},
 					],
 					'company'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Company', 'wp-graphql-woocommerce' );
+							return __( 'Company', 'graphql-for-ecommerce' );
 						},
 					],
 					'address1'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Address 1', 'wp-graphql-woocommerce' );
+							return __( 'Address 1', 'graphql-for-ecommerce' );
 						},
 					],
 					'address2'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Address 2', 'wp-graphql-woocommerce' );
+							return __( 'Address 2', 'graphql-for-ecommerce' );
 						},
 					],
 					'city'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'City', 'wp-graphql-woocommerce' );
+							return __( 'City', 'graphql-for-ecommerce' );
 						},
 					],
 					'state'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'State', 'wp-graphql-woocommerce' );
+							return __( 'State', 'graphql-for-ecommerce' );
 						},
 					],
 					'postcode'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Zip Postal Code', 'wp-graphql-woocommerce' );
+							return __( 'Zip Postal Code', 'graphql-for-ecommerce' );
 						},
 					],
 					'country'   => [
 						'type'        => 'CountriesEnum',
 						'description' => static function () {
-							return __( 'Country', 'wp-graphql-woocommerce' );
+							return __( 'Country', 'graphql-for-ecommerce' );
 						},
 					],
 					'email'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'E-mail', 'wp-graphql-woocommerce' );
+							return __( 'E-mail', 'graphql-for-ecommerce' );
 						},
 					],
 					'phone'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Phone', 'wp-graphql-woocommerce' );
+							return __( 'Phone', 'graphql-for-ecommerce' );
 						},
 					],
 					'overwrite' => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Clear old address data', 'wp-graphql-woocommerce' );
+							return __( 'Clear old address data', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-fee-input.php
+++ b/includes/type/input/class-fee-input.php
@@ -22,31 +22,31 @@ class Fee_Input {
 			'FeeInput',
 			[
 				'description' => static function () {
-					return __( 'Fee line data.', 'wp-graphql-woocommerce' );
+					return __( 'Fee line data.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'name'     => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Unique name for the fee.', 'wp-graphql-woocommerce' );
+							return __( 'Unique name for the fee.', 'graphql-for-ecommerce' );
 						},
 					],
 					'amount'   => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Fee amount', 'wp-graphql-woocommerce' );
+							return __( 'Fee amount', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxable'  => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Is the fee taxable?', 'wp-graphql-woocommerce' );
+							return __( 'Is the fee taxable?', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxClass' => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'The tax class for the fee if taxable.', 'wp-graphql-woocommerce' );
+							return __( 'The tax class for the fee if taxable.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-fee-line-input.php
+++ b/includes/type/input/class-fee-line-input.php
@@ -22,43 +22,43 @@ class Fee_Line_Input {
 			'FeeLineInput',
 			[
 				'description' => static function () {
-					return __( 'Fee line data.', 'wp-graphql-woocommerce' );
+					return __( 'Fee line data.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'        => [
 						'type'        => 'ID',
 						'description' => static function () {
-							return __( 'Fee Line ID', 'wp-graphql-woocommerce' );
+							return __( 'Fee Line ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'name'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Fee name.', 'wp-graphql-woocommerce' );
+							return __( 'Fee name.', 'graphql-for-ecommerce' );
 						},
 					],
 					'amount'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Fee amount.', 'wp-graphql-woocommerce' );
+							return __( 'Fee amount.', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxClass'  => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'Tax class of fee.', 'wp-graphql-woocommerce' );
+							return __( 'Tax class of fee.', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxStatus' => [
 						'type'        => 'TaxStatusEnum',
 						'description' => static function () {
-							return __( 'Tax status of fee.', 'wp-graphql-woocommerce' );
+							return __( 'Tax status of fee.', 'graphql-for-ecommerce' );
 						},
 					],
 					'total'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line total (after discounts).', 'wp-graphql-woocommerce' );
+							return __( 'Line total (after discounts).', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-line-item-input.php
+++ b/includes/type/input/class-line-item-input.php
@@ -22,67 +22,67 @@ class Line_Item_Input {
 			'LineItemInput',
 			[
 				'description' => static function () {
-					return __( 'Meta data.', 'wp-graphql-woocommerce' );
+					return __( 'Meta data.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'          => [
 						'type'        => 'ID',
 						'description' => static function () {
-							return __( 'Line Item ID', 'wp-graphql-woocommerce' );
+							return __( 'Line Item ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'name'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line name', 'wp-graphql-woocommerce' );
+							return __( 'Line name', 'graphql-for-ecommerce' );
 						},
 					],
 					'productId'   => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Product ID.', 'wp-graphql-woocommerce' );
+							return __( 'Product ID.', 'graphql-for-ecommerce' );
 						},
 					],
 					'variationId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Variation ID, if applicable.', 'wp-graphql-woocommerce' );
+							return __( 'Variation ID, if applicable.', 'graphql-for-ecommerce' );
 						},
 					],
 					'quantity'    => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Quantity ordered.', 'wp-graphql-woocommerce' );
+							return __( 'Quantity ordered.', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxClass'    => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'Tax class of product.', 'wp-graphql-woocommerce' );
+							return __( 'Tax class of product.', 'graphql-for-ecommerce' );
 						},
 					],
 					'subtotal'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line subtotal (before discounts).', 'wp-graphql-woocommerce' );
+							return __( 'Line subtotal (before discounts).', 'graphql-for-ecommerce' );
 						},
 					],
 					'total'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line total (after discounts).', 'wp-graphql-woocommerce' );
+							return __( 'Line total (after discounts).', 'graphql-for-ecommerce' );
 						},
 					],
 					'metaData'    => [
 						'type'        => [ 'list_of' => 'MetaDataInput' ],
 						'description' => static function () {
-							return __( 'Meta data.', 'wp-graphql-woocommerce' );
+							return __( 'Meta data.', 'graphql-for-ecommerce' );
 						},
 					],
 					'sku'         => [
 						'type'        => 'string',
 						'description' => static function () {
-							return __( 'Product SKU.', 'wp-graphql-woocommerce' );
+							return __( 'Product SKU.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-meta-data-input.php
+++ b/includes/type/input/class-meta-data-input.php
@@ -22,25 +22,25 @@ class Meta_Data_Input {
 			'MetaDataInput',
 			[
 				'description' => static function () {
-					return __( 'Meta data.', 'wp-graphql-woocommerce' );
+					return __( 'Meta data.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Meta ID.', 'wp-graphql-woocommerce' );
+							return __( 'Meta ID.', 'graphql-for-ecommerce' );
 						},
 					],
 					'key'   => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Meta key.', 'wp-graphql-woocommerce' );
+							return __( 'Meta key.', 'graphql-for-ecommerce' );
 						},
 					],
 					'value' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Meta value.', 'wp-graphql-woocommerce' );
+							return __( 'Meta value.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-orderby-inputs.php
+++ b/includes/type/input/class-orderby-inputs.php
@@ -27,7 +27,7 @@ class Orderby_Inputs {
 			$base_name . 'OrderbyInput',
 			[
 				'description' => static function () {
-					return __( 'Options for ordering the connection', 'wp-graphql-woocommerce' );
+					return __( 'Options for ordering the connection', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'field' => [

--- a/includes/type/input/class-product-attribute-filter-input.php
+++ b/includes/type/input/class-product-attribute-filter-input.php
@@ -22,31 +22,31 @@ class Product_Attribute_Filter_Input {
 			'ProductAttributeFilterInput',
 			[
 				'description' => static function () {
-					return __( 'Product filter', 'wp-graphql-woocommerce' );
+					return __( 'Product filter', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'taxonomy' => [
 						'type'        => [ 'non_null' => 'ProductAttributeEnum' ],
 						'description' => static function () {
-							return __( 'Which field to select taxonomy term by.', 'wp-graphql-woocommerce' );
+							return __( 'Which field to select taxonomy term by.', 'graphql-for-ecommerce' );
 						},
 					],
 					'terms'    => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'A list of term slugs', 'wp-graphql-woocommerce' );
+							return __( 'A list of term slugs', 'graphql-for-ecommerce' );
 						},
 					],
 					'ids'      => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'A list of term ids', 'wp-graphql-woocommerce' );
+							return __( 'A list of term ids', 'graphql-for-ecommerce' );
 						},
 					],
 					'operator' => [
 						'type'        => 'AttributeOperatorEnum',
 						'description' => static function () {
-							return __( 'Filter operation type', 'wp-graphql-woocommerce' );
+							return __( 'Filter operation type', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-product-attribute-input.php
+++ b/includes/type/input/class-product-attribute-input.php
@@ -22,7 +22,7 @@ class Product_Attribute_Input {
 			'ProductAttributeInput',
 			[
 				'description' => static function () {
-					return __( 'Options for ordering the connection', 'wp-graphql-woocommerce' );
+					return __( 'Options for ordering the connection', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'attributeName'  => [

--- a/includes/type/input/class-product-attribute-query-input.php
+++ b/includes/type/input/class-product-attribute-query-input.php
@@ -22,19 +22,19 @@ class Product_Attribute_Query_Input {
 			'ProductAttributeQueryInput',
 			[
 				'description' => static function () {
-					return __( 'Product filter', 'wp-graphql-woocommerce' );
+					return __( 'Product filter', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'queries'  => [
 						'type'        => [ 'list_of' => 'ProductAttributeFilterInput' ],
 						'description' => static function () {
-							return __( 'Limit result set to products with selected global attributes.', 'wp-graphql-woocommerce' );
+							return __( 'Limit result set to products with selected global attributes.', 'graphql-for-ecommerce' );
 						},
 					],
 					'relation' => [
 						'type'        => 'AttributeOperatorEnum',
 						'description' => static function () {
-							return __( 'The logical relationship between attributes when filtering across multiple at once.', 'wp-graphql-woocommerce' );
+							return __( 'The logical relationship between attributes when filtering across multiple at once.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-product-attributes-input.php
+++ b/includes/type/input/class-product-attributes-input.php
@@ -22,43 +22,43 @@ class Product_Attributes_Input {
 			'ProductAttributesInput',
 			[
 				'description' => static function () {
-					return __( 'Product attribute properties', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute properties', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'        => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Attribute ID', 'wp-graphql-woocommerce' );
+							return __( 'Attribute ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'name'      => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Attribute name', 'wp-graphql-woocommerce' );
+							return __( 'Attribute name', 'graphql-for-ecommerce' );
 						},
 					],
 					'position'  => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Attribute position', 'wp-graphql-woocommerce' );
+							return __( 'Attribute position', 'graphql-for-ecommerce' );
 						},
 					],
 					'visible'   => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Define if the attribute is visible on the "Additional information" tab in the product\'s page. Default is false.', 'wp-graphql-woocommerce' );
+							return __( 'Define if the attribute is visible on the "Additional information" tab in the product\'s page. Default is false.', 'graphql-for-ecommerce' );
 						},
 					],
 					'variation' => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Define if the attribute can be used as variation. Default is false.', 'wp-graphql-woocommerce' );
+							return __( 'Define if the attribute can be used as variation. Default is false.', 'graphql-for-ecommerce' );
 						},
 					],
 					'options'   => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'List of available term names for the attribute', 'wp-graphql-woocommerce' );
+							return __( 'List of available term names for the attribute', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-product-dimensions-input.php
+++ b/includes/type/input/class-product-dimensions-input.php
@@ -22,25 +22,25 @@ class Product_Dimensions_Input {
 			'ProductDimensionsInput',
 			[
 				'description' => static function () {
-					return __( 'Product dimensions', 'wp-graphql-woocommerce' );
+					return __( 'Product dimensions', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'length' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Length of the product', 'wp-graphql-woocommerce' );
+							return __( 'Length of the product', 'graphql-for-ecommerce' );
 						},
 					],
 					'width'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Width of the product', 'wp-graphql-woocommerce' );
+							return __( 'Width of the product', 'graphql-for-ecommerce' );
 						},
 					],
 					'height' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Height of the product', 'wp-graphql-woocommerce' );
+							return __( 'Height of the product', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-product-download-input.php
+++ b/includes/type/input/class-product-download-input.php
@@ -22,25 +22,25 @@ class Product_Download_Input {
 			'ProductDownloadInput',
 			[
 				'description' => static function () {
-					return __( 'Product download', 'wp-graphql-woocommerce' );
+					return __( 'Product download', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'   => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'File ID', 'wp-graphql-woocommerce' );
+							return __( 'File ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'name' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'File name', 'wp-graphql-woocommerce' );
+							return __( 'File name', 'graphql-for-ecommerce' );
 						},
 					],
 					'file' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'File URL', 'wp-graphql-woocommerce' );
+							return __( 'File URL', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-product-image-input.php
+++ b/includes/type/input/class-product-image-input.php
@@ -22,31 +22,31 @@ class Product_Image_Input {
 			'ProductImageInput',
 			[
 				'description' => static function () {
-					return __( 'Product image', 'wp-graphql-woocommerce' );
+					return __( 'Product image', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'      => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Image ID', 'wp-graphql-woocommerce' );
+							return __( 'Image ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'src'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Image URL', 'wp-graphql-woocommerce' );
+							return __( 'Image URL', 'graphql-for-ecommerce' );
 						},
 					],
 					'name'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Image name', 'wp-graphql-woocommerce' );
+							return __( 'Image name', 'graphql-for-ecommerce' );
 						},
 					],
 					'altText' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Image alternative text', 'wp-graphql-woocommerce' );
+							return __( 'Image alternative text', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-product-taxonomy-filter-input.php
+++ b/includes/type/input/class-product-taxonomy-filter-input.php
@@ -22,31 +22,31 @@ class Product_Taxonomy_Filter_Input {
 			'ProductTaxonomyFilterInput',
 			[
 				'description' => static function () {
-					return __( 'Product filter', 'wp-graphql-woocommerce' );
+					return __( 'Product filter', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'taxonomy' => [
 						'type'        => [ 'non_null' => 'ProductTaxonomyEnum' ],
 						'description' => static function () {
-							return __( 'Which field to select taxonomy term by.', 'wp-graphql-woocommerce' );
+							return __( 'Which field to select taxonomy term by.', 'graphql-for-ecommerce' );
 						},
 					],
 					'terms'    => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'A list of term slugs', 'wp-graphql-woocommerce' );
+							return __( 'A list of term slugs', 'graphql-for-ecommerce' );
 						},
 					],
 					'ids'      => [
 						'type'        => [ 'list_of' => 'Int' ],
 						'description' => static function () {
-							return __( 'A list of term ids', 'wp-graphql-woocommerce' );
+							return __( 'A list of term ids', 'graphql-for-ecommerce' );
 						},
 					],
 					'operator' => [
 						'type'        => 'TaxonomyOperatorEnum',
 						'description' => static function () {
-							return __( 'Filter operation type', 'wp-graphql-woocommerce' );
+							return __( 'Filter operation type', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-product-taxonomy-input.php
+++ b/includes/type/input/class-product-taxonomy-input.php
@@ -22,31 +22,31 @@ class Product_Taxonomy_Input {
 			'ProductTaxonomyInput',
 			[
 				'description' => static function () {
-					return __( 'Product taxonomy filter type', 'wp-graphql-woocommerce' );
+					return __( 'Product taxonomy filter type', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'relation' => [
 						'type'        => 'RelationEnum',
 						'description' => static function () {
-							return __( 'Logic relation between each filter.', 'wp-graphql-woocommerce' );
+							return __( 'Logic relation between each filter.', 'graphql-for-ecommerce' );
 						},
 					],
 					'filters'  => [
 						'type'        => [ 'list_of' => 'ProductTaxonomyFilterInput' ],
 						'description' => static function () {
-							return __( 'Product taxonomy rules to be filter results by', 'wp-graphql-woocommerce' );
+							return __( 'Product taxonomy rules to be filter results by', 'graphql-for-ecommerce' );
 						},
 					],
 					'or'       => [
 						'type'        => [ 'list_of' => 'ProductTaxonomyFilterInput' ],
 						'description' => static function () {
-							return __( 'Product taxonomy rules connected by OR logic', 'wp-graphql-woocommerce' );
+							return __( 'Product taxonomy rules connected by OR logic', 'graphql-for-ecommerce' );
 						},
 					],
 					'and'      => [
 						'type'        => [ 'list_of' => 'ProductTaxonomyFilterInput' ],
 						'description' => static function () {
-							return __( 'Product taxonomy rules connected by AND logic', 'wp-graphql-woocommerce' );
+							return __( 'Product taxonomy rules connected by AND logic', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-shipping-line-input.php
+++ b/includes/type/input/class-shipping-line-input.php
@@ -22,43 +22,43 @@ class Shipping_Line_Input {
 			'ShippingLineInput',
 			[
 				'description' => static function () {
-					return __( 'Shipping lines data.', 'wp-graphql-woocommerce' );
+					return __( 'Shipping lines data.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'          => [
 						'type'        => 'ID',
 						'description' => static function () {
-							return __( 'Shipping Line ID', 'wp-graphql-woocommerce' );
+							return __( 'Shipping Line ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'methodTitle' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Shipping method name.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping method name.', 'graphql-for-ecommerce' );
 						},
 					],
 					'methodId'    => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Shipping method ID.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping method ID.', 'graphql-for-ecommerce' );
 						},
 					],
 					'instanceId'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping instance ID.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping instance ID.', 'graphql-for-ecommerce' );
 						},
 					],
 					'total'       => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Line total (after discounts).', 'wp-graphql-woocommerce' );
+							return __( 'Line total (after discounts).', 'graphql-for-ecommerce' );
 						},
 					],
 					'metaData'    => [
 						'type'        => [ 'list_of' => 'MetaDataInput' ],
 						'description' => static function () {
-							return __( 'Meta data.', 'wp-graphql-woocommerce' );
+							return __( 'Meta data.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-shipping-location-input.php
+++ b/includes/type/input/class-shipping-location-input.php
@@ -22,19 +22,19 @@ class Shipping_Location_Input {
 			'ShippingLocationInput',
 			[
 				'description' => static function () {
-					return __( 'Shipping lines data.', 'wp-graphql-woocommerce' );
+					return __( 'Shipping lines data.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'code' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping location code.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping location code.', 'graphql-for-ecommerce' );
 						},
 					],
 					'type' => [
 						'type'        => 'ShippingLocationTypeEnum',
 						'description' => static function () {
-							return __( 'Shipping location type.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping location type.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/input/class-tax-rate-connection-orderby-input.php
+++ b/includes/type/input/class-tax-rate-connection-orderby-input.php
@@ -22,7 +22,7 @@ class Tax_Rate_Connection_Orderby_Input {
 			'TaxRateConnectionOrderbyInput',
 			[
 				'description' => static function () {
-					return __( 'Options for ordering the connection', 'wp-graphql-woocommerce' );
+					return __( 'Options for ordering the connection', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'field' => [

--- a/includes/type/input/class-wc-setting-input.php
+++ b/includes/type/input/class-wc-setting-input.php
@@ -22,19 +22,19 @@ class WC_Setting_Input {
 			'WCSettingInput',
 			[
 				'description' => static function () {
-					return __( 'WooCommerce setting input.', 'wp-graphql-woocommerce' );
+					return __( 'WooCommerce setting input.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A unique identifier for the setting.', 'wp-graphql-woocommerce' );
+							return __( 'A unique identifier for the setting.', 'graphql-for-ecommerce' );
 						},
 					],
 					'value' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Setting value.', 'wp-graphql-woocommerce' );
+							return __( 'Setting value.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/interface/class-attribute.php
+++ b/includes/type/interface/class-attribute.php
@@ -22,14 +22,14 @@ class Attribute {
 			'Attribute',
 			[
 				'description' => static function () {
-					return __( 'Attribute object', 'wp-graphql-woocommerce' );
+					return __( 'Attribute object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'name'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Name of attribute', 'wp-graphql-woocommerce' );
+							return __( 'Name of attribute', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['name'] ) ? $source['name'] : null;
@@ -38,7 +38,7 @@ class Attribute {
 					'value' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Selected value of attribute', 'wp-graphql-woocommerce' );
+							return __( 'Selected value of attribute', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['value'] ) ? $source['value'] : null;

--- a/includes/type/interface/class-cart-error.php
+++ b/includes/type/interface/class-cart-error.php
@@ -22,7 +22,7 @@ class Cart_Error {
 			'CartError',
 			[
 				'description' => static function () {
-					return __( 'An error that occurred when updating the cart', 'wp-graphql-woocommerce' );
+					return __( 'An error that occurred when updating the cart', 'graphql-for-ecommerce' );
 				},
 				'fields'      => self::get_fields(),
 				'resolveType' => static function ( array $value ) {
@@ -52,7 +52,7 @@ class Cart_Error {
 			'type'    => [
 				'type'        => [ 'non_null' => 'CartErrorType' ],
 				'description' => static function () {
-					return __( 'Type of error', 'wp-graphql-woocommerce' );
+					return __( 'Type of error', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( array $error ) {
 					return ! empty( $error['type'] ) ? $error['type'] : null;
@@ -61,7 +61,7 @@ class Cart_Error {
 			'reasons' => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Reason for error', 'wp-graphql-woocommerce' );
+					return __( 'Reason for error', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $error ) {
 					return ! empty( $error['reasons'] ) ? $error['reasons'] : [ 'Reasons for error unknown, sorry.' ];

--- a/includes/type/interface/class-cart-item.php
+++ b/includes/type/interface/class-cart-item.php
@@ -29,7 +29,7 @@ class Cart_Item {
 			'CartItem',
 			[
 				'description' => static function () {
-					return __( 'Cart item interface.', 'wp-graphql-woocommerce' );
+					return __( 'Cart item interface.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -44,7 +44,7 @@ class Cart_Item {
 
 					$type_name = apply_filters( 'woographql_cart_item_type', 'SimpleCartItem', $cart_item );
 					if ( empty( $type_name ) ) {
-						throw new UserError( __( 'Invalid cart item type provided.', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'Invalid cart item type provided.', 'graphql-for-ecommerce' ) );
 					}
 
 					return $type_registry->get_type( $type_name );
@@ -57,7 +57,7 @@ class Cart_Item {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A item in the cart', 'wp-graphql-woocommerce' );
+					return __( 'A item in the cart', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => [ 'Node', 'CartItem' ],
 				'fields'          => [],
@@ -75,7 +75,7 @@ class Cart_Item {
 			'key'         => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'CartItem ID', 'wp-graphql-woocommerce' );
+					return __( 'CartItem ID', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return ! empty( $source['key'] ) ? $source['key'] : null;
@@ -84,7 +84,7 @@ class Cart_Item {
 			'quantity'    => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Quantity of the product', 'wp-graphql-woocommerce' );
+					return __( 'Quantity of the product', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return isset( $source['quantity'] ) ? absint( $source['quantity'] ) : null;
@@ -93,13 +93,13 @@ class Cart_Item {
 			'subtotal'    => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Item\'s subtotal', 'wp-graphql-woocommerce' );
+					return __( 'Item\'s subtotal', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PricingFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the price', 'wp-graphql-woocommerce' );
+							return __( 'Format of the price', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -116,13 +116,13 @@ class Cart_Item {
 			'subtotalTax' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Item\'s subtotal tax', 'wp-graphql-woocommerce' );
+					return __( 'Item\'s subtotal tax', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PricingFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the price', 'wp-graphql-woocommerce' );
+							return __( 'Format of the price', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -139,13 +139,13 @@ class Cart_Item {
 			'total'       => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Item\'s total', 'wp-graphql-woocommerce' );
+					return __( 'Item\'s total', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PricingFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the price', 'wp-graphql-woocommerce' );
+							return __( 'Format of the price', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -164,13 +164,13 @@ class Cart_Item {
 			'tax'         => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Item\'s tax', 'wp-graphql-woocommerce' );
+					return __( 'Item\'s tax', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PricingFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the price', 'wp-graphql-woocommerce' );
+							return __( 'Format of the price', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -187,19 +187,19 @@ class Cart_Item {
 			'extraData'   => [
 				'type'        => [ 'list_of' => 'MetaData' ],
 				'description' => static function () {
-					return __( 'Object meta data', 'wp-graphql-woocommerce' );
+					return __( 'Object meta data', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'key'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Retrieve meta by key', 'wp-graphql-woocommerce' );
+							return __( 'Retrieve meta by key', 'graphql-for-ecommerce' );
 						},
 					],
 					'keysIn' => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Retrieve multiple metas by key', 'wp-graphql-woocommerce' );
+							return __( 'Retrieve multiple metas by key', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -268,7 +268,7 @@ class Cart_Item {
 					'simpleVariations' => [
 						'type'        => [ 'list_of' => 'SimpleAttribute' ],
 						'description' => static function () {
-							return __( 'Simple variation attribute data', 'wp-graphql-woocommerce' );
+							return __( 'Simple variation attribute data', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$attributes = [];
@@ -301,7 +301,7 @@ class Cart_Item {
 					'attributes' => [
 						'type'        => [ 'list_of' => 'VariationAttribute' ],
 						'description' => static function () {
-							return __( 'Attributes of the variation.', 'wp-graphql-woocommerce' );
+							return __( 'Attributes of the variation.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$attributes = [];

--- a/includes/type/interface/class-downloadable-product.php
+++ b/includes/type/interface/class-downloadable-product.php
@@ -23,7 +23,7 @@ class Downloadable_Product {
 			'DownloadableProduct',
 			[
 				'description' => static function () {
-					return __( 'A downloadable product.', 'wp-graphql-woocommerce' );
+					return __( 'A downloadable product.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -42,37 +42,37 @@ class Downloadable_Product {
 			'id'             => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Product or variation global ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'databaseId'     => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product or variation ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadExpiry' => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Download expiry', 'wp-graphql-woocommerce' );
+					return __( 'Download expiry', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadable'   => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Is downloadable?', 'wp-graphql-woocommerce' );
+					return __( 'Is downloadable?', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloadLimit'  => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Download limit', 'wp-graphql-woocommerce' );
+					return __( 'Download limit', 'graphql-for-ecommerce' );
 				},
 			],
 			'downloads'      => [
 				'type'        => [ 'list_of' => 'ProductDownload' ],
 				'description' => static function () {
-					return __( 'Product downloads', 'wp-graphql-woocommerce' );
+					return __( 'Product downloads', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/type/interface/class-inventoried-product.php
+++ b/includes/type/interface/class-inventoried-product.php
@@ -23,7 +23,7 @@ class Inventoried_Product {
 			'InventoriedProduct',
 			[
 				'description' => static function () {
-					return __( 'A product with stock information.', 'wp-graphql-woocommerce' );
+					return __( 'A product with stock information.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -42,55 +42,55 @@ class Inventoried_Product {
 			'id'                => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Product or variation global ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'databaseId'        => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product or variation ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'manageStock'       => [
 				'type'        => 'ManageStockEnum',
 				'description' => static function () {
-					return __( 'If product manage stock', 'wp-graphql-woocommerce' );
+					return __( 'If product manage stock', 'graphql-for-ecommerce' );
 				},
 			],
 			'lowStockAmount'    => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Low stock amount', 'wp-graphql-woocommerce' );
+					return __( 'Low stock amount', 'graphql-for-ecommerce' );
 				},
 			],
 			'stockQuantity'     => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Number of items available for sale', 'wp-graphql-woocommerce' );
+					return __( 'Number of items available for sale', 'graphql-for-ecommerce' );
 				},
 			],
 			'backorders'        => [
 				'type'        => 'BackordersEnum',
 				'description' => static function () {
-					return __( 'Product backorders status', 'wp-graphql-woocommerce' );
+					return __( 'Product backorders status', 'graphql-for-ecommerce' );
 				},
 			],
 			'soldIndividually'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'If should be sold individually', 'wp-graphql-woocommerce' );
+					return __( 'If should be sold individually', 'graphql-for-ecommerce' );
 				},
 			],
 			'backordersAllowed' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Can product be backordered?', 'wp-graphql-woocommerce' );
+					return __( 'Can product be backordered?', 'graphql-for-ecommerce' );
 				},
 			],
 			'stockStatus'       => [
 				'type'        => 'StockStatusEnum',
 				'description' => static function () {
-					return __( 'Product stock status', 'wp-graphql-woocommerce' );
+					return __( 'Product stock status', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/type/interface/class-payment-token-interface.php
+++ b/includes/type/interface/class-payment-token-interface.php
@@ -24,7 +24,7 @@ class Payment_Token_Interface {
 			'PaymentTokenInterface',
 			[
 				'description' => static function () {
-					return __( 'Payment token object', 'wp-graphql-woocommerce' );
+					return __( 'Payment token object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -56,7 +56,7 @@ class Payment_Token_Interface {
 				'id'        => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'Token ID unique identifier', 'wp-graphql-woocommerce' );
+						return __( 'Token ID unique identifier', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						return ! empty( $source->get_id() ) ? Relay::toGlobalId( 'token', $source->get_id() ) : null;
@@ -65,7 +65,7 @@ class Payment_Token_Interface {
 				'tokenId'   => [
 					'type'        => [ 'non_null' => 'Integer' ],
 					'description' => static function () {
-						return __( 'Token database ID.', 'wp-graphql-woocommerce' );
+						return __( 'Token database ID.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						return ! empty( $source->get_id() ) ? $source->get_id() : null;
@@ -74,7 +74,7 @@ class Payment_Token_Interface {
 				'type'      => [
 					'type'        => [ 'non_null' => 'String' ],
 					'description' => static function () {
-						return __( 'Token type', 'wp-graphql-woocommerce' );
+						return __( 'Token type', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						return ! empty( $source->get_type() ) ? $source->get_type() : null;
@@ -83,7 +83,7 @@ class Payment_Token_Interface {
 				'gateway'   => [
 					'type'        => 'PaymentGateway',
 					'description' => static function () {
-						return __( 'Token payment gateway', 'wp-graphql-woocommerce' );
+						return __( 'Token payment gateway', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$gateways   = \WC()->payment_gateways()->payment_gateways();
@@ -98,7 +98,7 @@ class Payment_Token_Interface {
 				'isDefault' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Is token connected to user\'s preferred payment method', 'wp-graphql-woocommerce' );
+						return __( 'Is token connected to user\'s preferred payment method', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						return ! is_null( $source->is_default() ) ? $source->is_default() : false;

--- a/includes/type/interface/class-product-attribute.php
+++ b/includes/type/interface/class-product-attribute.php
@@ -22,7 +22,7 @@ class Product_Attribute {
 			'ProductAttribute',
 			[
 				'description' => static function () {
-					return __( 'Product attribute object', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -48,13 +48,13 @@ class Product_Attribute {
 			'id'          => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Attribute Global ID', 'wp-graphql-woocommerce' );
+					return __( 'Attribute Global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'attributeId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Attribute ID', 'wp-graphql-woocommerce' );
+					return __( 'Attribute ID', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					return ! is_null( $attribute->get_id() ) ? $attribute->get_id() : null;
@@ -63,7 +63,7 @@ class Product_Attribute {
 			'name'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Attribute name', 'wp-graphql-woocommerce' );
+					return __( 'Attribute name', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					return ! empty( $attribute->get_name() ) ? sanitize_title( $attribute->get_name() ) : null;
@@ -72,7 +72,7 @@ class Product_Attribute {
 			'label'       => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Attribute label', 'wp-graphql-woocommerce' );
+					return __( 'Attribute label', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					return ! empty( $attribute->get_name() ) ? $attribute->get_name() : null;
@@ -81,7 +81,7 @@ class Product_Attribute {
 			'options'     => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static function () {
-					return __( 'Attribute options', 'wp-graphql-woocommerce' );
+					return __( 'Attribute options', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					$slugs = $attribute->get_slugs();
@@ -91,7 +91,7 @@ class Product_Attribute {
 			'position'    => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Attribute position', 'wp-graphql-woocommerce' );
+					return __( 'Attribute position', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					return ! is_null( $attribute->get_position() ) ? $attribute->get_position() : null;
@@ -100,7 +100,7 @@ class Product_Attribute {
 			'visible'     => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Is attribute visible', 'wp-graphql-woocommerce' );
+					return __( 'Is attribute visible', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					return ! is_null( $attribute->get_visible() ) ? $attribute->get_visible() : null;
@@ -109,7 +109,7 @@ class Product_Attribute {
 			'variation'   => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Is attribute on product variation', 'wp-graphql-woocommerce' );
+					return __( 'Is attribute on product variation', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					return ! is_null( $attribute->get_variation() ) ? $attribute->get_variation() : null;
@@ -118,7 +118,7 @@ class Product_Attribute {
 			'scope'       => [
 				'type'        => [ 'non_null' => 'ProductAttributeTypesEnum' ],
 				'description' => static function () {
-					return __( 'Product attribute scope.', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute scope.', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $attribute ) {
 					return $attribute->is_taxonomy() ? 'global' : 'local';

--- a/includes/type/interface/class-product-union.php
+++ b/includes/type/interface/class-product-union.php
@@ -25,7 +25,7 @@ class Product_Union {
 			'ProductUnion',
 			[
 				'description' => static function () {
-					return __( 'Union between the product and product variation types', 'wp-graphql-woocommerce' );
+					return __( 'Union between the product and product variation types', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -45,61 +45,61 @@ class Product_Union {
 				'id'                => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'Product or variation global ID', 'wp-graphql-woocommerce' );
+						return __( 'Product or variation global ID', 'graphql-for-ecommerce' );
 					},
 				],
 				'databaseId'        => [
 					'type'        => [ 'non_null' => 'Int' ],
 					'description' => static function () {
-						return __( 'Product or variation ID', 'wp-graphql-woocommerce' );
+						return __( 'Product or variation ID', 'graphql-for-ecommerce' );
 					},
 				],
 				'slug'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Product slug', 'wp-graphql-woocommerce' );
+						return __( 'Product slug', 'graphql-for-ecommerce' );
 					},
 				],
 				'type'              => [
 					'type'        => 'ProductTypesEnum',
 					'description' => static function () {
-						return __( 'Product type', 'wp-graphql-woocommerce' );
+						return __( 'Product type', 'graphql-for-ecommerce' );
 					},
 				],
 				'name'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Product name', 'wp-graphql-woocommerce' );
+						return __( 'Product name', 'graphql-for-ecommerce' );
 					},
 				],
 				'featured'          => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'If the product is featured', 'wp-graphql-woocommerce' );
+						return __( 'If the product is featured', 'graphql-for-ecommerce' );
 					},
 				],
 				'catalogVisibility' => [
 					'type'        => 'CatalogVisibilityEnum',
 					'description' => static function () {
-						return __( 'Catalog visibility', 'wp-graphql-woocommerce' );
+						return __( 'Catalog visibility', 'graphql-for-ecommerce' );
 					},
 				],
 				'sku'               => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Product SKU', 'wp-graphql-woocommerce' );
+						return __( 'Product SKU', 'graphql-for-ecommerce' );
 					},
 				],
 				'description'       => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Product description', 'wp-graphql-woocommerce' );
+						return __( 'Product description', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PostObjectFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the field output', 'wp-graphql-woocommerce' );
+								return __( 'Format of the field output', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -114,7 +114,7 @@ class Product_Union {
 				'image'             => [
 					'type'        => 'MediaItem',
 					'description' => static function () {
-						return __( 'Main image', 'wp-graphql-woocommerce' );
+						return __( 'Main image', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source, array $args, AppContext $context ) {
 						// @codingStandardsIgnoreLine.
@@ -127,13 +127,13 @@ class Product_Union {
 				'onSale'            => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Is product on sale?', 'wp-graphql-woocommerce' );
+						return __( 'Is product on sale?', 'graphql-for-ecommerce' );
 					},
 				],
 				'purchasable'       => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Can product be purchased?', 'wp-graphql-woocommerce' );
+						return __( 'Can product be purchased?', 'graphql-for-ecommerce' );
 					},
 				],
 			],

--- a/includes/type/interface/class-product-variation.php
+++ b/includes/type/interface/class-product-variation.php
@@ -43,7 +43,7 @@ class Product_Variation {
 				'toType'        => 'Product',
 				'fromFieldName' => 'parent',
 				'description'   => static function () {
-					return __( 'The parent of the variation', 'wp-graphql-woocommerce' );
+					return __( 'The parent of the variation', 'graphql-for-ecommerce' );
 				},
 				'oneToOne'      => true,
 				'queryClass'    => '\WC_Product_Query',
@@ -66,7 +66,7 @@ class Product_Variation {
 				'eagerlyLoadType' => true,
 				'model'           => \WPGraphQL\WooCommerce\Model\Product_Variation::class,
 				'description'     => static function () {
-					return __( 'A product variation', 'wp-graphql-woocommerce' );
+					return __( 'A product variation', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => [ 'Node', 'ProductVariation' ],
 				'fields'          => [],
@@ -84,13 +84,13 @@ class Product_Variation {
 			'shippingClass' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product variation shipping class', 'wp-graphql-woocommerce' );
+					return __( 'Product variation shipping class', 'graphql-for-ecommerce' );
 				},
 			],
 			'hasAttributes' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Does product variation have any visible attributes', 'wp-graphql-woocommerce' );
+					return __( 'Does product variation have any visible attributes', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/type/interface/class-product-with-attributes.php
+++ b/includes/type/interface/class-product-with-attributes.php
@@ -28,7 +28,7 @@ class Product_With_Attributes {
 			'ProductWithAttributes',
 			[
 				'description' => static function () {
-					return __( 'Products with default attributes.', 'wp-graphql-woocommerce' );
+					return __( 'Products with default attributes.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -48,13 +48,13 @@ class Product_With_Attributes {
 			'id'         => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Product or variation global ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'databaseId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product or variation ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation ID', 'graphql-for-ecommerce' );
 				},
 			],
 		];
@@ -83,7 +83,7 @@ class Product_With_Attributes {
 					'type' => [
 						'type'        => 'ProductAttributeTypesEnum',
 						'description' => static function () {
-							return __( 'Filter results by attribute scope.', 'wp-graphql-woocommerce' );
+							return __( 'Filter results by attribute scope.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/interface/class-product-with-dimensions.php
+++ b/includes/type/interface/class-product-with-dimensions.php
@@ -23,7 +23,7 @@ class Product_With_Dimensions {
 			'ProductWithDimensions',
 			[
 				'description' => static function () {
-					return __( 'A physical product.', 'wp-graphql-woocommerce' );
+					return __( 'A physical product.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -42,55 +42,55 @@ class Product_With_Dimensions {
 			'id'               => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Product or variation global ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'databaseId'       => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product or variation ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'weight'           => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product\'s weight', 'wp-graphql-woocommerce' );
+					return __( 'Product\'s weight', 'graphql-for-ecommerce' );
 				},
 			],
 			'length'           => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product\'s length', 'wp-graphql-woocommerce' );
+					return __( 'Product\'s length', 'graphql-for-ecommerce' );
 				},
 			],
 			'width'            => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product\'s width', 'wp-graphql-woocommerce' );
+					return __( 'Product\'s width', 'graphql-for-ecommerce' );
 				},
 			],
 			'height'           => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product\'s height', 'wp-graphql-woocommerce' );
+					return __( 'Product\'s height', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingClassId'  => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'shipping class ID', 'wp-graphql-woocommerce' );
+					return __( 'shipping class ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingRequired' => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Does product need to be shipped?', 'wp-graphql-woocommerce' );
+					return __( 'Does product need to be shipped?', 'graphql-for-ecommerce' );
 				},
 			],
 			'shippingTaxable'  => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Is product shipping taxable?', 'wp-graphql-woocommerce' );
+					return __( 'Is product shipping taxable?', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/type/interface/class-product-with-pricing.php
+++ b/includes/type/interface/class-product-with-pricing.php
@@ -23,7 +23,7 @@ class Product_With_Pricing {
 			'ProductWithPricing',
 			[
 				'description' => static function () {
-					return __( 'Products with pricing.', 'wp-graphql-woocommerce' );
+					return __( 'Products with pricing.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => self::get_fields(),
@@ -42,25 +42,25 @@ class Product_With_Pricing {
 			'id'           => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Product or variation global ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'databaseId'   => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product or variation ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'price'        => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product\'s active price', 'wp-graphql-woocommerce' );
+					return __( 'Product\'s active price', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PricingFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the price', 'wp-graphql-woocommerce' );
+							return __( 'Format of the price', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -78,13 +78,13 @@ class Product_With_Pricing {
 			'regularPrice' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product\'s regular price', 'wp-graphql-woocommerce' );
+					return __( 'Product\'s regular price', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PricingFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the price', 'wp-graphql-woocommerce' );
+							return __( 'Format of the price', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -101,13 +101,13 @@ class Product_With_Pricing {
 			'salePrice'    => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product\'s sale price', 'wp-graphql-woocommerce' );
+					return __( 'Product\'s sale price', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PricingFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the price', 'wp-graphql-woocommerce' );
+							return __( 'Format of the price', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -124,13 +124,13 @@ class Product_With_Pricing {
 			'taxStatus'    => [
 				'type'        => 'TaxStatusEnum',
 				'description' => static function () {
-					return __( 'Tax status', 'wp-graphql-woocommerce' );
+					return __( 'Tax status', 'graphql-for-ecommerce' );
 				},
 			],
 			'taxClass'     => [
 				'type'        => 'TaxClassEnum',
 				'description' => static function () {
-					return __( 'Tax class', 'wp-graphql-woocommerce' );
+					return __( 'Tax class', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/type/interface/class-product-with-variations.php
+++ b/includes/type/interface/class-product-with-variations.php
@@ -28,7 +28,7 @@ class Product_With_Variations {
 			'ProductWithVariations',
 			[
 				'description' => static function () {
-					return __( 'A product with variations.', 'wp-graphql-woocommerce' );
+					return __( 'A product with variations.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node', 'ProductWithAttributes' ],
 				'fields'      => self::get_fields(),
@@ -48,13 +48,13 @@ class Product_With_Variations {
 			'id'         => [
 				'type'        => [ 'non_null' => 'ID' ],
 				'description' => static function () {
-					return __( 'Product or variation global ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation global ID', 'graphql-for-ecommerce' );
 				},
 			],
 			'databaseId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => static function () {
-					return __( 'Product or variation ID', 'wp-graphql-woocommerce' );
+					return __( 'Product or variation ID', 'graphql-for-ecommerce' );
 				},
 			],
 		];

--- a/includes/type/interface/class-product.php
+++ b/includes/type/interface/class-product.php
@@ -33,19 +33,19 @@ class Product {
 			[
 				'type'        => 'Product',
 				'description' => static function () {
-					return __( 'A product object', 'wp-graphql-woocommerce' );
+					return __( 'A product object', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'id'     => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The ID for identifying the product', 'wp-graphql-woocommerce' );
+							return __( 'The ID for identifying the product', 'graphql-for-ecommerce' );
 						},
 					],
 					'idType' => [
 						'type'        => 'ProductIdTypeEnum',
 						'description' => static function () {
-							return __( 'Type of ID being used identify product', 'wp-graphql-woocommerce' );
+							return __( 'Type of ID being used identify product', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -79,7 +79,7 @@ class Product {
 						default:
 							$id_components = Relay::fromGlobalId( $id );
 							if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-								throw new UserError( __( 'The "global ID" is invalid', 'wp-graphql-woocommerce' ) );
+								throw new UserError( __( 'The "global ID" is invalid', 'graphql-for-ecommerce' ) );
 							}
 							$product_id = absint( $id_components['id'] );
 							break;
@@ -87,12 +87,12 @@ class Product {
 
 					if ( empty( $product_id ) ) {
 						/* translators: %1$s: ID type, %2$s: ID value */
-						throw new UserError( sprintf( __( 'No product ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+						throw new UserError( sprintf( __( 'No product ID was found corresponding to the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 					}
 					$product = get_post( $product_id );
 					if ( ! is_object( $product ) || 'product' !== $product->post_type ) {
 						/* translators: %1$s: ID type, %2$s: ID value */
-						throw new UserError( sprintf( __( 'No product exists with the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+						throw new UserError( sprintf( __( 'No product exists with the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 					}
 
 					return Factory::resolve_crud_object( $product_id, $context );
@@ -111,37 +111,37 @@ class Product {
 			'type'              => [
 				'type'        => 'ProductTypesEnum',
 				'description' => static function () {
-					return __( 'Product type', 'wp-graphql-woocommerce' );
+					return __( 'Product type', 'graphql-for-ecommerce' );
 				},
 			],
 			'name'              => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product name', 'wp-graphql-woocommerce' );
+					return __( 'Product name', 'graphql-for-ecommerce' );
 				},
 			],
 			'featured'          => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'If the product is featured', 'wp-graphql-woocommerce' );
+					return __( 'If the product is featured', 'graphql-for-ecommerce' );
 				},
 			],
 			'catalogVisibility' => [
 				'type'        => 'CatalogVisibilityEnum',
 				'description' => static function () {
-					return __( 'Catalog visibility', 'wp-graphql-woocommerce' );
+					return __( 'Catalog visibility', 'graphql-for-ecommerce' );
 				},
 			],
 			'description'       => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product description', 'wp-graphql-woocommerce' );
+					return __( 'Product description', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PostObjectFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the field output', 'wp-graphql-woocommerce' );
+							return __( 'Format of the field output', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -156,13 +156,13 @@ class Product {
 			'shortDescription'  => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product short description', 'wp-graphql-woocommerce' );
+					return __( 'Product short description', 'graphql-for-ecommerce' );
 				},
 				'args'        => [
 					'format' => [
 						'type'        => 'PostObjectFieldFormatEnum',
 						'description' => static function () {
-							return __( 'Format of the field output', 'wp-graphql-woocommerce' );
+							return __( 'Format of the field output', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -178,61 +178,61 @@ class Product {
 			'sku'               => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Product SKU', 'wp-graphql-woocommerce' );
+					return __( 'Product SKU', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateOnSaleFrom'    => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Date on sale from', 'wp-graphql-woocommerce' );
+					return __( 'Date on sale from', 'graphql-for-ecommerce' );
 				},
 			],
 			'dateOnSaleTo'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Date on sale to', 'wp-graphql-woocommerce' );
+					return __( 'Date on sale to', 'graphql-for-ecommerce' );
 				},
 			],
 			'totalSales'        => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Number total of sales', 'wp-graphql-woocommerce' );
+					return __( 'Number total of sales', 'graphql-for-ecommerce' );
 				},
 			],
 			'reviewsAllowed'    => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'If reviews are allowed', 'wp-graphql-woocommerce' );
+					return __( 'If reviews are allowed', 'graphql-for-ecommerce' );
 				},
 			],
 			'purchaseNote'      => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Purchase note', 'wp-graphql-woocommerce' );
+					return __( 'Purchase note', 'graphql-for-ecommerce' );
 				},
 			],
 			'menuOrder'         => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Menu order', 'wp-graphql-woocommerce' );
+					return __( 'Menu order', 'graphql-for-ecommerce' );
 				},
 			],
 			'averageRating'     => [
 				'type'        => 'Float',
 				'description' => static function () {
-					return __( 'Product average count', 'wp-graphql-woocommerce' );
+					return __( 'Product average count', 'graphql-for-ecommerce' );
 				},
 			],
 			'reviewCount'       => [
 				'type'        => 'Int',
 				'description' => static function () {
-					return __( 'Product review count', 'wp-graphql-woocommerce' );
+					return __( 'Product review count', 'graphql-for-ecommerce' );
 				},
 			],
 			'image'             => [
 				'type'        => 'MediaItem',
 				'description' => static function () {
-					return __( 'Main image', 'wp-graphql-woocommerce' );
+					return __( 'Main image', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source, array $args, AppContext $context ) {
 					// @codingStandardsIgnoreLine.
@@ -245,19 +245,19 @@ class Product {
 			'onSale'            => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Is product on sale?', 'wp-graphql-woocommerce' );
+					return __( 'Is product on sale?', 'graphql-for-ecommerce' );
 				},
 			],
 			'purchasable'       => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Can product be purchased?', 'wp-graphql-woocommerce' );
+					return __( 'Can product be purchased?', 'graphql-for-ecommerce' );
 				},
 			],
 			'virtual'           => [
 				'type'        => 'Boolean',
 				'description' => static function () {
-					return __( 'Is product virtual?', 'wp-graphql-woocommerce' );
+					return __( 'Is product virtual?', 'graphql-for-ecommerce' );
 				},
 			],
 			'metaData'          => \WPGraphQL\WooCommerce\Type\WPObject\Meta_Data_Type::get_metadata_field_definition(),

--- a/includes/type/interface/class-wc-setting.php
+++ b/includes/type/interface/class-wc-setting.php
@@ -50,14 +50,14 @@ class WC_Setting {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A WC setting object', 'wp-graphql-woocommerce' );
+					return __( 'A WC setting object', 'graphql-for-ecommerce' );
 				},
 				'resolveType'     => [ self::class, 'resolve_type' ],
 				'fields'          => [
 					'id'          => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The globally unique identifier for the WC setting.', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the WC setting.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return $source['id'] ?? null;
@@ -66,7 +66,7 @@ class WC_Setting {
 					'label'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A human readable label for the setting used in user interfaces.', 'wp-graphql-woocommerce' );
+							return __( 'A human readable label for the setting used in user interfaces.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return $source['label'] ?? $source['title'] ?? null;
@@ -75,7 +75,7 @@ class WC_Setting {
 					'groupId'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'The ID of the settings group this setting belongs to.', 'wp-graphql-woocommerce' );
+							return __( 'The ID of the settings group this setting belongs to.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return $source['group_id'] ?? null;
@@ -84,7 +84,7 @@ class WC_Setting {
 					'description' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A human readable description for the setting used in user interfaces.', 'wp-graphql-woocommerce' );
+							return __( 'A human readable description for the setting used in user interfaces.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['description'] ) ? $source['description'] : null;
@@ -93,7 +93,7 @@ class WC_Setting {
 					'type'        => [
 						'type'        => 'WCSettingTypeEnum',
 						'description' => static function () {
-							return __( 'Type of setting.', 'wp-graphql-woocommerce' );
+							return __( 'Type of setting.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$raw_type = $source['type'] ?? '';
@@ -103,7 +103,7 @@ class WC_Setting {
 					'tip'         => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Additional help text shown to the user about the setting', 'wp-graphql-woocommerce' );
+							return __( 'Additional help text shown to the user about the setting', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['desc_tip'] ) ? $source['desc_tip'] : ( ! empty( $source['tip'] ) ? $source['tip'] : null );
@@ -112,7 +112,7 @@ class WC_Setting {
 					'placeholder' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Placeholder text to be displayed in text inputs.', 'wp-graphql-woocommerce' );
+							return __( 'Placeholder text to be displayed in text inputs.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['placeholder'] ) ? $source['placeholder'] : null;
@@ -121,7 +121,7 @@ class WC_Setting {
 					'options'     => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Array of option key/value pairs for select and multiselect types.', 'wp-graphql-woocommerce' );
+							return __( 'Array of option key/value pairs for select and multiselect types.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							if ( empty( $source['options'] ) || ! is_array( $source['options'] ) ) {

--- a/includes/type/object/class-cart-error-types.php
+++ b/includes/type/object/class-cart-error-types.php
@@ -22,14 +22,14 @@ class Cart_Error_Types {
 			'CartItemError',
 			[
 				'description' => static function () {
-					return __( 'Error that occurred when adding an item to the cart.', 'wp-graphql-woocommerce' );
+					return __( 'Error that occurred when adding an item to the cart.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'CartError' ],
 				'fields'      => [
 					'productId'   => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => static function () {
-							return __( 'Cart item product database ID or global ID', 'wp-graphql-woocommerce' );
+							return __( 'Cart item product database ID or global ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return ! empty( $error['productId'] ) ? $error['productId'] : null;
@@ -38,7 +38,7 @@ class Cart_Error_Types {
 					'quantity'    => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Cart item quantity', 'wp-graphql-woocommerce' );
+							return __( 'Cart item quantity', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return ! empty( $error['quantity'] ) ? $error['quantity'] : null;
@@ -47,7 +47,7 @@ class Cart_Error_Types {
 					'variationId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Cart item product variation database ID or global ID', 'wp-graphql-woocommerce' );
+							return __( 'Cart item product variation database ID or global ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return ! empty( $error['variationId'] ) ? $error['variationId'] : null;
@@ -56,7 +56,7 @@ class Cart_Error_Types {
 					'variation'   => [
 						'type'        => [ 'list_of' => 'ProductAttributeOutput' ],
 						'description' => static function () {
-							return __( 'Cart item product variation attributes', 'wp-graphql-woocommerce' );
+							return __( 'Cart item product variation attributes', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return ! empty( $error['variation'] ) ? $error['variation'] : null;
@@ -65,7 +65,7 @@ class Cart_Error_Types {
 					'extraData'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'JSON string representation of extra cart item data', 'wp-graphql-woocommerce' );
+							return __( 'JSON string representation of extra cart item data', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return ! empty( $error['extraData'] ) ? $error['extraData'] : null;
@@ -79,14 +79,14 @@ class Cart_Error_Types {
 			'CouponError',
 			[
 				'description' => static function () {
-					return __( 'Error that occurred when applying a coupon to the cart.', 'wp-graphql-woocommerce' );
+					return __( 'Error that occurred when applying a coupon to the cart.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'CartError' ],
 				'fields'      => [
 					'code' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Coupon code of the coupon the failed to be applied', 'wp-graphql-woocommerce' );
+							return __( 'Coupon code of the coupon the failed to be applied', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return ! empty( $error['code'] ) ? $error['code'] : null;
@@ -100,14 +100,14 @@ class Cart_Error_Types {
 			'ShippingMethodError',
 			[
 				'description' => static function () {
-					return __( 'Error that occurred when setting the chosen shipping method for the eventually order.', 'wp-graphql-woocommerce' );
+					return __( 'Error that occurred when setting the chosen shipping method for the eventually order.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'CartError' ],
 				'fields'      => [
 					'package'      => [
 						'type'        => [ 'non_null' => 'Integer' ],
 						'description' => static function () {
-							return __( 'Index of package for desired shipping method', 'wp-graphql-woocommerce' );
+							return __( 'Index of package for desired shipping method', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return isset( $error['package'] ) && is_int( $error['package'] ) ? $error['package'] : null;
@@ -116,7 +116,7 @@ class Cart_Error_Types {
 					'chosenMethod' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'ID of chosen shipping rate', 'wp-graphql-woocommerce' );
+							return __( 'ID of chosen shipping rate', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $error ) {
 							return ! empty( $error['chosen_method'] ) ? $error['chosen_method'] : null;
@@ -130,7 +130,7 @@ class Cart_Error_Types {
 			'UnknownCartError',
 			[
 				'description' => static function () {
-					return __( 'Error that occurred with no recognizable reason.', 'wp-graphql-woocommerce' );
+					return __( 'Error that occurred with no recognizable reason.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'CartError' ],
 				'fields'      => [],

--- a/includes/type/object/class-cart-notice.php
+++ b/includes/type/object/class-cart-notice.php
@@ -22,13 +22,13 @@ class Cart_Notice {
 			'CartNotice',
 			[
 				'description' => static function () {
-					return __( 'A WooCommerce notice', 'wp-graphql-woocommerce' );
+					return __( 'A WooCommerce notice', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'type'    => [
 						'type'        => 'CartNoticeTypeEnum',
 						'description' => static function () {
-							return __( 'Notice type', 'wp-graphql-woocommerce' );
+							return __( 'Notice type', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $notice ) {
 							return $notice['type'] ?? null;
@@ -37,7 +37,7 @@ class Cart_Notice {
 					'message' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Notice message', 'wp-graphql-woocommerce' );
+							return __( 'Notice message', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $notice ) {
 							return $notice['message'] ?? null;

--- a/includes/type/object/class-cart-type.php
+++ b/includes/type/object/class-cart-type.php
@@ -45,13 +45,13 @@ class Cart_Type {
 				'subtotal'                 => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart subtotal', 'wp-graphql-woocommerce' );
+						return __( 'Cart subtotal', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -68,13 +68,13 @@ class Cart_Type {
 				'subtotalTax'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart subtotal tax', 'wp-graphql-woocommerce' );
+						return __( 'Cart subtotal tax', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -91,13 +91,13 @@ class Cart_Type {
 				'discountTotal'            => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart discount total', 'wp-graphql-woocommerce' );
+						return __( 'Cart discount total', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -114,13 +114,13 @@ class Cart_Type {
 				'discountTax'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart discount tax', 'wp-graphql-woocommerce' );
+						return __( 'Cart discount tax', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -137,7 +137,7 @@ class Cart_Type {
 				'availableShippingMethods' => [
 					'type'        => [ 'list_of' => 'ShippingPackage' ],
 					'description' => static function () {
-						return __( 'Available shipping methods for this order.', 'wp-graphql-woocommerce' );
+						return __( 'Available shipping methods for this order.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$packages = [];
@@ -157,7 +157,7 @@ class Cart_Type {
 				'chosenShippingMethods'    => [
 					'type'        => [ 'list_of' => 'String' ],
 					'description' => static function () {
-						return __( 'Shipping method chosen for this order.', 'wp-graphql-woocommerce' );
+						return __( 'Shipping method chosen for this order.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$chosen_shipping_methods = [];
@@ -178,13 +178,13 @@ class Cart_Type {
 				'shippingTotal'            => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart shipping total', 'wp-graphql-woocommerce' );
+						return __( 'Cart shipping total', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -201,13 +201,13 @@ class Cart_Type {
 				'shippingTax'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart shipping tax', 'wp-graphql-woocommerce' );
+						return __( 'Cart shipping tax', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -224,13 +224,13 @@ class Cart_Type {
 				'contentsTotal'            => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart contents total', 'wp-graphql-woocommerce' );
+						return __( 'Cart contents total', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -255,13 +255,13 @@ class Cart_Type {
 				'contentsTax'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart contents tax', 'wp-graphql-woocommerce' );
+						return __( 'Cart contents tax', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -280,14 +280,14 @@ class Cart_Type {
 				'feeTotal'                 => [
 					'type'              => 'String',
 					'description'       => static function () {
-						return __( 'Cart fee total', 'wp-graphql-woocommerce' );
+						return __( 'Cart fee total', 'graphql-for-ecommerce' );
 					},
-					'deprecationReason' => __( 'Always null', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Always null', 'graphql-for-ecommerce' ),
 					'args'              => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -304,14 +304,14 @@ class Cart_Type {
 				'feeTax'                   => [
 					'type'              => 'String',
 					'description'       => static function () {
-						return __( 'Cart fee tax', 'wp-graphql-woocommerce' );
+						return __( 'Cart fee tax', 'graphql-for-ecommerce' );
 					},
-					'deprecationReason' => __( 'Always null', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Always null', 'graphql-for-ecommerce' ),
 					'args'              => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -328,13 +328,13 @@ class Cart_Type {
 				'total'                    => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart total after calculation', 'wp-graphql-woocommerce' );
+						return __( 'Cart total after calculation', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -354,13 +354,13 @@ class Cart_Type {
 				'totalTax'                 => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart total tax amount', 'wp-graphql-woocommerce' );
+						return __( 'Cart total tax amount', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -377,7 +377,7 @@ class Cart_Type {
 				'totalTaxes'               => [
 					'type'        => [ 'list_of' => 'CartTax' ],
 					'description' => static function () {
-						return __( 'Cart total taxes itemized', 'wp-graphql-woocommerce' );
+						return __( 'Cart total taxes itemized', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$taxes = $source->get_tax_totals();
@@ -387,7 +387,7 @@ class Cart_Type {
 				'isEmpty'                  => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Is cart empty', 'wp-graphql-woocommerce' );
+						return __( 'Is cart empty', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						return ! is_null( $source->is_empty() ) ? $source->is_empty() : null;
@@ -396,7 +396,7 @@ class Cart_Type {
 				'displayPricesIncludeTax'  => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Do display prices include taxes', 'wp-graphql-woocommerce' );
+						return __( 'Do display prices include taxes', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						return ! is_null( $source->display_prices_including_tax() )
@@ -407,7 +407,7 @@ class Cart_Type {
 				'needsShippingAddress'     => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Is customer shipping address needed', 'wp-graphql-woocommerce' );
+						return __( 'Is customer shipping address needed', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						return ! is_null( $source->needs_shipping_address() )
@@ -418,9 +418,9 @@ class Cart_Type {
 				'fees'                     => [
 					'type'              => [ 'list_of' => 'CartFee' ],
 					'description'       => static function () {
-						return __( 'Additional fees on the cart.', 'wp-graphql-woocommerce' );
+						return __( 'Additional fees on the cart.', 'graphql-for-ecommerce' );
 					},
-					'deprecationReason' => __( 'Always null', 'wp-graphql-woocommerce' ),
+					'deprecationReason' => __( 'Always null', 'graphql-for-ecommerce' ),
 					'resolve'           => static function ( $source ) {
 						$fees = $source->get_fees();
 						return ! empty( $fees ) ? array_values( $fees ) : null;
@@ -429,7 +429,7 @@ class Cart_Type {
 				'appliedCoupons'           => [
 					'type'        => [ 'list_of' => 'AppliedCoupon' ],
 					'description' => static function () {
-						return __( 'Coupons applied to the cart', 'wp-graphql-woocommerce' );
+						return __( 'Coupons applied to the cart', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$applied_coupons = $source->get_applied_coupons();
@@ -440,7 +440,7 @@ class Cart_Type {
 				'taxLines'                 => [
 					'type'        => [ 'list_of' => 'CartTaxLine' ],
 					'description' => static function () {
-						return __( 'Cart tax lines itemized', 'wp-graphql-woocommerce' );
+						return __( 'Cart tax lines itemized', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $cart ) {
 						if ( 'itemized' !== get_option( 'woocommerce_tax_total_display' ) ) {
@@ -477,13 +477,13 @@ class Cart_Type {
 			'CartTaxLine',
 			[
 				'description' => static function () {
-					return __( 'The cart tax line object', 'wp-graphql-woocommerce' );
+					return __( 'The cart tax line object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'name'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax line name', 'wp-graphql-woocommerce' );
+							return __( 'Tax line name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['name'] ) ? $source['name'] : null;
@@ -492,7 +492,7 @@ class Cart_Type {
 					'price' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax line price', 'wp-graphql-woocommerce' );
+							return __( 'Tax line price', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['price'] ) ? wc_graphql_price( $source['price'] ) : null;
@@ -501,7 +501,7 @@ class Cart_Type {
 					'rate'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax line rate', 'wp-graphql-woocommerce' );
+							return __( 'Tax line rate', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['rate'] ) ? $source['rate'] : null;
@@ -527,7 +527,7 @@ class Cart_Type {
 						'needsShipping' => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Limit results to cart items that require shipping', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to cart items that require shipping', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -535,7 +535,7 @@ class Cart_Type {
 						'itemCount'    => [
 							'type'        => 'Int',
 							'description' => static function () {
-								return __( 'Total number of items in the cart.', 'wp-graphql-woocommerce' );
+								return __( 'Total number of items in the cart.', 'graphql-for-ecommerce' );
 							},
 							'resolve'     => static function ( $source ) {
 								if ( empty( $source['edges'] ) ) {
@@ -553,7 +553,7 @@ class Cart_Type {
 						'productCount' => [
 							'type'        => 'Int',
 							'description' => static function () {
-								return __( 'Total number of different products in the cart', 'wp-graphql-woocommerce' );
+								return __( 'Total number of different products in the cart', 'graphql-for-ecommerce' );
 							},
 							'resolve'     => static function ( $source ) {
 								if ( empty( $source['edges'] ) ) {
@@ -585,7 +585,7 @@ class Cart_Type {
 			'Cart',
 			[
 				'description' => static function () {
-					return __( 'The cart object', 'wp-graphql-woocommerce' );
+					return __( 'The cart object', 'graphql-for-ecommerce' );
 				},
 				/**
 				 * Allows for a decisive filtering of the cart fields.
@@ -617,13 +617,13 @@ class Cart_Type {
 			'CartFee',
 			[
 				'description' => static function () {
-					return __( 'An additional fee', 'wp-graphql-woocommerce' );
+					return __( 'An additional fee', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'       => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Fee ID', 'wp-graphql-woocommerce' );
+							return __( 'Fee ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->id ) ? $source->id : null;
@@ -632,7 +632,7 @@ class Cart_Type {
 					'name'     => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Fee name', 'wp-graphql-woocommerce' );
+							return __( 'Fee name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->name ) ? $source->name : null;
@@ -641,7 +641,7 @@ class Cart_Type {
 					'taxClass' => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'Fee tax class', 'wp-graphql-woocommerce' );
+							return __( 'Fee tax class', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->tax_class ) ? $source->tax_class : null;
@@ -650,7 +650,7 @@ class Cart_Type {
 					'taxable'  => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Is fee taxable?', 'wp-graphql-woocommerce' );
+							return __( 'Is fee taxable?', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! is_null( $source->taxable ) ? $source->taxable : null;
@@ -659,7 +659,7 @@ class Cart_Type {
 					'amount'   => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Fee amount', 'wp-graphql-woocommerce' );
+							return __( 'Fee amount', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! is_null( $source->amount ) ? $source->amount : 0;
@@ -668,7 +668,7 @@ class Cart_Type {
 					'total'    => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Fee total', 'wp-graphql-woocommerce' );
+							return __( 'Fee total', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! is_null( $source->total ) ? $source->total : 0;
@@ -689,13 +689,13 @@ class Cart_Type {
 			'CartTax',
 			[
 				'description' => static function () {
-					return __( 'An itemized cart tax item', 'wp-graphql-woocommerce' );
+					return __( 'An itemized cart tax item', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'         => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Tax Rate ID', 'wp-graphql-woocommerce' );
+							return __( 'Tax Rate ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->tax_rate_id ) ? $source->tax_rate_id : null;
@@ -704,7 +704,7 @@ class Cart_Type {
 					'label'      => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Tax label', 'wp-graphql-woocommerce' );
+							return __( 'Tax label', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->label ) ? $source->label : null;
@@ -713,7 +713,7 @@ class Cart_Type {
 					'isCompound' => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Is tax compound?', 'wp-graphql-woocommerce' );
+							return __( 'Is tax compound?', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->is_compound ) ? $source->is_compound : null;
@@ -722,13 +722,13 @@ class Cart_Type {
 					'amount'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax amount', 'wp-graphql-woocommerce' );
+							return __( 'Tax amount', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -761,13 +761,13 @@ class Cart_Type {
 			'AppliedCoupon',
 			[
 				'description' => static function () {
-					return __( 'Coupon applied to the shopping cart.', 'wp-graphql-woocommerce' );
+					return __( 'Coupon applied to the shopping cart.', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'code'           => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Coupon code', 'wp-graphql-woocommerce' );
+							return __( 'Coupon code', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return $source;
@@ -779,18 +779,18 @@ class Cart_Type {
 							'excludeTax' => [
 								'type'        => 'Boolean',
 								'description' => static function () {
-									return __( 'Exclude Taxes (Default "true")', 'wp-graphql-woocommerce' );
+									return __( 'Exclude Taxes (Default "true")', 'graphql-for-ecommerce' );
 								},
 							],
 							'format'     => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
 						'description' => static function () {
-							return __( 'Discount applied with this coupon', 'wp-graphql-woocommerce' );
+							return __( 'Discount applied with this coupon', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args ) {
 							$ex_tax = ! empty( $args['excludeTax'] ) ? $args['excludeTax'] : true;
@@ -806,13 +806,13 @@ class Cart_Type {
 					'discountTax'    => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Taxes on discount applied with this coupon', 'wp-graphql-woocommerce' );
+							return __( 'Taxes on discount applied with this coupon', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -829,7 +829,7 @@ class Cart_Type {
 					'description'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Description of applied coupon', 'wp-graphql-woocommerce' );
+							return __( 'Description of applied coupon', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$coupon = new \WC_Coupon( $source );

--- a/includes/type/object/class-collection-stats-type.php
+++ b/includes/type/object/class-collection-stats-type.php
@@ -23,7 +23,7 @@ class Collection_Stats_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'Price range', 'wp-graphql-woocommerce' );
+					return __( 'Price range', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'minPrice' => [
@@ -32,12 +32,12 @@ class Collection_Stats_Type {
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
 						'description' => static function () {
-							return __( 'Minimum price', 'wp-graphql-woocommerce' );
+							return __( 'Minimum price', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args ) {
 							if ( empty( $source['min_price'] ) ) {
@@ -57,12 +57,12 @@ class Collection_Stats_Type {
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
 						'description' => static function () {
-							return __( 'Maximum price', 'wp-graphql-woocommerce' );
+							return __( 'Maximum price', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args ) {
 							if ( empty( $source['max_price'] ) ) {
@@ -85,13 +85,13 @@ class Collection_Stats_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'Product attribute terms count', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute terms count', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'slug'  => [
 						'type'        => [ 'non_null' => 'ProductAttributeEnum' ],
 						'description' => static function () {
-							return __( 'Attribute name', 'wp-graphql-woocommerce' );
+							return __( 'Attribute name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return $source->name;
@@ -100,7 +100,7 @@ class Collection_Stats_Type {
 					'label' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Attribute taxonomy', 'wp-graphql-woocommerce' );
+							return __( 'Attribute taxonomy', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$taxonomy = get_taxonomy( $source->name );
@@ -114,7 +114,7 @@ class Collection_Stats_Type {
 					'name'  => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Attribute name', 'wp-graphql-woocommerce' );
+							return __( 'Attribute name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$taxonomy = get_taxonomy( $source->name );
@@ -128,7 +128,7 @@ class Collection_Stats_Type {
 					'terms' => [
 						'type'        => [ 'list_of' => 'SingleAttributeCount' ],
 						'description' => static function () {
-							return __( 'Attribute terms', 'wp-graphql-woocommerce' );
+							return __( 'Attribute terms', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -140,25 +140,25 @@ class Collection_Stats_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'Single attribute term count', 'wp-graphql-woocommerce' );
+					return __( 'Single attribute term count', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'termId' => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Term ID', 'wp-graphql-woocommerce' );
+							return __( 'Term ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'count'  => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Number of products.', 'wp-graphql-woocommerce' );
+							return __( 'Number of products.', 'graphql-for-ecommerce' );
 						},
 					],
 					'node'   => [
 						'type'        => 'TermNode',
 						'description' => static function () {
-							return __( 'Term object.', 'wp-graphql-woocommerce' );
+							return __( 'Term object.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							if ( empty( $source->termId ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -186,19 +186,19 @@ class Collection_Stats_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'Single rating count', 'wp-graphql-woocommerce' );
+					return __( 'Single rating count', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'rating' => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => static function () {
-							return __( 'Average rating', 'wp-graphql-woocommerce' );
+							return __( 'Average rating', 'graphql-for-ecommerce' );
 						},
 					],
 					'count'  => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Number of products', 'wp-graphql-woocommerce' );
+							return __( 'Number of products', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -210,19 +210,19 @@ class Collection_Stats_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'Single stock status count', 'wp-graphql-woocommerce' );
+					return __( 'Single stock status count', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'status' => [
 						'type'        => [ 'non_null' => 'StockStatusEnum' ],
 						'description' => static function () {
-							return __( 'Status', 'wp-graphql-woocommerce' );
+							return __( 'Status', 'graphql-for-ecommerce' );
 						},
 					],
 					'count'  => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Number of products.', 'wp-graphql-woocommerce' );
+							return __( 'Number of products.', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -233,13 +233,13 @@ class Collection_Stats_Type {
 			'CollectionStats',
 			[
 				'description' => static function () {
-					return __( 'Data about a collection of products', 'wp-graphql-woocommerce' );
+					return __( 'Data about a collection of products', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'priceRange'        => [
 						'type'        => 'PriceRange',
 						'description' => static function () {
-							return __( 'Min and max prices found in collection of products, provided using the smallest unit of the currency', 'wp-graphql-woocommerce' );
+							return __( 'Min and max prices found in collection of products, provided using the smallest unit of the currency', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$min_price = ! empty( $source['min_price'] ) ? $source['min_price'] : null;
@@ -253,18 +253,18 @@ class Collection_Stats_Type {
 							'page'    => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'Page of results to return', 'wp-graphql-woocommerce' );
+									return __( 'Page of results to return', 'graphql-for-ecommerce' );
 								},
 							],
 							'perPage' => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'Number of results to return per page', 'wp-graphql-woocommerce' );
+									return __( 'Number of results to return per page', 'graphql-for-ecommerce' );
 								},
 							],
 						],
 						'description' => static function () {
-							return __( 'Returns number of products within attribute terms', 'wp-graphql-woocommerce' );
+							return __( 'Returns number of products within attribute terms', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, $args ) {
 							$page             = ! empty( $args['page'] ) ? $args['page'] : 1;
@@ -291,18 +291,18 @@ class Collection_Stats_Type {
 							'page'    => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'Page of results to return', 'wp-graphql-woocommerce' );
+									return __( 'Page of results to return', 'graphql-for-ecommerce' );
 								},
 							],
 							'perPage' => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'Number of results to return per page', 'wp-graphql-woocommerce' );
+									return __( 'Number of results to return per page', 'graphql-for-ecommerce' );
 								},
 							],
 						],
 						'description' => static function () {
-							return __( 'Returns number of products with each average rating', 'wp-graphql-woocommerce' );
+							return __( 'Returns number of products with each average rating', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, $args ) {
 							$page          = ! empty( $args['page'] ) ? $args['page'] : 1;
@@ -323,18 +323,18 @@ class Collection_Stats_Type {
 							'page'    => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'Page of results to return', 'wp-graphql-woocommerce' );
+									return __( 'Page of results to return', 'graphql-for-ecommerce' );
 								},
 							],
 							'perPage' => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'Number of results to return per page', 'wp-graphql-woocommerce' );
+									return __( 'Number of results to return per page', 'graphql-for-ecommerce' );
 								},
 							],
 						],
 						'description' => static function () {
-							return __( 'Returns number of products with each stock status', 'wp-graphql-woocommerce' );
+							return __( 'Returns number of products with each stock status', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, $args ) {
 							$page                = ! empty( $args['page'] ) ? $args['page'] : 1;
@@ -475,7 +475,7 @@ class Collection_Stats_Type {
 			if ( ! empty( $where_args['attributes']['relation'] ) ) {
 				$relation = $where_args['attributes']['relation'];
 				if ( 'NOT_IN' === $relation ) {
-					graphql_debug( __( 'NOT_IN relation is not supported for attributes queries top-level "relation" field. Use "IN" or "AND" instead.', 'wp-graphql-woocommerce' ) );
+					graphql_debug( __( 'NOT_IN relation is not supported for attributes queries top-level "relation" field. Use "IN" or "AND" instead.', 'graphql-for-ecommerce' ) );
 					$relation = 'IN';
 				}
 				$request->set_param( 'attributes_relation', $where_args['attributes']['relation'] );

--- a/includes/type/object/class-country-state-type.php
+++ b/includes/type/object/class-country-state-type.php
@@ -24,13 +24,13 @@ class Country_State_Type {
 			'CountryState',
 			[
 				'description' => static function () {
-					return __( 'shipping country state object', 'wp-graphql-woocommerce' );
+					return __( 'shipping country state object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'code' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Country state code', 'wp-graphql-woocommerce' );
+							return __( 'Country state code', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['code'] ) ? $source['code'] : null;
@@ -39,7 +39,7 @@ class Country_State_Type {
 					'name' => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Country state name', 'wp-graphql-woocommerce' );
+							return __( 'Country state name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['name'] ) ? $source['name'] : null;

--- a/includes/type/object/class-coupon-type.php
+++ b/includes/type/object/class-coupon-type.php
@@ -24,122 +24,122 @@ class Coupon_Type {
 			'Coupon',
 			[
 				'description' => static function () {
-					return __( 'A coupon object', 'wp-graphql-woocommerce' );
+					return __( 'A coupon object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'                 => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The globally unique identifier for the coupon', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the coupon', 'graphql-for-ecommerce' );
 						},
 					],
 					'databaseId'         => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'The ID of the coupon in the database', 'wp-graphql-woocommerce' );
+							return __( 'The ID of the coupon in the database', 'graphql-for-ecommerce' );
 						},
 					],
 					'code'               => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Coupon code', 'wp-graphql-woocommerce' );
+							return __( 'Coupon code', 'graphql-for-ecommerce' );
 						},
 					],
 					'date'               => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Date coupon created', 'wp-graphql-woocommerce' );
+							return __( 'Date coupon created', 'graphql-for-ecommerce' );
 						},
 					],
 					'modified'           => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Date coupon modified', 'wp-graphql-woocommerce' );
+							return __( 'Date coupon modified', 'graphql-for-ecommerce' );
 						},
 					],
 					'description'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Explanation of what the coupon does', 'wp-graphql-woocommerce' );
+							return __( 'Explanation of what the coupon does', 'graphql-for-ecommerce' );
 						},
 					],
 					'discountType'       => [
 						'type'        => 'DiscountTypeEnum',
 						'description' => static function () {
-							return __( 'Type of discount', 'wp-graphql-woocommerce' );
+							return __( 'Type of discount', 'graphql-for-ecommerce' );
 						},
 					],
 					'amount'             => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Amount off provided by the coupon', 'wp-graphql-woocommerce' );
+							return __( 'Amount off provided by the coupon', 'graphql-for-ecommerce' );
 						},
 					],
 					'dateExpiry'         => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Date coupon expires', 'wp-graphql-woocommerce' );
+							return __( 'Date coupon expires', 'graphql-for-ecommerce' );
 						},
 					],
 					'usageCount'         => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'How many times the coupon has been used', 'wp-graphql-woocommerce' );
+							return __( 'How many times the coupon has been used', 'graphql-for-ecommerce' );
 						},
 					],
 					'individualUse'      => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Individual use means this coupon cannot be used in conjunction with other coupons', 'wp-graphql-woocommerce' );
+							return __( 'Individual use means this coupon cannot be used in conjunction with other coupons', 'graphql-for-ecommerce' );
 						},
 					],
 					'usageLimit'         => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Amount of times this coupon can be used globally', 'wp-graphql-woocommerce' );
+							return __( 'Amount of times this coupon can be used globally', 'graphql-for-ecommerce' );
 						},
 					],
 					'usageLimitPerUser'  => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Amount of times this coupon can be used by a customer', 'wp-graphql-woocommerce' );
+							return __( 'Amount of times this coupon can be used by a customer', 'graphql-for-ecommerce' );
 						},
 					],
 					'limitUsageToXItems' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'The number of products in your cart this coupon can apply to (for product discounts)', 'wp-graphql-woocommerce' );
+							return __( 'The number of products in your cart this coupon can apply to (for product discounts)', 'graphql-for-ecommerce' );
 						},
 					],
 					'freeShipping'       => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Does this coupon grant free shipping?', 'wp-graphql-woocommerce' );
+							return __( 'Does this coupon grant free shipping?', 'graphql-for-ecommerce' );
 						},
 					],
 					'excludeSaleItems'   => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Excluding sale items mean this coupon cannot be used on items that are on sale (or carts that contain on sale items)', 'wp-graphql-woocommerce' );
+							return __( 'Excluding sale items mean this coupon cannot be used on items that are on sale (or carts that contain on sale items)', 'graphql-for-ecommerce' );
 						},
 					],
 					'minimumAmount'      => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Minimum spend amount that must be met before this coupon can be used', 'wp-graphql-woocommerce' );
+							return __( 'Minimum spend amount that must be met before this coupon can be used', 'graphql-for-ecommerce' );
 						},
 					],
 					'maximumAmount'      => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Maximum spend amount that must be met before this coupon can be used ', 'wp-graphql-woocommerce' );
+							return __( 'Maximum spend amount that must be met before this coupon can be used ', 'graphql-for-ecommerce' );
 						},
 					],
 					'emailRestrictions'  => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Only customers with a matching email address can use the coupon', 'wp-graphql-woocommerce' );
+							return __( 'Only customers with a matching email address can use the coupon', 'graphql-for-ecommerce' );
 						},
 					],
 					'metaData'           => Meta_Data_Type::get_metadata_field_definition(),

--- a/includes/type/object/class-customer-address-type.php
+++ b/includes/type/object/class-customer-address-type.php
@@ -24,13 +24,13 @@ class Customer_Address_Type {
 			'CustomerAddress',
 			[
 				'description' => static function () {
-					return __( 'A customer address object', 'wp-graphql-woocommerce' );
+					return __( 'A customer address object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'firstName' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'First name', 'wp-graphql-woocommerce' );
+							return __( 'First name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['first_name'] ) ? $address['first_name'] : null;
@@ -39,7 +39,7 @@ class Customer_Address_Type {
 					'lastName'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Last name', 'wp-graphql-woocommerce' );
+							return __( 'Last name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['last_name'] ) ? $address['last_name'] : null;
@@ -48,7 +48,7 @@ class Customer_Address_Type {
 					'company'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Company', 'wp-graphql-woocommerce' );
+							return __( 'Company', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['company'] ) ? $address['company'] : null;
@@ -57,7 +57,7 @@ class Customer_Address_Type {
 					'address1'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Address 1', 'wp-graphql-woocommerce' );
+							return __( 'Address 1', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['address_1'] ) ? $address['address_1'] : null;
@@ -66,7 +66,7 @@ class Customer_Address_Type {
 					'address2'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Address 2', 'wp-graphql-woocommerce' );
+							return __( 'Address 2', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['address_2'] ) ? $address['address_2'] : null;
@@ -75,7 +75,7 @@ class Customer_Address_Type {
 					'city'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'City', 'wp-graphql-woocommerce' );
+							return __( 'City', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['city'] ) ? $address['city'] : null;
@@ -84,7 +84,7 @@ class Customer_Address_Type {
 					'state'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'State', 'wp-graphql-woocommerce' );
+							return __( 'State', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['state'] ) ? $address['state'] : null;
@@ -93,7 +93,7 @@ class Customer_Address_Type {
 					'postcode'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Zip Postal Code', 'wp-graphql-woocommerce' );
+							return __( 'Zip Postal Code', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['postcode'] ) ? $address['postcode'] : null;
@@ -102,7 +102,7 @@ class Customer_Address_Type {
 					'country'   => [
 						'type'        => 'CountriesEnum',
 						'description' => static function () {
-							return __( 'Country', 'wp-graphql-woocommerce' );
+							return __( 'Country', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['country'] ) ? $address['country'] : null;
@@ -111,7 +111,7 @@ class Customer_Address_Type {
 					'email'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'E-mail', 'wp-graphql-woocommerce' );
+							return __( 'E-mail', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['email'] ) ? $address['email'] : null;
@@ -120,7 +120,7 @@ class Customer_Address_Type {
 					'phone'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Phone', 'wp-graphql-woocommerce' );
+							return __( 'Phone', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $address ) {
 							return ! empty( $address['phone'] ) ? $address['phone'] : null;

--- a/includes/type/object/class-customer-type.php
+++ b/includes/type/object/class-customer-type.php
@@ -34,13 +34,13 @@ class Customer_Type {
 				'id'                    => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'The globally unique identifier for the customer', 'wp-graphql-woocommerce' );
+						return __( 'The globally unique identifier for the customer', 'graphql-for-ecommerce' );
 					},
 				],
 				'databaseId'            => [
 					'type'        => 'Int',
 					'description' => static function () {
-						return __( 'The ID of the customer in the database', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the customer in the database', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$database_id = absint( $source->ID );
@@ -50,25 +50,25 @@ class Customer_Type {
 				'isVatExempt'           => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Is customer VAT exempt?', 'wp-graphql-woocommerce' );
+						return __( 'Is customer VAT exempt?', 'graphql-for-ecommerce' );
 					},
 				],
 				'hasCalculatedShipping' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Has calculated shipping?', 'wp-graphql-woocommerce' );
+						return __( 'Has calculated shipping?', 'graphql-for-ecommerce' );
 					},
 				],
 				'calculatedShipping'    => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Has customer calculated shipping?', 'wp-graphql-woocommerce' );
+						return __( 'Has customer calculated shipping?', 'graphql-for-ecommerce' );
 					},
 				],
 				'lastOrder'             => [
 					'type'        => 'Order',
 					'description' => static function () {
-						return __( 'Gets the customers last order.', 'wp-graphql-woocommerce' );
+						return __( 'Gets the customers last order.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source, array $args, AppContext $context ) {
 						return Factory::resolve_crud_object( $source->last_order_id, $context );
@@ -77,86 +77,86 @@ class Customer_Type {
 				'orderCount'            => [
 					'type'        => 'Int',
 					'description' => static function () {
-						return __( 'Return the number of orders this customer has.', 'wp-graphql-woocommerce' );
+						return __( 'Return the number of orders this customer has.', 'graphql-for-ecommerce' );
 					},
 				],
 				'totalSpent'            => [
 					'type'        => 'Float',
 					'description' => static function () {
-						return __( 'Return how much money this customer has spent.', 'wp-graphql-woocommerce' );
+						return __( 'Return how much money this customer has spent.', 'graphql-for-ecommerce' );
 					},
 				],
 				'username'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the customer\'s username.', 'wp-graphql-woocommerce' );
+						return __( 'Return the customer\'s username.', 'graphql-for-ecommerce' );
 					},
 				],
 				'email'                 => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the customer\'s email.', 'wp-graphql-woocommerce' );
+						return __( 'Return the customer\'s email.', 'graphql-for-ecommerce' );
 					},
 				],
 				'firstName'             => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the customer\'s first name.', 'wp-graphql-woocommerce' );
+						return __( 'Return the customer\'s first name.', 'graphql-for-ecommerce' );
 					},
 				],
 				'lastName'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the customer\'s last name.', 'wp-graphql-woocommerce' );
+						return __( 'Return the customer\'s last name.', 'graphql-for-ecommerce' );
 					},
 				],
 				'displayName'           => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the customer\'s display name.', 'wp-graphql-woocommerce' );
+						return __( 'Return the customer\'s display name.', 'graphql-for-ecommerce' );
 					},
 				],
 				'role'                  => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the customer\'s user role.', 'wp-graphql-woocommerce' );
+						return __( 'Return the customer\'s user role.', 'graphql-for-ecommerce' );
 					},
 				],
 				'date'                  => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the date customer was created', 'wp-graphql-woocommerce' );
+						return __( 'Return the date customer was created', 'graphql-for-ecommerce' );
 					},
 				],
 				'modified'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Return the date customer was last updated', 'wp-graphql-woocommerce' );
+						return __( 'Return the date customer was last updated', 'graphql-for-ecommerce' );
 					},
 				],
 				'billing'               => [
 					'type'        => 'CustomerAddress',
 					'description' => static function () {
-						return __( 'Return the date customer billing address properties', 'wp-graphql-woocommerce' );
+						return __( 'Return the date customer billing address properties', 'graphql-for-ecommerce' );
 					},
 				],
 				'shipping'              => [
 					'type'        => 'CustomerAddress',
 					'description' => static function () {
-						return __( 'Return the date customer shipping address properties', 'wp-graphql-woocommerce' );
+						return __( 'Return the date customer shipping address properties', 'graphql-for-ecommerce' );
 					},
 				],
 				'isPayingCustomer'      => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Return the date customer was last updated', 'wp-graphql-woocommerce' );
+						return __( 'Return the date customer was last updated', 'graphql-for-ecommerce' );
 					},
 				],
 				'metaData'              => Meta_Data_Type::get_metadata_field_definition(),
 				'session'               => [
 					'type'        => [ 'list_of' => 'MetaData' ],
 					'description' => static function () {
-						return __( 'Session data for the viewing customer', 'wp-graphql-woocommerce' );
+						return __( 'Session data for the viewing customer', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						/**
@@ -180,7 +180,7 @@ class Customer_Type {
 							return $session;
 						}
 
-						throw new UserError( __( 'It\'s not possible to access another user\'s session data', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'It\'s not possible to access another user\'s session data', 'graphql-for-ecommerce' ) );
 					},
 				],
 			],
@@ -204,19 +204,19 @@ class Customer_Type {
 						'active'                => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Limit results to downloadable items that can be downloaded now.', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to downloadable items that can be downloaded now.', 'graphql-for-ecommerce' );
 							},
 						],
 						'expired'               => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Limit results to downloadable items that are expired.', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to downloadable items that are expired.', 'graphql-for-ecommerce' );
 							},
 						],
 						'hasDownloadsRemaining' => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Limit results to downloadable items that have downloads remaining.', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to downloadable items that have downloads remaining.', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -241,7 +241,7 @@ class Customer_Type {
 			'Customer',
 			[
 				'description' => static function () {
-					return __( 'A customer object', 'wp-graphql-woocommerce' );
+					return __( 'A customer object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				/**
@@ -272,7 +272,7 @@ class Customer_Type {
 				'availablePaymentMethods'   => [
 					'type'        => [ 'list_of' => 'PaymentTokenInterface' ],
 					'description' => static function () {
-						return __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' );
+						return __( 'Customer\'s stored payment tokens.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						if ( get_current_user_id() === $source->ID ) {
@@ -283,13 +283,13 @@ class Customer_Type {
 							return [];
 						}
 
-						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'graphql-for-ecommerce' ) );
 					},
 				],
 				'availablePaymentMethodsCC' => [
 					'type'        => [ 'list_of' => 'PaymentTokenCC' ],
 					'description' => static function () {
-						return __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' );
+						return __( 'Customer\'s stored payment tokens.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						if ( get_current_user_id() === $source->ID ) {
@@ -305,13 +305,13 @@ class Customer_Type {
 							return [];
 						}
 
-						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'graphql-for-ecommerce' ) );
 					},
 				],
 				'availablePaymentMethodsEC' => [
 					'type'        => [ 'list_of' => 'PaymentTokenECheck' ],
 					'description' => static function () {
-						return __( 'Customer\'s stored payment tokens.', 'wp-graphql-woocommerce' );
+						return __( 'Customer\'s stored payment tokens.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						if ( get_current_user_id() === $source->ID ) {
@@ -327,7 +327,7 @@ class Customer_Type {
 							return [];
 						}
 
-						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'wp-graphql-woocommerce' ) );
+						throw new UserError( __( 'Not authorized to view this user\'s payment methods.', 'graphql-for-ecommerce' ) );
 					},
 				],
 			]
@@ -351,7 +351,7 @@ class Customer_Type {
 				[
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' );
+						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						if ( \get_current_user_id() === $source->ID || 'guest' === $source->id ) {
@@ -383,7 +383,7 @@ class Customer_Type {
 				[
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' );
+						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						if ( \get_current_user_id() === $source->userId ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -417,7 +417,7 @@ class Customer_Type {
 				[
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' );
+						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						if ( \get_current_user_id() === $source->ID || 'guest' === $source->id ) {
@@ -449,7 +449,7 @@ class Customer_Type {
 				[
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'wp-graphql-woocommerce' );
+						return __( 'A JWT token that can be used in future requests to for WooCommerce session identification', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						if ( \get_current_user_id() === $source->userId ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -488,7 +488,7 @@ class Customer_Type {
 					'cartUrl'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonced link to the cart page. By default, it expires in 1 hour.', 'wp-graphql-woocommerce' );
+							return __( 'A nonced link to the cart page. By default, it expires in 1 hour.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							// Get current customer and user ID.
@@ -518,7 +518,7 @@ class Customer_Type {
 					'cartNonce' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce for the cart page. By default, it expires in 1 hour.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce for the cart page. By default, it expires in 1 hour.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							// Get current customer and user ID.
@@ -544,7 +544,7 @@ class Customer_Type {
 					'checkoutUrl'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce link to the checkout page for session user. Expires in 24 hours.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce link to the checkout page for session user. Expires in 24 hours.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							// Get current customer and user ID.
@@ -574,7 +574,7 @@ class Customer_Type {
 					'checkoutNonce' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce for the checkout page. By default, it expires in 1 hour.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce for the checkout page. By default, it expires in 1 hour.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							// Get current customer and user ID.
@@ -600,7 +600,7 @@ class Customer_Type {
 					'accountUrl'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce link to the account page for session user. Expires in 24 hours.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce link to the account page for session user. Expires in 24 hours.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							if ( ! is_user_logged_in() ) {
@@ -634,7 +634,7 @@ class Customer_Type {
 					'accountNonce' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce for the account page. By default, it expires in 1 hour.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce for the account page. By default, it expires in 1 hour.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							if ( ! is_user_logged_in() ) {
@@ -664,7 +664,7 @@ class Customer_Type {
 					'addPaymentMethodUrl'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce link to the add payment method page for the authenticated user. Expires in 24 hours.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce link to the add payment method page for the authenticated user. Expires in 24 hours.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							if ( ! is_user_logged_in() ) {
@@ -696,7 +696,7 @@ class Customer_Type {
 					'addPaymentMethodNonce' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce for the add payment method page. By default, it expires in 1 hour.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce for the add payment method page. By default, it expires in 1 hour.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							if ( ! is_user_logged_in() ) {

--- a/includes/type/object/class-downloadable-item-type.php
+++ b/includes/type/object/class-downloadable-item-type.php
@@ -29,14 +29,14 @@ class Downloadable_Item_Type {
 			'DownloadableItem',
 			[
 				'description' => static function () {
-					return __( 'A downloadable item', 'wp-graphql-woocommerce' );
+					return __( 'A downloadable item', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'                 => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Downloadable item unique identifier', 'wp-graphql-woocommerce' );
+							return __( 'Downloadable item unique identifier', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['download_id'] ) ? Relay::toGlobalId( 'download', $source['download_id'] ) : null;
@@ -45,7 +45,7 @@ class Downloadable_Item_Type {
 					'downloadId'         => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Downloadable item ID.', 'wp-graphql-woocommerce' );
+							return __( 'Downloadable item ID.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['download_id'] ) ? $source['download_id'] : null;
@@ -54,7 +54,7 @@ class Downloadable_Item_Type {
 					'url'                => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Download URL of the downloadable item.', 'wp-graphql-woocommerce' );
+							return __( 'Download URL of the downloadable item.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['download_url'] ) ? $source['download_url'] : null;
@@ -63,7 +63,7 @@ class Downloadable_Item_Type {
 					'name'               => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Name of the downloadable item.', 'wp-graphql-woocommerce' );
+							return __( 'Name of the downloadable item.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['download_name'] ) ? $source['download_name'] : null;
@@ -72,7 +72,7 @@ class Downloadable_Item_Type {
 					'downloadsRemaining' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Number of times the item can be downloaded.', 'wp-graphql-woocommerce' );
+							return __( 'Number of times the item can be downloaded.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['downloads_remaining'] ) && is_numeric( $source['downloads_remaining'] )
@@ -83,7 +83,7 @@ class Downloadable_Item_Type {
 					'accessExpires'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'The date the downloadable item expires', 'wp-graphql-woocommerce' );
+							return __( 'The date the downloadable item expires', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['access_expires'] ) ? $source['access_expires'] : null;
@@ -92,7 +92,7 @@ class Downloadable_Item_Type {
 					'product'            => [
 						'type'        => 'ProductUnion',
 						'description' => static function () {
-							return __( 'Product of downloadable item.', 'wp-graphql-woocommerce' );
+							return __( 'Product of downloadable item.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							return Factory::resolve_crud_object( $source['product_id'], $context );
@@ -101,7 +101,7 @@ class Downloadable_Item_Type {
 					'downloadNonce'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonce for the authenticated download URL. Expires in 24 hours.', 'wp-graphql-woocommerce' );
+							return __( 'A nonce for the authenticated download URL. Expires in 24 hours.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$customer_id = get_current_user_id();
@@ -115,7 +115,7 @@ class Downloadable_Item_Type {
 					'downloadUrl'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A nonced URL that authenticates the user and redirects to the WooCommerce download. Expires in 24 hours.', 'wp-graphql-woocommerce' );
+							return __( 'A nonced URL that authenticates the user and redirects to the WooCommerce download. Expires in 24 hours.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$customer_id = get_current_user_id();
@@ -141,7 +141,7 @@ class Downloadable_Item_Type {
 					'download'           => [
 						'type'        => 'ProductDownload',
 						'description' => static function () {
-							return __( 'ProductDownload of the downloadable item', 'wp-graphql-woocommerce' );
+							return __( 'ProductDownload of the downloadable item', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$download_id = $source['download_id'];
@@ -197,7 +197,7 @@ class Downloadable_Item_Type {
 			[
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'A pre-authenticated download URL with a time-limited token. Does not require cookie-based authentication.', 'wp-graphql-woocommerce' );
+					return __( 'A pre-authenticated download URL with a time-limited token. Does not require cookie-based authentication.', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					$customer_id = get_current_user_id();

--- a/includes/type/object/class-meta-data-type.php
+++ b/includes/type/object/class-meta-data-type.php
@@ -24,13 +24,13 @@ class Meta_Data_Type {
 			'MetaData',
 			[
 				'description' => static function () {
-					return __( 'Extra data defined on the WC object', 'wp-graphql-woocommerce' );
+					return __( 'Extra data defined on the WC object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'    => [
 						'type'        => 'ID',
 						'description' => static function () {
-							return __( 'Meta ID.', 'wp-graphql-woocommerce' );
+							return __( 'Meta ID.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->id ) ? $source->id : null;
@@ -39,7 +39,7 @@ class Meta_Data_Type {
 					'key'   => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Meta key.', 'wp-graphql-woocommerce' );
+							return __( 'Meta key.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->key ) ? (string) $source->key : null;
@@ -48,7 +48,7 @@ class Meta_Data_Type {
 					'value' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Meta value.', 'wp-graphql-woocommerce' );
+							return __( 'Meta value.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							if ( empty( $source->value ) ) {
@@ -76,25 +76,25 @@ class Meta_Data_Type {
 		return [
 			'type'        => [ 'list_of' => 'MetaData' ],
 			'description' => static function () {
-					return __( 'Object meta data', 'wp-graphql-woocommerce' );
+					return __( 'Object meta data', 'graphql-for-ecommerce' );
 			},
 			'args'        => [
 				'key'      => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Retrieve meta by key', 'wp-graphql-woocommerce' );
+						return __( 'Retrieve meta by key', 'graphql-for-ecommerce' );
 					},
 				],
 				'keysIn'   => [
 					'type'        => [ 'list_of' => 'String' ],
 					'description' => static function () {
-						return __( 'Retrieve multiple metas by key', 'wp-graphql-woocommerce' );
+						return __( 'Retrieve multiple metas by key', 'graphql-for-ecommerce' );
 					},
 				],
 				'multiple' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Retrieve meta with matching keys', 'wp-graphql-woocommerce' );
+						return __( 'Retrieve meta with matching keys', 'graphql-for-ecommerce' );
 					},
 				],
 			],

--- a/includes/type/object/class-order-item-type.php
+++ b/includes/type/object/class-order-item-type.php
@@ -28,31 +28,31 @@ class Order_Item_Type {
 		$types = [
 			'CouponLine'   => [
 				// Description.
-				__( 'a coupon line object', 'wp-graphql-woocommerce' ),
+				__( 'a coupon line object', 'graphql-for-ecommerce' ),
 				// Fields.
 				[
 					'code'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line\'s Coupon code', 'wp-graphql-woocommerce' );
+							return __( 'Line\'s Coupon code', 'graphql-for-ecommerce' );
 						},
 					],
 					'discount'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line\'s Discount total', 'wp-graphql-woocommerce' );
+							return __( 'Line\'s Discount total', 'graphql-for-ecommerce' );
 						},
 					],
 					'discountTax' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line\'s Discount total tax', 'wp-graphql-woocommerce' );
+							return __( 'Line\'s Discount total tax', 'graphql-for-ecommerce' );
 						},
 					],
 					'coupon'      => [
 						'type'        => 'Coupon',
 						'description' => static function () {
-							return __( 'Line\'s Coupon', 'wp-graphql-woocommerce' );
+							return __( 'Line\'s Coupon', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							return Factory::resolve_crud_object( $source->coupon_id, $context );
@@ -62,92 +62,92 @@ class Order_Item_Type {
 			],
 			'FeeLine'      => [
 				// Description.
-				__( 'a fee line object', 'wp-graphql-woocommerce' ),
+				__( 'a fee line object', 'graphql-for-ecommerce' ),
 				// Fields.
 				[
 					'amount'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Fee amount', 'wp-graphql-woocommerce' );
+							return __( 'Fee amount', 'graphql-for-ecommerce' );
 						},
 					],
 					'name'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Fee name', 'wp-graphql-woocommerce' );
+							return __( 'Fee name', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxStatus' => [
 						'type'        => 'TaxStatusEnum',
 						'description' => static function () {
-							return __( 'Tax status of fee', 'wp-graphql-woocommerce' );
+							return __( 'Tax status of fee', 'graphql-for-ecommerce' );
 						},
 					],
 					'total'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line total (after discounts)', 'wp-graphql-woocommerce' );
+							return __( 'Line total (after discounts)', 'graphql-for-ecommerce' );
 						},
 					],
 					'totalTax'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line total tax (after discounts)', 'wp-graphql-woocommerce' );
+							return __( 'Line total tax (after discounts)', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxes'     => [
 						'type'        => [ 'list_of' => 'OrderItemTax' ],
 						'description' => static function () {
-							return __( 'Line taxes', 'wp-graphql-woocommerce' );
+							return __( 'Line taxes', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxClass'  => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'Line tax class', 'wp-graphql-woocommerce' );
+							return __( 'Line tax class', 'graphql-for-ecommerce' );
 						},
 					],
 				],
 			],
 			'ShippingLine' => [
 				// Description.
-				__( 'a shipping line object', 'wp-graphql-woocommerce' ),
+				__( 'a shipping line object', 'graphql-for-ecommerce' ),
 				// Fields.
 				[
 					'methodTitle'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping Line\'s shipping method name', 'wp-graphql-woocommerce' );
+							return __( 'Shipping Line\'s shipping method name', 'graphql-for-ecommerce' );
 						},
 					],
 					'total'          => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line total (after discounts)', 'wp-graphql-woocommerce' );
+							return __( 'Line total (after discounts)', 'graphql-for-ecommerce' );
 						},
 					],
 					'totalTax'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line total tax (after discounts)', 'wp-graphql-woocommerce' );
+							return __( 'Line total tax (after discounts)', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxes'          => [
 						'type'        => [ 'list_of' => 'OrderItemTax' ],
 						'description' => static function () {
-							return __( 'Line taxes', 'wp-graphql-woocommerce' );
+							return __( 'Line taxes', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxClass'       => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'Line tax class', 'wp-graphql-woocommerce' );
+							return __( 'Line tax class', 'graphql-for-ecommerce' );
 						},
 					],
 					'shippingMethod' => [
 						'type'        => 'ShippingMethod',
 						'description' => static function () {
-							return __( 'Shipping Line\'s shipping method', 'wp-graphql-woocommerce' );
+							return __( 'Shipping Line\'s shipping method', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return Factory::resolve_shipping_method( $source->method_id );
@@ -157,43 +157,43 @@ class Order_Item_Type {
 			],
 			'TaxLine'      => [
 				// Description.
-				__( 'a tax line object', 'wp-graphql-woocommerce' ),
+				__( 'a tax line object', 'graphql-for-ecommerce' ),
 				// Fields.
 				[
 					'rateCode'         => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax rate code/name', 'wp-graphql-woocommerce' );
+							return __( 'Tax rate code/name', 'graphql-for-ecommerce' );
 						},
 					],
 					'label'            => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax rate label', 'wp-graphql-woocommerce' );
+							return __( 'Tax rate label', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxTotal'         => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax total (not including shipping taxes)', 'wp-graphql-woocommerce' );
+							return __( 'Tax total (not including shipping taxes)', 'graphql-for-ecommerce' );
 						},
 					],
 					'shippingTaxTotal' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax line\'s shipping tax total', 'wp-graphql-woocommerce' );
+							return __( 'Tax line\'s shipping tax total', 'graphql-for-ecommerce' );
 						},
 					],
 					'isCompound'       => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Is this a compound tax rate?', 'wp-graphql-woocommerce' );
+							return __( 'Is this a compound tax rate?', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxRate'          => [
 						'type'        => 'TaxRate',
 						'description' => static function () {
-							return __( 'Tax line\'s tax rate', 'wp-graphql-woocommerce' );
+							return __( 'Tax line\'s tax rate', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							return Factory::resolve_tax_rate( $source->rate_id, $context );
@@ -203,43 +203,43 @@ class Order_Item_Type {
 			],
 			'LineItem'     => [
 				// Description.
-				__( 'a line item object', 'wp-graphql-woocommerce' ),
+				__( 'a line item object', 'graphql-for-ecommerce' ),
 				// Fields.
 				[
 					'productId'     => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Line item\'s product ID', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s product ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'variationId'   => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Line item\'s product variation ID', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s product variation ID', 'graphql-for-ecommerce' );
 						},
 					],
 					'quantity'      => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Line item\'s product quantity', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s product quantity', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxClass'      => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'Line item\'s tax class', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s tax class', 'graphql-for-ecommerce' );
 						},
 					],
 					'subtotal'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line item\'s subtotal', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s subtotal', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -253,13 +253,13 @@ class Order_Item_Type {
 					'subtotalTax'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line item\'s subtotal tax', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s subtotal tax', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -273,13 +273,13 @@ class Order_Item_Type {
 					'total'         => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line item\'s total', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s total', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -293,13 +293,13 @@ class Order_Item_Type {
 					'totalTax'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Line item\'s total tax', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s total tax', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -313,19 +313,19 @@ class Order_Item_Type {
 					'taxes'         => [
 						'type'        => [ 'list_of' => 'OrderItemTax' ],
 						'description' => static function () {
-							return __( 'Line item\'s taxes', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s taxes', 'graphql-for-ecommerce' );
 						},
 					],
 					'itemDownloads' => [
 						'type'        => [ 'list_of' => 'ProductDownload' ],
 						'description' => static function () {
-							return __( 'Line item\'s taxes', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s taxes', 'graphql-for-ecommerce' );
 						},
 					],
 					'taxStatus'     => [
 						'type'        => 'TaxStatusEnum',
 						'description' => static function () {
-							return __( 'Line item\'s taxes', 'wp-graphql-woocommerce' );
+							return __( 'Line item\'s taxes', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -383,13 +383,13 @@ class Order_Item_Type {
 			'OrderItemTax',
 			[
 				'description' => static function () {
-					return __( 'Order item tax statement', 'wp-graphql-woocommerce' );
+					return __( 'Order item tax statement', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'taxLineId' => [
 						'type'        => [ 'non_null' => 'Int' ],
 						'description' => static function () {
-							return __( 'Order item ID for tax line connected to this statement', 'wp-graphql-woocommerce' );
+							return __( 'Order item ID for tax line connected to this statement', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['ID'] ) ? $source['ID'] : null;
@@ -398,7 +398,7 @@ class Order_Item_Type {
 					'subtotal'  => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Subtotal', 'wp-graphql-woocommerce' );
+							return __( 'Subtotal', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['subtotal'] ) ? $source['subtotal'] : null;
@@ -407,7 +407,7 @@ class Order_Item_Type {
 					'total'     => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Total', 'wp-graphql-woocommerce' );
+							return __( 'Total', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['total'] ) ? $source['total'] : null;
@@ -416,7 +416,7 @@ class Order_Item_Type {
 					'amount'    => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Amount taxed', 'wp-graphql-woocommerce' );
+							return __( 'Amount taxed', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['amount'] ) ? $source['amount'] : null;
@@ -425,7 +425,7 @@ class Order_Item_Type {
 					'taxLine'   => [
 						'type'        => 'TaxLine',
 						'description' => static function () {
-							return __( 'Tax line connected to this statement', 'wp-graphql-woocommerce' );
+							return __( 'Tax line connected to this statement', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$item = \WC_Order_Factory::get_order_item( $source['ID'] );
@@ -454,19 +454,19 @@ class Order_Item_Type {
 				'id'         => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'The ID of the order item in the database', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the order item in the database', 'graphql-for-ecommerce' );
 					},
 				],
 				'databaseId' => [
 					'type'        => 'Int',
 					'description' => static function () {
-						return __( 'The ID of the order item in the database', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the order item in the database', 'graphql-for-ecommerce' );
 					},
 				],
 				'orderId'    => [
 					'type'        => 'Int',
 					'description' => static function () {
-						return __( 'The Id of the order the order item belongs to.', 'wp-graphql-woocommerce' );
+						return __( 'The Id of the order the order item belongs to.', 'graphql-for-ecommerce' );
 					},
 				],
 

--- a/includes/type/object/class-order-note-type.php
+++ b/includes/type/object/class-order-note-type.php
@@ -28,7 +28,7 @@ class Order_Note_Type {
 				'interfaces'      => [ 'Node' ],
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A order note', 'wp-graphql-woocommerce' );
+					return __( 'A order note', 'graphql-for-ecommerce' );
 				},
 				'fields'          => apply_filters( 'woographql_order_note_field_definitions', self::get_fields() ),
 			]
@@ -47,7 +47,7 @@ class Order_Note_Type {
 				'id'             => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'Database ID or global ID of the order note', 'wp-graphql-woocommerce' );
+						return __( 'Database ID or global ID of the order note', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $order_note ) {
 						return Relay::toGlobalId( 'order_note', $order_note->databaseId );
@@ -56,7 +56,7 @@ class Order_Note_Type {
 				'databaseId'     => [
 					'type'        => 'Int',
 					'description' => static function () {
-						return __( 'Database ID of the order note', 'wp-graphql-woocommerce' );
+						return __( 'Database ID of the order note', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $order_note ) {
 						return $order_note->databaseId;
@@ -65,7 +65,7 @@ class Order_Note_Type {
 				'dateCreated'    => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'The date the order note was created, in the site\'s timezone.', 'wp-graphql-woocommerce' );
+						return __( 'The date the order note was created, in the site\'s timezone.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $order_note ) {
 						return $order_note->date;
@@ -74,7 +74,7 @@ class Order_Note_Type {
 				'note'           => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order note.', 'wp-graphql-woocommerce' );
+						return __( 'Order note.', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $order_note ) {
 						return $order_note->contentRaw;
@@ -83,7 +83,7 @@ class Order_Note_Type {
 				'isCustomerNote' => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Whether the note is a customer note', 'wp-graphql-woocommerce' );
+						return __( 'Whether the note is a customer note', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $order_note ) {
 						return (bool) get_comment_meta( $order_note->databaseId, 'is_customer_note', true );

--- a/includes/type/object/class-order-type.php
+++ b/includes/type/object/class-order-type.php
@@ -30,7 +30,7 @@ class Order_Type {
 			'Order',
 			[
 				'description' => static function () {
-					return __( 'A order object', 'wp-graphql-woocommerce' );
+					return __( 'A order object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [
 					'Node',
@@ -68,97 +68,97 @@ class Order_Type {
 				'id'                    => [
 					'type'        => [ 'non_null' => 'ID' ],
 					'description' => static function () {
-						return __( 'The globally unique identifier for the order', 'wp-graphql-woocommerce' );
+						return __( 'The globally unique identifier for the order', 'graphql-for-ecommerce' );
 					},
 				],
 				'databaseId'            => [
 					'type'        => 'Int',
 					'description' => static function () {
-						return __( 'The ID of the order in the database', 'wp-graphql-woocommerce' );
+						return __( 'The ID of the order in the database', 'graphql-for-ecommerce' );
 					},
 				],
 				'orderKey'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order key', 'wp-graphql-woocommerce' );
+						return __( 'Order key', 'graphql-for-ecommerce' );
 					},
 				],
 				'date'                  => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Date order was created', 'wp-graphql-woocommerce' );
+						return __( 'Date order was created', 'graphql-for-ecommerce' );
 					},
 				],
 				'modified'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Date order was last updated', 'wp-graphql-woocommerce' );
+						return __( 'Date order was last updated', 'graphql-for-ecommerce' );
 					},
 				],
 				'currency'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order currency', 'wp-graphql-woocommerce' );
+						return __( 'Order currency', 'graphql-for-ecommerce' );
 					},
 				],
 				'paymentMethod'         => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Payment method', 'wp-graphql-woocommerce' );
+						return __( 'Payment method', 'graphql-for-ecommerce' );
 					},
 				],
 				'paymentMethodTitle'    => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Payment method title', 'wp-graphql-woocommerce' );
+						return __( 'Payment method title', 'graphql-for-ecommerce' );
 					},
 				],
 				'transactionId'         => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Transaction ID', 'wp-graphql-woocommerce' );
+						return __( 'Transaction ID', 'graphql-for-ecommerce' );
 					},
 				],
 				'customerIpAddress'     => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Customer IP Address', 'wp-graphql-woocommerce' );
+						return __( 'Customer IP Address', 'graphql-for-ecommerce' );
 					},
 				],
 				'customerUserAgent'     => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Customer User Agent', 'wp-graphql-woocommerce' );
+						return __( 'Customer User Agent', 'graphql-for-ecommerce' );
 					},
 				],
 				'createdVia'            => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'How order was created', 'wp-graphql-woocommerce' );
+						return __( 'How order was created', 'graphql-for-ecommerce' );
 					},
 				],
 				'dateCompleted'         => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Date order was completed', 'wp-graphql-woocommerce' );
+						return __( 'Date order was completed', 'graphql-for-ecommerce' );
 					},
 				],
 				'datePaid'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Date order was paid', 'wp-graphql-woocommerce' );
+						return __( 'Date order was paid', 'graphql-for-ecommerce' );
 					},
 				],
 				'discountTotal'         => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Discount total amount', 'wp-graphql-woocommerce' );
+						return __( 'Discount total amount', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -175,13 +175,13 @@ class Order_Type {
 				'discountTax'           => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Discount tax amount', 'wp-graphql-woocommerce' );
+						return __( 'Discount tax amount', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -198,13 +198,13 @@ class Order_Type {
 				'shippingTotal'         => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Shipping total amount', 'wp-graphql-woocommerce' );
+						return __( 'Shipping total amount', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -221,13 +221,13 @@ class Order_Type {
 				'shippingTax'           => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Shipping tax amount', 'wp-graphql-woocommerce' );
+						return __( 'Shipping tax amount', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -244,13 +244,13 @@ class Order_Type {
 				'cartTax'               => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart tax amount', 'wp-graphql-woocommerce' );
+						return __( 'Cart tax amount', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -267,13 +267,13 @@ class Order_Type {
 				'total'                 => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order grand total', 'wp-graphql-woocommerce' );
+						return __( 'Order grand total', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -289,13 +289,13 @@ class Order_Type {
 				'totalTax'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order taxes', 'wp-graphql-woocommerce' );
+						return __( 'Order taxes', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -312,13 +312,13 @@ class Order_Type {
 				'subtotal'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order subtotal', 'wp-graphql-woocommerce' );
+						return __( 'Order subtotal', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'format' => [
 							'type'        => 'PricingFieldFormatEnum',
 							'description' => static function () {
-								return __( 'Format of the price', 'wp-graphql-woocommerce' );
+								return __( 'Format of the price', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -334,62 +334,62 @@ class Order_Type {
 				'orderNumber'           => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order number', 'wp-graphql-woocommerce' );
+						return __( 'Order number', 'graphql-for-ecommerce' );
 					},
 				],
 				'orderVersion'          => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order version', 'wp-graphql-woocommerce' );
+						return __( 'Order version', 'graphql-for-ecommerce' );
 					},
 				],
 				'pricesIncludeTax'      => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Prices include taxes?', 'wp-graphql-woocommerce' );
+						return __( 'Prices include taxes?', 'graphql-for-ecommerce' );
 					},
 				],
 				'cartHash'              => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Cart hash', 'wp-graphql-woocommerce' );
+						return __( 'Cart hash', 'graphql-for-ecommerce' );
 					},
 				],
 				'customerNote'          => [
 					'type'             => 'String',
 					'description'      => static function () {
-						return __( 'Customer note', 'wp-graphql-woocommerce' );
+						return __( 'Customer note', 'graphql-for-ecommerce' );
 					},
-					'deprecatedReason' => __( 'Use "orderNotes" field instead.', 'wp-graphql-woocommerce' ),
+					'deprecatedReason' => __( 'Use "orderNotes" field instead.', 'graphql-for-ecommerce' ),
 				],
 				'isDownloadPermitted'   => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Is product download is permitted', 'wp-graphql-woocommerce' );
+						return __( 'Is product download is permitted', 'graphql-for-ecommerce' );
 					},
 				],
 				'billing'               => [
 					'type'        => 'CustomerAddress',
 					'description' => static function () {
-						return __( 'Order billing properties', 'wp-graphql-woocommerce' );
+						return __( 'Order billing properties', 'graphql-for-ecommerce' );
 					},
 				],
 				'shipping'              => [
 					'type'        => 'CustomerAddress',
 					'description' => static function () {
-						return __( 'Order shipping properties', 'wp-graphql-woocommerce' );
+						return __( 'Order shipping properties', 'graphql-for-ecommerce' );
 					},
 				],
 				'status'                => [
 					'type'        => 'OrderStatusEnum',
 					'description' => static function () {
-						return __( 'Order status', 'wp-graphql-woocommerce' );
+						return __( 'Order status', 'graphql-for-ecommerce' );
 					},
 				],
 				'parent'                => [
 					'type'        => 'Order',
 					'description' => static function () {
-						return __( 'Parent order', 'wp-graphql-woocommerce' );
+						return __( 'Parent order', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $order, array $args, AppContext $context ) {
 						return Factory::resolve_crud_object( $order->parent_id, $context );
@@ -398,7 +398,7 @@ class Order_Type {
 				'customer'              => [
 					'type'        => 'Customer',
 					'description' => static function () {
-						return __( 'Order customer', 'wp-graphql-woocommerce' );
+						return __( 'Order customer', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $order, array $args, AppContext $context ) {
 						if ( empty( $order->customer_id ) ) {
@@ -412,43 +412,43 @@ class Order_Type {
 				'shippingAddressMapUrl' => [
 					'type'        => 'String',
 					'description' => static function () {
-						return __( 'Order customer', 'wp-graphql-woocommerce' );
+						return __( 'Order customer', 'graphql-for-ecommerce' );
 					},
 				],
 				'hasBillingAddress'     => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Order has a billing address?', 'wp-graphql-woocommerce' );
+						return __( 'Order has a billing address?', 'graphql-for-ecommerce' );
 					},
 				],
 				'hasShippingAddress'    => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'Order has a shipping address?', 'wp-graphql-woocommerce' );
+						return __( 'Order has a shipping address?', 'graphql-for-ecommerce' );
 					},
 				],
 				'needsShippingAddress'  => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'If order needs shipping address', 'wp-graphql-woocommerce' );
+						return __( 'If order needs shipping address', 'graphql-for-ecommerce' );
 					},
 				],
 				'hasDownloadableItem'   => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'If order contains a downloadable product', 'wp-graphql-woocommerce' );
+						return __( 'If order contains a downloadable product', 'graphql-for-ecommerce' );
 					},
 				],
 				'needsPayment'          => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'If order needs payment', 'wp-graphql-woocommerce' );
+						return __( 'If order needs payment', 'graphql-for-ecommerce' );
 					},
 				],
 				'needsProcessing'       => [
 					'type'        => 'Boolean',
 					'description' => static function () {
-						return __( 'If order needs processing before it can be completed', 'wp-graphql-woocommerce' );
+						return __( 'If order needs processing before it can be completed', 'graphql-for-ecommerce' );
 					},
 				],
 				'metaData'              => Meta_Data_Type::get_metadata_field_definition(),
@@ -497,19 +497,19 @@ class Order_Type {
 						'active'                => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Limit results to downloadable items that can be downloaded now.', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to downloadable items that can be downloaded now.', 'graphql-for-ecommerce' );
 							},
 						],
 						'expired'               => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Limit results to downloadable items that are expired.', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to downloadable items that are expired.', 'graphql-for-ecommerce' );
 							},
 						],
 						'hasDownloadsRemaining' => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Limit results to downloadable items that have downloads remaining.', 'wp-graphql-woocommerce' );
+								return __( 'Limit results to downloadable items that have downloads remaining.', 'graphql-for-ecommerce' );
 							},
 						],
 					],

--- a/includes/type/object/class-payment-gateway-type.php
+++ b/includes/type/object/class-payment-gateway-type.php
@@ -24,14 +24,14 @@ class Payment_Gateway_Type {
 			'PaymentGateway',
 			[
 				'description' => static function () {
-					return __( 'A payment gateway object', 'wp-graphql-woocommerce' );
+					return __( 'A payment gateway object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'          => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'gateway\'s title', 'wp-graphql-woocommerce' );
+							return __( 'gateway\'s title', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->id ) ? $source->id : null;
@@ -40,7 +40,7 @@ class Payment_Gateway_Type {
 					'title'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'gateway\'s title', 'wp-graphql-woocommerce' );
+							return __( 'gateway\'s title', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->title ) ? $source->title : null;
@@ -49,7 +49,7 @@ class Payment_Gateway_Type {
 					'description' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'gateway\'s description', 'wp-graphql-woocommerce' );
+							return __( 'gateway\'s description', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->description ) ? $source->description : null;
@@ -58,7 +58,7 @@ class Payment_Gateway_Type {
 					'icon'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'gateway\'s icon', 'wp-graphql-woocommerce' );
+							return __( 'gateway\'s icon', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->icon ) ? $source->icon : null;

--- a/includes/type/object/class-payment-token-types.php
+++ b/includes/type/object/class-payment-token-types.php
@@ -26,7 +26,7 @@ class Payment_Token_Types {
 			'PaymentToken',
 			[
 				'description' => static function () {
-					return __( 'A payment token', 'wp-graphql-woocommerce' );
+					return __( 'A payment token', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'PaymentTokenInterface' ],
 				'fields'      => [],
@@ -36,7 +36,7 @@ class Payment_Token_Types {
 			'PaymentTokenCC',
 			[
 				'description' => static function () {
-					return __( 'A credit card payment token', 'wp-graphql-woocommerce' );
+					return __( 'A credit card payment token', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'PaymentTokenInterface' ],
 				'fields'      => Payment_Token_Interface::get_fields( self::get_credit_card_fields() ),
@@ -47,7 +47,7 @@ class Payment_Token_Types {
 			'PaymentTokenECheck',
 			[
 				'description' => static function () {
-					return __( 'An electronic check payment token', 'wp-graphql-woocommerce' );
+					return __( 'An electronic check payment token', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'PaymentTokenInterface' ],
 				'fields'      => Payment_Token_Interface::get_fields( self::get_e_check_fields() ),
@@ -65,7 +65,7 @@ class Payment_Token_Types {
 			'last4' => [
 				'type'        => 'Integer',
 				'description' => static function () {
-					return __( 'Last 4 digits of the stored account number', 'wp-graphql-woocommerce' );
+					return __( 'Last 4 digits of the stored account number', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return ! empty( $source->get_last4() ) ? $source->get_last4() : null;
@@ -84,7 +84,7 @@ class Payment_Token_Types {
 			'cardType'    => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Card type (visa, mastercard, etc)', 'wp-graphql-woocommerce' );
+					return __( 'Card type (visa, mastercard, etc)', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return ! empty( $source->get_card_type() ) ? $source->get_card_type() : null;
@@ -93,7 +93,7 @@ class Payment_Token_Types {
 			'expiryYear'  => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Card\'s expiration year.', 'wp-graphql-woocommerce' );
+					return __( 'Card\'s expiration year.', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return ! empty( $source->get_expiry_year() ) ? $source->get_expiry_year() : null;
@@ -102,7 +102,7 @@ class Payment_Token_Types {
 			'expiryMonth' => [
 				'type'        => 'String',
 				'description' => static function () {
-					return __( 'Card\'s expiration month', 'wp-graphql-woocommerce' );
+					return __( 'Card\'s expiration month', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return ! empty( $source->get_expiry_month() ) ? $source->get_expiry_month() : null;
@@ -111,7 +111,7 @@ class Payment_Token_Types {
 			'last4'       => [
 				'type'        => 'Integer',
 				'description' => static function () {
-					return __( 'Last 4 digits of the stored credit card number', 'wp-graphql-woocommerce' );
+					return __( 'Last 4 digits of the stored credit card number', 'graphql-for-ecommerce' );
 				},
 				'resolve'     => static function ( $source ) {
 					return ! empty( $source->get_last4() ) ? $source->get_last4() : null;

--- a/includes/type/object/class-product-attribute-object-type.php
+++ b/includes/type/object/class-product-attribute-object-type.php
@@ -24,14 +24,14 @@ class Product_Attribute_Object_Type {
 			'ProductAttributeObject',
 			[
 				'description'     => static function () {
-					return __( 'Product attribute object.', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute object.', 'graphql-for-ecommerce' );
 				},
 				'eagerlyLoadType' => true,
 				'fields'          => [
 					'id'          => [
 						'type'        => 'ID',
 						'description' => static function () {
-							return __( 'Unique identifier for the product attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Unique identifier for the product attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->attribute_id ) ? $source->attribute_id : null;
@@ -40,7 +40,7 @@ class Product_Attribute_Object_Type {
 					'name'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Name of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Name of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->attribute_name ) ? (string) $source->attribute_name : null;
@@ -49,7 +49,7 @@ class Product_Attribute_Object_Type {
 					'label'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Label of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Label of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->attribute_label ) ? (string) $source->attribute_label : null;
@@ -58,7 +58,7 @@ class Product_Attribute_Object_Type {
 					'type'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Type of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Type of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->attribute_type ) ? (string) $source->attribute_type : null;
@@ -67,7 +67,7 @@ class Product_Attribute_Object_Type {
 					'orderBy'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Order by which the attribute should be sorted.', 'wp-graphql-woocommerce' );
+							return __( 'Order by which the attribute should be sorted.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->attribute_orderby ) ? (string) $source->attribute_orderby : null;
@@ -76,7 +76,7 @@ class Product_Attribute_Object_Type {
 					'hasArchives' => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Whether or not the attribute has archives.', 'wp-graphql-woocommerce' );
+							return __( 'Whether or not the attribute has archives.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source->attribute_public ) ? $source->attribute_public : false;

--- a/includes/type/object/class-product-attribute-term-object-type.php
+++ b/includes/type/object/class-product-attribute-term-object-type.php
@@ -24,14 +24,14 @@ class Product_Attribute_Term_Object_Type {
 			'ProductAttributeTermObject',
 			[
 				'description'     => static function () {
-					return __( 'Product attribute object.', 'wp-graphql-woocommerce' );
+					return __( 'Product attribute object.', 'graphql-for-ecommerce' );
 				},
 				'eagerlyLoadType' => true,
 				'fields'          => [
 					'id'          => [
 						'type'        => 'Integer',
 						'description' => static function () {
-							return __( 'Unique identifier for the product attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Unique identifier for the product attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->id ) ? $source->id : null;
@@ -40,7 +40,7 @@ class Product_Attribute_Term_Object_Type {
 					'name'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Name of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Name of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->name ) ? $source->name : null;
@@ -49,7 +49,7 @@ class Product_Attribute_Term_Object_Type {
 					'slug'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Label of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Label of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->slug ) ? $source->slug : null;
@@ -58,7 +58,7 @@ class Product_Attribute_Term_Object_Type {
 					'description' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Type of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'Type of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->description ) ? $source->description : null;
@@ -67,7 +67,7 @@ class Product_Attribute_Term_Object_Type {
 					'menuOrder'   => [
 						'type'        => 'Integer',
 						'description' => static function () {
-							return __( 'Order by which the attribute should be sorted.', 'wp-graphql-woocommerce' );
+							return __( 'Order by which the attribute should be sorted.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source->menu_order ) ? $source->menu_order : 0;
@@ -76,7 +76,7 @@ class Product_Attribute_Term_Object_Type {
 					'count'       => [
 						'type'        => 'Integer',
 						'description' => static function () {
-							return __( 'Whether or not the attribute has archives.', 'wp-graphql-woocommerce' );
+							return __( 'Whether or not the attribute has archives.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source->count ) ? $source->count : 0;

--- a/includes/type/object/class-product-attribute-types.php
+++ b/includes/type/object/class-product-attribute-types.php
@@ -25,14 +25,14 @@ class Product_Attribute_Types {
 			'LocalProductAttribute',
 			[
 				'description' => static function () {
-					return __( 'A product attribute object', 'wp-graphql-woocommerce' );
+					return __( 'A product attribute object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'ProductAttribute' ],
 				'fields'      => [
 					'id'    => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Attribute Global ID', 'wp-graphql-woocommerce' );
+							return __( 'Attribute Global ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $attribute ) {
 							$id_parts = [ $attribute->get_name() ];
@@ -45,7 +45,7 @@ class Product_Attribute_Types {
 					'scope' => [
 						'type'        => [ 'non_null' => 'ProductAttributeTypesEnum' ],
 						'description' => static function () {
-							return __( 'Product attribute scope.', 'wp-graphql-woocommerce' );
+							return __( 'Product attribute scope.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function () {
 							return 'local';
@@ -60,14 +60,14 @@ class Product_Attribute_Types {
 			'GlobalProductAttribute',
 			[
 				'description' => static function () {
-					return __( 'A product attribute object', 'wp-graphql-woocommerce' );
+					return __( 'A product attribute object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'ProductAttribute' ],
 				'fields'      => [
 					'id'    => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Attribute Global ID', 'wp-graphql-woocommerce' );
+							return __( 'Attribute Global ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $attribute ) {
 							return Relay::toGlobalId( 'GlobalProductAttribute', $attribute->get_id() );
@@ -76,7 +76,7 @@ class Product_Attribute_Types {
 					'scope' => [
 						'type'        => [ 'non_null' => 'ProductAttributeTypesEnum' ],
 						'description' => static function () {
-							return __( 'Product attribute scope.', 'wp-graphql-woocommerce' );
+							return __( 'Product attribute scope.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function () {
 							return 'global';
@@ -85,7 +85,7 @@ class Product_Attribute_Types {
 					'label' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Attribute label', 'wp-graphql-woocommerce' );
+							return __( 'Attribute label', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $attribute ) {
 							$taxonomy = get_taxonomy( $attribute->get_name() );
@@ -95,7 +95,7 @@ class Product_Attribute_Types {
 					'name'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Product attribute name', 'wp-graphql-woocommerce' );
+							return __( 'Product attribute name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $attribute ) {
 							return $attribute->get_name();
@@ -104,7 +104,7 @@ class Product_Attribute_Types {
 					'slug'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Product attribute slug', 'wp-graphql-woocommerce' );
+							return __( 'Product attribute slug', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $attribute ) {
 							return ! empty( $attribute->get_name() ) ? $attribute->get_name() : null;
@@ -119,13 +119,13 @@ class Product_Attribute_Types {
 			'ProductAttributeOutput',
 			[
 				'description' => static function () {
-					return __( 'A simple product attribute object', 'wp-graphql-woocommerce' );
+					return __( 'A simple product attribute object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'attributeName'  => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Attribute name.', 'wp-graphql-woocommerce' );
+							return __( 'Attribute name.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $attribute ) {
 							return ! empty( $attribute['attributeName'] ) ? $attribute['attributeName'] : null;
@@ -134,7 +134,7 @@ class Product_Attribute_Types {
 					'attributeValue' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Attribute value.', 'wp-graphql-woocommerce' );
+							return __( 'Attribute value.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( array $attribute ) {
 							return ! empty( $attribute['attributeValue'] ) ? $attribute['attributeValue'] : null;

--- a/includes/type/object/class-product-category-type.php
+++ b/includes/type/object/class-product-category-type.php
@@ -28,7 +28,7 @@ class Product_Category_Type {
 				'image'     => [
 					'type'        => 'MediaItem',
 					'description' => static function () {
-						return __( 'Product category image', 'wp-graphql-woocommerce' );
+						return __( 'Product category image', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source, array $args, AppContext $context ) {
 						$thumbnail_id = get_term_meta( $source->term_id, 'thumbnail_id', true );
@@ -40,7 +40,7 @@ class Product_Category_Type {
 				'display'   => [
 					'type'        => 'ProductCategoryDisplay',
 					'description' => static function () {
-						return __( 'Product category display type', 'wp-graphql-woocommerce' );
+						return __( 'Product category display type', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$display = get_term_meta( $source->term_id, 'display_type', true );
@@ -50,7 +50,7 @@ class Product_Category_Type {
 				'menuOrder' => [
 					'type'        => 'Integer',
 					'description' => static function () {
-						return __( 'Product category menu order', 'wp-graphql-woocommerce' );
+						return __( 'Product category menu order', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source ) {
 						$order = get_term_meta( $source->term_id, 'order', true );

--- a/includes/type/object/class-product-download-type.php
+++ b/includes/type/object/class-product-download-type.php
@@ -24,13 +24,13 @@ class Product_Download_Type {
 			'ProductDownload',
 			[
 				'description' => static function () {
-					return __( 'A product object', 'wp-graphql-woocommerce' );
+					return __( 'A product object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'downloadId'      => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'Product download ID', 'wp-graphql-woocommerce' );
+							return __( 'Product download ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->get_id() : null;
@@ -39,7 +39,7 @@ class Product_Download_Type {
 					'name'            => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Product download name', 'wp-graphql-woocommerce' );
+							return __( 'Product download name', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->get_name() : null;
@@ -48,7 +48,7 @@ class Product_Download_Type {
 					'filePathType'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Type of file path set', 'wp-graphql-woocommerce' );
+							return __( 'Type of file path set', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->get_type_of_file_path() : null;
@@ -57,7 +57,7 @@ class Product_Download_Type {
 					'fileType'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'File type', 'wp-graphql-woocommerce' );
+							return __( 'File type', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->get_file_type() : null;
@@ -66,7 +66,7 @@ class Product_Download_Type {
 					'fileExt'         => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'File extension', 'wp-graphql-woocommerce' );
+							return __( 'File extension', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->get_file_extension() : null;
@@ -75,7 +75,7 @@ class Product_Download_Type {
 					'allowedFileType' => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Is file allowed', 'wp-graphql-woocommerce' );
+							return __( 'Is file allowed', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->is_allowed_filetype() : null;
@@ -84,7 +84,7 @@ class Product_Download_Type {
 					'fileExists'      => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Validate file exists', 'wp-graphql-woocommerce' );
+							return __( 'Validate file exists', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->file_exists() : null;
@@ -93,7 +93,7 @@ class Product_Download_Type {
 					'file'            => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Download file', 'wp-graphql-woocommerce' );
+							return __( 'Download file', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $download ) {
 							return ! empty( $download ) ? $download->get_file() : null;

--- a/includes/type/object/class-product-types.php
+++ b/includes/type/object/class-product-types.php
@@ -70,7 +70,7 @@ class Product_Types {
 				'eagerlyLoadType' => true,
 				'model'           => \WPGraphQL\WooCommerce\Model\Product::class,
 				'description'     => static function () {
-					return __( 'A simple product object', 'wp-graphql-woocommerce' );
+					return __( 'A simple product object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => self::get_product_interfaces(
 					[
@@ -97,7 +97,7 @@ class Product_Types {
 				'eagerlyLoadType' => true,
 				'model'           => \WPGraphQL\WooCommerce\Model\Product::class,
 				'description'     => static function () {
-					return __( 'A variable product object', 'wp-graphql-woocommerce' );
+					return __( 'A variable product object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => self::get_product_interfaces(
 					[
@@ -124,7 +124,7 @@ class Product_Types {
 				'eagerlyLoadType' => true,
 				'model'           => \WPGraphQL\WooCommerce\Model\Product::class,
 				'description'     => static function () {
-					return __( 'A external product object', 'wp-graphql-woocommerce' );
+					return __( 'A external product object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => self::get_product_interfaces( [ 'ProductWithPricing' ] ),
 				'fields'          => array_merge(
@@ -132,13 +132,13 @@ class Product_Types {
 						'externalUrl' => [
 							'type'        => 'String',
 							'description' => static function () {
-								return __( 'External product url', 'wp-graphql-woocommerce' );
+								return __( 'External product url', 'graphql-for-ecommerce' );
 							},
 						],
 						'buttonText'  => [
 							'type'        => 'String',
 							'description' => static function () {
-								return __( 'External product Buy button text', 'wp-graphql-woocommerce' );
+								return __( 'External product Buy button text', 'graphql-for-ecommerce' );
 							},
 						],
 					]
@@ -159,26 +159,26 @@ class Product_Types {
 				'eagerlyLoadType' => true,
 				'model'           => \WPGraphQL\WooCommerce\Model\Product::class,
 				'description'     => static function () {
-					return __( 'A group product object', 'wp-graphql-woocommerce' );
+					return __( 'A group product object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => self::get_product_interfaces( [ 'ProductWithPricing' ] ),
 				'fields'          => [
 					'addToCartText'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Product\'s add to cart button text description', 'wp-graphql-woocommerce' );
+							return __( 'Product\'s add to cart button text description', 'graphql-for-ecommerce' );
 						},
 					],
 					'addToCartDescription' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Product\'s add to cart button text description', 'wp-graphql-woocommerce' );
+							return __( 'Product\'s add to cart button text description', 'graphql-for-ecommerce' );
 						},
 					],
 					'price'                => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Products\' price range', 'wp-graphql-woocommerce' );
+							return __( 'Products\' price range', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( Model $source ) {
 							$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
@@ -232,7 +232,7 @@ class Product_Types {
 				'eagerlyLoadType' => true,
 				'model'           => \WPGraphQL\WooCommerce\Model\Product::class,
 				'description'     => static function () {
-					return __( 'A product object for a product type that is unsupported by the current API.', 'wp-graphql-woocommerce' );
+					return __( 'A product object for a product type that is unsupported by the current API.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => self::get_product_interfaces(
 					[
@@ -246,7 +246,7 @@ class Product_Types {
 					'type' => [
 						'type'        => 'ProductTypesEnum',
 						'description' => static function () {
-							return __( 'Product type', 'wp-graphql-woocommerce' );
+							return __( 'Product type', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function () {
 							return 'unsupported';

--- a/includes/type/object/class-refund-type.php
+++ b/includes/type/object/class-refund-type.php
@@ -26,44 +26,44 @@ class Refund_Type {
 			'Refund',
 			[
 				'description' => static function () {
-					return __( 'A refund object', 'wp-graphql-woocommerce' );
+					return __( 'A refund object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'         => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The globally unique identifier for the refund', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the refund', 'graphql-for-ecommerce' );
 						},
 					],
 					'databaseId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'The ID of the refund in the database', 'wp-graphql-woocommerce' );
+							return __( 'The ID of the refund in the database', 'graphql-for-ecommerce' );
 						},
 					],
 					'title'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A title for the new post type', 'wp-graphql-woocommerce' );
+							return __( 'A title for the new post type', 'graphql-for-ecommerce' );
 						},
 					],
 					'amount'     => [
 						'type'        => 'Float',
 						'description' => static function () {
-							return __( 'Refunded amount', 'wp-graphql-woocommerce' );
+							return __( 'Refunded amount', 'graphql-for-ecommerce' );
 						},
 					],
 					'reason'     => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Reason for refund', 'wp-graphql-woocommerce' );
+							return __( 'Reason for refund', 'graphql-for-ecommerce' );
 						},
 					],
 					'refundedBy' => [
 						'type'        => 'User',
 						'description' => static function () {
-							return __( 'User who completed the refund', 'wp-graphql-woocommerce' );
+							return __( 'User who completed the refund', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args, AppContext $context ) {
 							$user_id = absint( $source->refunded_by_id );
@@ -76,7 +76,7 @@ class Refund_Type {
 					'date'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'The date of the refund', 'wp-graphql-woocommerce' );
+							return __( 'The date of the refund', 'graphql-for-ecommerce' );
 						},
 					],
 

--- a/includes/type/object/class-root-query.php
+++ b/includes/type/object/class-root-query.php
@@ -35,18 +35,18 @@ class Root_Query {
 						'recalculateTotals' => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'Should cart totals be recalculated.', 'wp-graphql-woocommerce' );
+								return __( 'Should cart totals be recalculated.', 'graphql-for-ecommerce' );
 							},
 						],
 						'fees'              => [
 							'type'        => [ 'list_of' => 'FeeInput' ],
 							'description' => static function () {
-								return __( 'Fees to add to the cart.', 'wp-graphql-woocommerce' );
+								return __( 'Fees to add to the cart.', 'graphql-for-ecommerce' );
 							},
 						],
 					],
 					'description' => static function () {
-						return __( 'The cart object', 'wp-graphql-woocommerce' );
+						return __( 'The cart object', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $_, $args ) {
 						$token_invalid = apply_filters( 'graphql_woocommerce_session_token_errors', null );
@@ -95,12 +95,12 @@ class Root_Query {
 						],
 					],
 					'description' => static function () {
-						return __( 'The cart object', 'wp-graphql-woocommerce' );
+						return __( 'The cart object', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source, array $args ) {
 						$item = Factory::resolve_cart()->get_cart_item( $args['key'] );
 						if ( empty( $item ) || empty( $item['key'] ) ) {
-							throw new UserError( __( 'Failed to retrieve cart item.', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'Failed to retrieve cart item.', 'graphql-for-ecommerce' ) );
 						}
 
 						return $item;
@@ -114,14 +114,14 @@ class Root_Query {
 						],
 					],
 					'description' => static function () {
-						return __( 'The cart object', 'wp-graphql-woocommerce' );
+						return __( 'The cart object', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $source, array $args ) {
 						$fees   = Factory::resolve_cart()->get_fees();
 						$fee_id = $args['id'];
 
 						if ( empty( $fees[ $fee_id ] ) ) {
-							throw new UserError( __( 'The ID input is invalid', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'The ID input is invalid', 'graphql-for-ecommerce' ) );
 						}
 
 						return $fees[ $fee_id ];
@@ -130,14 +130,14 @@ class Root_Query {
 				'coupon'           => [
 					'type'        => 'Coupon',
 					'description' => static function () {
-						return __( 'A coupon object', 'wp-graphql-woocommerce' );
+						return __( 'A coupon object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'     => [ 'type' => [ 'non_null' => 'ID' ] ],
 						'idType' => [
 							'type'        => 'CouponIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify coupon', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify coupon', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -157,7 +157,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $args['id'] );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$coupon_id = absint( $id_components['id'] );
 								break;
@@ -177,13 +177,13 @@ class Root_Query {
 
 						if ( empty( $coupon_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No coupon ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No coupon ID was found corresponding to the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						$coupon = get_post( $coupon_id );
 						if ( ! is_object( $coupon ) || 'shop_coupon' !== $coupon->post_type ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No coupon exists with the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No coupon exists with the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						return Factory::resolve_crud_object( $coupon_id, $context );
@@ -192,19 +192,19 @@ class Root_Query {
 				'customer'         => [
 					'type'        => 'Customer',
 					'description' => static function () {
-						return __( 'A customer object', 'wp-graphql-woocommerce' );
+						return __( 'A customer object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'         => [
 							'type'        => 'ID',
 							'description' => static function () {
-								return __( 'Get the customer by their global ID', 'wp-graphql-woocommerce' );
+								return __( 'Get the customer by their global ID', 'graphql-for-ecommerce' );
 							},
 						],
 						'customerId' => [
 							'type'        => 'Int',
 							'description' => static function () {
-								return __( 'Get the customer by their database ID', 'wp-graphql-woocommerce' );
+								return __( 'Get the customer by their database ID', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -218,7 +218,7 @@ class Root_Query {
 						if ( ! empty( $args['id'] ) ) {
 							$id_components = Relay::fromGlobalId( $args['id'] );
 							if ( ! isset( $id_components['id'] ) || ! absint( $id_components['id'] ) ) {
-								throw new UserError( __( 'The ID input is invalid', 'wp-graphql-woocommerce' ) );
+								throw new UserError( __( 'The ID input is invalid', 'graphql-for-ecommerce' ) );
 							}
 
 							$customer_id = absint( $id_components['id'] );
@@ -231,7 +231,7 @@ class Root_Query {
 							&& ! current_user_can( 'list_users' )
 							&& $current_user_id !== $customer_id;
 						if ( $unauthorized ) {
-							throw new UserError( __( 'Not authorized to access this customer', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'Not authorized to access this customer', 'graphql-for-ecommerce' ) );
 						}
 
 						// If we have a customer ID, resolve to that customer.
@@ -246,19 +246,19 @@ class Root_Query {
 				'order'            => [
 					'type'        => 'Order',
 					'description' => static function () {
-						return __( 'A order object', 'wp-graphql-woocommerce' );
+						return __( 'A order object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'     => [
 							'type'        => 'ID',
 							'description' => static function () {
-								return __( 'The ID for identifying the order', 'wp-graphql-woocommerce' );
+								return __( 'The ID for identifying the order', 'graphql-for-ecommerce' );
 							},
 						],
 						'idType' => [
 							'type'        => 'OrderIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify order', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify order', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -278,7 +278,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $id );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$order_id = absint( $id_components['id'] );
 								break;
@@ -286,12 +286,12 @@ class Root_Query {
 
 						if ( empty( $order_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No order ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No order ID was found corresponding to the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						if ( 'shop_order' !== OrderUtil::get_order_type( $order_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No order exists with the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No order exists with the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						// Check if user authorized to view order.
@@ -321,7 +321,7 @@ class Root_Query {
 
 						// Throw if authorized to view order.
 						if ( ! $is_authorized ) {
-							throw new UserError( __( 'Not authorized to access this order', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'Not authorized to access this order', 'graphql-for-ecommerce' ) );
 						}
 
 						return Factory::resolve_crud_object( $order_id, $context );
@@ -330,19 +330,19 @@ class Root_Query {
 				'productVariation' => [
 					'type'        => 'ProductVariation',
 					'description' => static function () {
-						return __( 'A product variation object', 'wp-graphql-woocommerce' );
+						return __( 'A product variation object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'     => [
 							'type'        => 'ID',
 							'description' => static function () {
-								return __( 'The ID for identifying the product variation', 'wp-graphql-woocommerce' );
+								return __( 'The ID for identifying the product variation', 'graphql-for-ecommerce' );
 							},
 						],
 						'idType' => [
 							'type'        => 'ProductVariationIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify product variation', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify product variation', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -359,7 +359,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $id );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$variation_id = absint( $id_components['id'] );
 								break;
@@ -367,13 +367,13 @@ class Root_Query {
 
 						if ( empty( $variation_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No product variation ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No product variation ID was found corresponding to the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						$variation = get_post( $variation_id );
 						if ( ! is_object( $variation ) || 'product_variation' !== $variation->post_type ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No product variation exists with the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No product variation exists with the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						return Factory::resolve_crud_object( $variation_id, $context );
@@ -382,19 +382,19 @@ class Root_Query {
 				'refund'           => [
 					'type'        => 'Refund',
 					'description' => static function () {
-						return __( 'A refund object', 'wp-graphql-woocommerce' );
+						return __( 'A refund object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'     => [
 							'type'        => [ 'non_null' => 'ID' ],
 							'description' => static function () {
-								return __( 'The ID for identifying the refund', 'wp-graphql-woocommerce' );
+								return __( 'The ID for identifying the refund', 'graphql-for-ecommerce' );
 							},
 						],
 						'idType' => [
 							'type'        => 'RefundIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify refund', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify refund', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -411,7 +411,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $id );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$refund_id = absint( $id_components['id'] );
 								break;
@@ -419,12 +419,12 @@ class Root_Query {
 
 						if ( empty( $refund_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No refund ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No refund ID was found corresponding to the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						if ( 'shop_order_refund' !== OrderUtil::get_order_type( $refund_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No refund exists with the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $id ) );
+							throw new UserError( sprintf( __( 'No refund exists with the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $id ) );
 						}
 
 						// Check if user authorized to view order.
@@ -438,7 +438,7 @@ class Root_Query {
 						if ( get_current_user_id() ) {
 							$refund = \wc_get_order( $refund_id );
 							if ( ! is_object( $refund ) || ! is_a( $refund, \WC_Order_Refund::class ) ) {
-								throw new UserError( __( 'Failed to retrieve refund', 'wp-graphql-woocommerce' ) );
+								throw new UserError( __( 'Failed to retrieve refund', 'graphql-for-ecommerce' ) );
 							}
 							$order_id = $refund->get_parent_id();
 
@@ -460,7 +460,7 @@ class Root_Query {
 
 						// Throw if authorized to view refund.
 						if ( ! $is_authorized ) {
-							throw new UserError( __( 'Not authorized to access this refund', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'Not authorized to access this refund', 'graphql-for-ecommerce' ) );
 						}
 
 						return Factory::resolve_crud_object( $refund_id, $context );
@@ -469,25 +469,25 @@ class Root_Query {
 				'shippingMethod'   => [
 					'type'        => 'ShippingMethod',
 					'description' => static function () {
-						return __( 'A shipping method object', 'wp-graphql-woocommerce' );
+						return __( 'A shipping method object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'     => [
 							'type'        => 'ID',
 							'description' => static function () {
-								return __( 'The ID for identifying the shipping method', 'wp-graphql-woocommerce' );
+								return __( 'The ID for identifying the shipping method', 'graphql-for-ecommerce' );
 							},
 						],
 						'idType' => [
 							'type'        => 'ShippingMethodIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify product variation', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify product variation', 'graphql-for-ecommerce' );
 							},
 						],
 					],
 					'resolve'     => static function ( $source, array $args ) {
 						if ( ! \wc_rest_check_manager_permissions( 'shipping_methods', 'read' ) ) {
-							throw new UserError( __( 'Sorry, you cannot view shipping methods.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+							throw new UserError( __( 'Sorry, you cannot view shipping methods.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 						}
 
 						$id      = isset( $args['id'] ) ? $args['id'] : null;
@@ -502,7 +502,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $id );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$method_id = $id_components['id'];
 								break;
@@ -514,29 +514,29 @@ class Root_Query {
 				'shippingZone'     => [
 					'type'        => 'ShippingZone',
 					'description' => static function () {
-						return __( 'A shipping zone object', 'wp-graphql-woocommerce' );
+						return __( 'A shipping zone object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'     => [
 							'type'        => 'ID',
 							'description' => static function () {
-								return __( 'The ID for identifying the shipping zone', 'wp-graphql-woocommerce' );
+								return __( 'The ID for identifying the shipping zone', 'graphql-for-ecommerce' );
 							},
 						],
 						'idType' => [
 							'type'        => 'ShippingZoneIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify shipping zone', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify shipping zone', 'graphql-for-ecommerce' );
 							},
 						],
 					],
 					'resolve'     => static function ( $source, array $args, AppContext $context ) {
 						if ( ! \wc_shipping_enabled() ) {
-							throw new UserError( __( 'Shipping is disabled.', 'wp-graphql-woocommerce' ), 404 );
+							throw new UserError( __( 'Shipping is disabled.', 'graphql-for-ecommerce' ), 404 );
 						}
 
 						if ( ! \wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-							throw new UserError( __( 'Permission denied.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+							throw new UserError( __( 'Permission denied.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 						}
 
 						$id      = isset( $args['id'] ) ? $args['id'] : null;
@@ -551,7 +551,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $id );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$zone_id = $id_components['id'];
 								break;
@@ -563,25 +563,25 @@ class Root_Query {
 				'taxRate'          => [
 					'type'        => 'TaxRate',
 					'description' => static function () {
-						return __( 'A tax rate object', 'wp-graphql-woocommerce' );
+						return __( 'A tax rate object', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'id'     => [
 							'type'        => 'ID',
 							'description' => static function () {
-								return __( 'The ID for identifying the tax rate', 'wp-graphql-woocommerce' );
+								return __( 'The ID for identifying the tax rate', 'graphql-for-ecommerce' );
 							},
 						],
 						'idType' => [
 							'type'        => 'TaxRateIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify tax rate', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify tax rate', 'graphql-for-ecommerce' );
 							},
 						],
 					],
 					'resolve'     => static function ( $source, array $args, AppContext $context ) {
 						if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-							throw new UserError( __( 'Sorry, you cannot view tax rates.', 'wp-graphql-woocommerce' ), \rest_authorization_required_code() );
+							throw new UserError( __( 'Sorry, you cannot view tax rates.', 'graphql-for-ecommerce' ), \rest_authorization_required_code() );
 						}
 						$id      = isset( $args['id'] ) ? $args['id'] : null;
 						$id_type = isset( $args['idType'] ) ? $args['idType'] : 'global_id';
@@ -595,7 +595,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $id );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$rate_id = absint( $id_components['id'] );
 								break;
@@ -607,7 +607,7 @@ class Root_Query {
 				'countries'        => [
 					'type'        => [ 'list_of' => 'CountriesEnum' ],
 					'description' => static function () {
-						return __( 'Countries', 'wp-graphql-woocommerce' );
+						return __( 'Countries', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function () {
 						$wc_countries = new \WC_Countries();
@@ -619,7 +619,7 @@ class Root_Query {
 				'allowedCountries' => [
 					'type'        => [ 'list_of' => 'CountriesEnum' ],
 					'description' => static function () {
-						return __( 'Countries that the store sells to', 'wp-graphql-woocommerce' );
+						return __( 'Countries that the store sells to', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function () {
 						$wc_countries = new \WC_Countries();
@@ -634,12 +634,12 @@ class Root_Query {
 						'country' => [
 							'type'        => [ 'non_null' => 'CountriesEnum' ],
 							'description' => static function () {
-								return __( 'Target country', 'wp-graphql-woocommerce' );
+								return __( 'Target country', 'graphql-for-ecommerce' );
 							},
 						],
 					],
 					'description' => static function () {
-						return __( 'Countries that the store sells to', 'wp-graphql-woocommerce' );
+						return __( 'Countries that the store sells to', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $_, $args ) {
 						$country      = $args['country'];
@@ -661,11 +661,11 @@ class Root_Query {
 				'wcSettingGroups'  => [
 					'type'        => [ 'list_of' => 'WCSettingGroup' ],
 					'description' => static function () {
-						return __( 'WooCommerce setting groups', 'wp-graphql-woocommerce' );
+						return __( 'WooCommerce setting groups', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function () {
 						if ( ! \wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-							throw new UserError( __( 'Sorry, you cannot view settings.', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'Sorry, you cannot view settings.', 'graphql-for-ecommerce' ) );
 						}
 
 						$groups = apply_filters( 'woocommerce_settings_groups', [] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
@@ -675,19 +675,19 @@ class Root_Query {
 				'wcSettings'       => [
 					'type'        => [ 'list_of' => 'WCSetting' ],
 					'description' => static function () {
-						return __( 'WooCommerce settings for a specific group', 'wp-graphql-woocommerce' );
+						return __( 'WooCommerce settings for a specific group', 'graphql-for-ecommerce' );
 					},
 					'args'        => [
 						'group' => [
 							'type'        => [ 'non_null' => 'String' ],
 							'description' => static function () {
-								return __( 'Settings group ID', 'wp-graphql-woocommerce' );
+								return __( 'Settings group ID', 'graphql-for-ecommerce' );
 							},
 						],
 					],
 					'resolve'     => static function ( $_, $args ) {
 						if ( ! \wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-							throw new UserError( __( 'Sorry, you cannot view settings.', 'wp-graphql-woocommerce' ) );
+							throw new UserError( __( 'Sorry, you cannot view settings.', 'graphql-for-ecommerce' ) );
 						}
 
 						$controller = new \WC_REST_Setting_Options_Controller();
@@ -706,19 +706,19 @@ class Root_Query {
 						'calculatePriceRange'        => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'If true, calculates the minimum and maximum product prices for the collection.', 'wp-graphql-woocommerce' );
+								return __( 'If true, calculates the minimum and maximum product prices for the collection.', 'graphql-for-ecommerce' );
 							},
 						],
 						'calculateRatingCounts'      => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'If true, calculates rating counts for products in the collection.', 'wp-graphql-woocommerce' );
+								return __( 'If true, calculates rating counts for products in the collection.', 'graphql-for-ecommerce' );
 							},
 						],
 						'calculateStockStatusCounts' => [
 							'type'        => 'Boolean',
 							'description' => static function () {
-								return __( 'If true, calculates stock counts for products in the collection.', 'wp-graphql-woocommerce' );
+								return __( 'If true, calculates stock counts for products in the collection.', 'graphql-for-ecommerce' );
 							},
 						],
 						'taxonomies'                 => [
@@ -729,7 +729,7 @@ class Root_Query {
 						],
 					],
 					'description' => static function () {
-						return __( 'Statistics for a product taxonomy query', 'wp-graphql-woocommerce' );
+						return __( 'Statistics for a product taxonomy query', 'graphql-for-ecommerce' );
 					},
 					'resolve'     => static function ( $_, $args ) {
 						/** @var array<string, mixed> $data */
@@ -921,7 +921,7 @@ class Root_Query {
 					'type'              => $type_name,
 					'description'       => static function () use ( $type_key ) {
 						/* translators: %s: Product type slug */
-						return sprintf( __( 'A %s product object', 'wp-graphql-woocommerce' ), $type_key );
+						return sprintf( __( 'A %s product object', 'graphql-for-ecommerce' ), $type_key );
 					},
 					'deprecationReason' => 'Use "product" instead.',
 					'args'              => [
@@ -929,13 +929,13 @@ class Root_Query {
 							'type'        => 'ID',
 							'description' => static function () use ( $type_name ) {
 								/* translators: %s: product type */
-								return sprintf( __( 'The ID for identifying the %s product', 'wp-graphql-woocommerce' ), $type_name );
+								return sprintf( __( 'The ID for identifying the %s product', 'graphql-for-ecommerce' ), $type_name );
 							},
 						],
 						'idType' => [
 							'type'        => 'ProductIdTypeEnum',
 							'description' => static function () {
-								return __( 'Type of ID being used identify product', 'wp-graphql-woocommerce' );
+								return __( 'Type of ID being used identify product', 'graphql-for-ecommerce' );
 							},
 						],
 					],
@@ -959,7 +959,7 @@ class Root_Query {
 							default:
 								$id_components = Relay::fromGlobalId( $id );
 								if ( empty( $id_components['id'] ) || empty( $id_components['type'] ) ) {
-									throw new UserError( __( 'The "id" is invalid', 'wp-graphql-woocommerce' ) );
+									throw new UserError( __( 'The "id" is invalid', 'graphql-for-ecommerce' ) );
 								}
 								$product_id = absint( $id_components['id'] );
 								break;
@@ -967,18 +967,18 @@ class Root_Query {
 
 						if ( empty( $product_id ) ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No product ID was found corresponding to the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $product_id ) );
+							throw new UserError( sprintf( __( 'No product ID was found corresponding to the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $product_id ) );
 						}
 
 						if ( \WC()->product_factory->get_product_type( $product_id ) !== $type_key && 'off' === $unsupported_type_enabled ) {
 							/* translators: Invalid product type message %1$s: Product ID, %2$s: Product type */
-							throw new UserError( sprintf( __( 'This product of ID %1$s is not a %2$s product', 'wp-graphql-woocommerce' ), $product_id, $type_key ) );
+							throw new UserError( sprintf( __( 'This product of ID %1$s is not a %2$s product', 'graphql-for-ecommerce' ), $product_id, $type_key ) );
 						}
 
 						$product = get_post( $product_id );
 						if ( ! is_object( $product ) || 'product' !== $product->post_type ) {
 							/* translators: %1$s: ID type, %2$s: ID value */
-							throw new UserError( sprintf( __( 'No product exists with the %1$s: %2$s', 'wp-graphql-woocommerce' ), $id_type, $product_id ) );
+							throw new UserError( sprintf( __( 'No product exists with the %1$s: %2$s', 'graphql-for-ecommerce' ), $id_type, $product_id ) );
 						}
 
 						return Factory::resolve_crud_object( $product_id, $context );

--- a/includes/type/object/class-shipping-location-type.php
+++ b/includes/type/object/class-shipping-location-type.php
@@ -25,19 +25,19 @@ class Shipping_Location_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A Shipping zone object', 'wp-graphql-woocommerce' );
+					return __( 'A Shipping zone object', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'code' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'The globally unique identifier for the tax rate.', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the tax rate.', 'graphql-for-ecommerce' );
 						},
 					],
 					'type' => [
 						'type'        => 'ShippingLocationTypeEnum',
 						'description' => static function () {
-							return __( 'Shipping zone location name.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping zone location name.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/object/class-shipping-method-type.php
+++ b/includes/type/object/class-shipping-method-type.php
@@ -24,32 +24,32 @@ class Shipping_Method_Type {
 			'ShippingMethod',
 			[
 				'description' => static function () {
-					return __( 'A shipping method object', 'wp-graphql-woocommerce' );
+					return __( 'A shipping method object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'          => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The globally unique identifier for the tax rate.', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the tax rate.', 'graphql-for-ecommerce' );
 						},
 					],
 					'databaseId'  => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The ID of the shipping method in the database', 'wp-graphql-woocommerce' );
+							return __( 'The ID of the shipping method in the database', 'graphql-for-ecommerce' );
 						},
 					],
 					'title'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping method title.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping method title.', 'graphql-for-ecommerce' );
 						},
 					],
 					'description' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping method description.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping method description.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/object/class-shipping-package-type.php
+++ b/includes/type/object/class-shipping-package-type.php
@@ -24,13 +24,13 @@ class Shipping_Package_Type {
 			'ShippingPackage',
 			[
 				'description' => static function () {
-					return __( 'Shipping package object', 'wp-graphql-woocommerce' );
+					return __( 'Shipping package object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'packageDetails'             => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping package details', 'wp-graphql-woocommerce' );
+							return __( 'Shipping package details', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$product_names = [];
@@ -47,7 +47,7 @@ class Shipping_Package_Type {
 					'rates'                      => [
 						'type'        => [ 'list_of' => 'ShippingRate' ],
 						'description' => static function () {
-							return __( 'Shipping package rates', 'wp-graphql-woocommerce' );
+							return __( 'Shipping package rates', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['rates'] ) ? $source['rates'] : null;
@@ -56,7 +56,7 @@ class Shipping_Package_Type {
 					'supportsShippingCalculator' => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'This shipping package supports the shipping calculator.', 'wp-graphql-woocommerce' );
+							return __( 'This shipping package supports the shipping calculator.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound

--- a/includes/type/object/class-shipping-rate-type.php
+++ b/includes/type/object/class-shipping-rate-type.php
@@ -24,13 +24,13 @@ class Shipping_Rate_Type {
 			'ShippingRate',
 			[
 				'description' => static function () {
-					return __( 'Shipping rate object', 'wp-graphql-woocommerce' );
+					return __( 'Shipping rate object', 'graphql-for-ecommerce' );
 				},
 				'fields'      => [
 					'id'         => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Shipping rate ID', 'wp-graphql-woocommerce' );
+							return __( 'Shipping rate ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->get_id() ) ? $source->get_id() : null;
@@ -39,7 +39,7 @@ class Shipping_Rate_Type {
 					'methodId'   => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'Shipping method ID', 'wp-graphql-woocommerce' );
+							return __( 'Shipping method ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->get_method_id() ) ? $source->get_method_id() : null;
@@ -48,7 +48,7 @@ class Shipping_Rate_Type {
 					'instanceId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Shipping instance ID', 'wp-graphql-woocommerce' );
+							return __( 'Shipping instance ID', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->get_instance_id() ) ? $source->get_instance_id() : null;
@@ -57,7 +57,7 @@ class Shipping_Rate_Type {
 					'label'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping rate label', 'wp-graphql-woocommerce' );
+							return __( 'Shipping rate label', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source->get_label() ) ? $source->get_label() : null;
@@ -66,13 +66,13 @@ class Shipping_Rate_Type {
 					'cost'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping rate cost. Includes tax when woocommerce_tax_display_cart is set to incl.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping rate cost. Includes tax when woocommerce_tax_display_cart is set to incl.', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -96,13 +96,13 @@ class Shipping_Rate_Type {
 					'subtotal'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping rate cost before tax.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping rate cost before tax.', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],
@@ -122,13 +122,13 @@ class Shipping_Rate_Type {
 					'taxTotal'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping rate tax total.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping rate tax total.', 'graphql-for-ecommerce' );
 						},
 						'args'        => [
 							'format' => [
 								'type'        => 'PricingFieldFormatEnum',
 								'description' => static function () {
-									return __( 'Format of the price', 'wp-graphql-woocommerce' );
+									return __( 'Format of the price', 'graphql-for-ecommerce' );
 								},
 							],
 						],

--- a/includes/type/object/class-shipping-zone-type.php
+++ b/includes/type/object/class-shipping-zone-type.php
@@ -28,38 +28,38 @@ class Shipping_Zone_Type {
 			'ShippingZone',
 			[
 				'description' => static function () {
-					return __( 'A Shipping zone object', 'wp-graphql-woocommerce' );
+					return __( 'A Shipping zone object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'         => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The globally unique identifier for the tax rate.', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the tax rate.', 'graphql-for-ecommerce' );
 						},
 					],
 					'databaseId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'The ID of the customer in the database', 'wp-graphql-woocommerce' );
+							return __( 'The ID of the customer in the database', 'graphql-for-ecommerce' );
 						},
 					],
 					'name'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Shipping zone name.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping zone name.', 'graphql-for-ecommerce' );
 						},
 					],
 					'order'      => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Shipping zone order.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping zone order.', 'graphql-for-ecommerce' );
 						},
 					],
 					'locations'  => [
 						'type'        => [ 'list_of' => 'ShippingLocation' ],
 						'description' => static function () {
-							return __( 'Shipping zone locations.', 'wp-graphql-woocommerce' );
+							return __( 'Shipping zone locations.', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -70,7 +70,7 @@ class Shipping_Zone_Type {
 							'id'         => [
 								'type'        => [ 'non_null' => 'ID' ],
 								'description' => static function () {
-									return __( 'The globally unique identifier for the shipping method.', 'wp-graphql-woocommerce' );
+									return __( 'The globally unique identifier for the shipping method.', 'graphql-for-ecommerce' );
 								},
 								'resolve'     => static function ( $edge ) {
 									if ( isset( $edge['node'] ) ) {
@@ -85,7 +85,7 @@ class Shipping_Zone_Type {
 							'instanceId' => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'Shipping method instance ID.', 'wp-graphql-woocommerce' );
+									return __( 'Shipping method instance ID.', 'graphql-for-ecommerce' );
 								},
 								'resolve'     => static function ( $edge ) {
 									if ( isset( $edge['node'] ) ) {
@@ -98,7 +98,7 @@ class Shipping_Zone_Type {
 							'order'      => [
 								'type'        => 'Int',
 								'description' => static function () {
-									return __( 'The order of the shipping method.', 'wp-graphql-woocommerce' );
+									return __( 'The order of the shipping method.', 'graphql-for-ecommerce' );
 								},
 								'resolve'     => static function ( $edge ) {
 									if ( isset( $edge['node'] ) ) {
@@ -111,7 +111,7 @@ class Shipping_Zone_Type {
 							'enabled'    => [
 								'type'        => 'Boolean',
 								'description' => static function () {
-									return __( 'Whether the shipping method is enabled.', 'wp-graphql-woocommerce' );
+									return __( 'Whether the shipping method is enabled.', 'graphql-for-ecommerce' );
 								},
 								'resolve'     => static function ( $edge ) {
 									if ( isset( $edge['node'] ) ) {
@@ -125,7 +125,7 @@ class Shipping_Zone_Type {
 							'settings'   => [
 								'type'        => [ 'list_of' => 'WCStringSetting' ],
 								'description' => static function () {
-									return __( 'Shipping method settings.', 'wp-graphql-woocommerce' );
+									return __( 'Shipping method settings.', 'graphql-for-ecommerce' );
 								},
 								'resolve'     => static function ( $edge ) {
 									$settings = [];

--- a/includes/type/object/class-simple-attribute-type.php
+++ b/includes/type/object/class-simple-attribute-type.php
@@ -24,7 +24,7 @@ class Simple_Attribute_Type {
 			'SimpleAttribute',
 			[
 				'description' => static function () {
-					return __( 'A simple attribute object', 'wp-graphql-woocommerce' );
+					return __( 'A simple attribute object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Attribute' ],
 				'fields'      => [],

--- a/includes/type/object/class-tax-class-type.php
+++ b/includes/type/object/class-tax-class-type.php
@@ -25,14 +25,14 @@ class Tax_Class_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A Tax class object', 'wp-graphql-woocommerce' );
+					return __( 'A Tax class object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => [ 'Node' ],
 				'fields'          => [
 					'id'   => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The globally unique identifier for the tax class.', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the tax class.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args, $context, $info ) {
 							return ! empty( $source['slug'] ) ? \GraphQLRelay\Relay::toGlobalId( 'tax_class', $source['slug'] ) : null;
@@ -41,7 +41,7 @@ class Tax_Class_Type {
 					'slug' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'The globally unique identifier for the tax class.', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the tax class.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args, $context, $info ) {
 							return ! empty( $source['slug'] ) ? $source['slug'] : null;
@@ -50,7 +50,7 @@ class Tax_Class_Type {
 					'name' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax class name.', 'wp-graphql-woocommerce' );
+							return __( 'Tax class name.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source, array $args, $context, $info ) {
 							return ! empty( $source['name'] ) ? $source['name'] : null;

--- a/includes/type/object/class-tax-rate-type.php
+++ b/includes/type/object/class-tax-rate-type.php
@@ -24,100 +24,100 @@ class Tax_Rate_Type {
 			'TaxRate',
 			[
 				'description' => static function () {
-					return __( 'A Tax rate object', 'wp-graphql-woocommerce' );
+					return __( 'A Tax rate object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Node' ],
 				'fields'      => [
 					'id'         => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The globally unique identifier for the tax rate.', 'wp-graphql-woocommerce' );
+							return __( 'The globally unique identifier for the tax rate.', 'graphql-for-ecommerce' );
 						},
 					],
 					'databaseId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'The ID of the customer in the database', 'wp-graphql-woocommerce' );
+							return __( 'The ID of the customer in the database', 'graphql-for-ecommerce' );
 						},
 					],
 					'country'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Country ISO 3166 code.', 'wp-graphql-woocommerce' );
+							return __( 'Country ISO 3166 code.', 'graphql-for-ecommerce' );
 						},
 					],
 					'state'      => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'State code.', 'wp-graphql-woocommerce' );
+							return __( 'State code.', 'graphql-for-ecommerce' );
 						},
 					],
 					'postcode'   => [
 						'type'              => 'String',
 						'description'       => static function () {
-							return __( 'Postcode/ZIP.', 'wp-graphql-woocommerce' );
+							return __( 'Postcode/ZIP.', 'graphql-for-ecommerce' );
 						},
 						'deprecationReason' => 'Use "postcodes" instead.',
 					],
 					'city'       => [
 						'type'              => 'String',
 						'description'       => static function () {
-							return __( 'City name.', 'wp-graphql-woocommerce' );
+							return __( 'City name.', 'graphql-for-ecommerce' );
 						},
 						'deprecationReason' => 'Use "cities" instead.',
 					],
 					'postcodes'  => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Postcodes/ZIPs.', 'wp-graphql-woocommerce' );
+							return __( 'Postcodes/ZIPs.', 'graphql-for-ecommerce' );
 						},
 					],
 					'cities'     => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'City names.', 'wp-graphql-woocommerce' );
+							return __( 'City names.', 'graphql-for-ecommerce' );
 						},
 					],
 					'rate'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax rate.', 'wp-graphql-woocommerce' );
+							return __( 'Tax rate.', 'graphql-for-ecommerce' );
 						},
 					],
 					'name'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Tax rate name.', 'wp-graphql-woocommerce' );
+							return __( 'Tax rate name.', 'graphql-for-ecommerce' );
 						},
 					],
 					'priority'   => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Tax priority.', 'wp-graphql-woocommerce' );
+							return __( 'Tax priority.', 'graphql-for-ecommerce' );
 						},
 					],
 					'compound'   => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Whether or not this is a compound rate.', 'wp-graphql-woocommerce' );
+							return __( 'Whether or not this is a compound rate.', 'graphql-for-ecommerce' );
 						},
 					],
 					'shipping'   => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Whether or not this tax rate also gets applied to shipping.', 'wp-graphql-woocommerce' );
+							return __( 'Whether or not this tax rate also gets applied to shipping.', 'graphql-for-ecommerce' );
 						},
 					],
 					'order'      => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Indicates the order that will appear in queries.', 'wp-graphql-woocommerce' );
+							return __( 'Indicates the order that will appear in queries.', 'graphql-for-ecommerce' );
 						},
 					],
 					'class'      => [
 						'type'        => 'TaxClassEnum',
 						'description' => static function () {
-							return __( 'Tax class. Default is standard.', 'wp-graphql-woocommerce' );
+							return __( 'Tax class. Default is standard.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/type/object/class-variation-attribute-type.php
+++ b/includes/type/object/class-variation-attribute-type.php
@@ -24,14 +24,14 @@ class Variation_Attribute_Type {
 			'VariationAttribute',
 			[
 				'description' => static function () {
-					return __( 'A product variation attribute object', 'wp-graphql-woocommerce' );
+					return __( 'A product variation attribute object', 'graphql-for-ecommerce' );
 				},
 				'interfaces'  => [ 'Attribute' ],
 				'fields'      => [
 					'id'          => [
 						'type'        => [ 'non_null' => 'ID' ],
 						'description' => static function () {
-							return __( 'The Global ID of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'The Global ID of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['id'] ) ? $source['id'] : null;
@@ -40,7 +40,7 @@ class Variation_Attribute_Type {
 					'attributeId' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'The Database ID of the attribute.', 'wp-graphql-woocommerce' );
+							return __( 'The Database ID of the attribute.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['attributeId'] ) ? $source['attributeId'] : null;
@@ -49,7 +49,7 @@ class Variation_Attribute_Type {
 					'label'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Label of attribute', 'wp-graphql-woocommerce' );
+							return __( 'Label of attribute', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['label'] ) ? $source['label'] : null;
@@ -58,7 +58,7 @@ class Variation_Attribute_Type {
 					'name'        => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Name of attribute', 'wp-graphql-woocommerce' );
+							return __( 'Name of attribute', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['name'] ) ? $source['name'] : null;
@@ -67,7 +67,7 @@ class Variation_Attribute_Type {
 					'value'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Selected value of attribute', 'wp-graphql-woocommerce' );
+							return __( 'Selected value of attribute', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return isset( $source['value'] ) ? $source['value'] : null;

--- a/includes/type/object/class-wc-setting-group-type.php
+++ b/includes/type/object/class-wc-setting-group-type.php
@@ -25,31 +25,31 @@ class WC_Setting_Group_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A WooCommerce settings group', 'wp-graphql-woocommerce' );
+					return __( 'A WooCommerce settings group', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'id'          => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => static function () {
-							return __( 'A unique identifier that can be used to link settings together.', 'wp-graphql-woocommerce' );
+							return __( 'A unique identifier that can be used to link settings together.', 'graphql-for-ecommerce' );
 						},
 					],
 					'label'       => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A human readable label for the setting group used in interfaces.', 'wp-graphql-woocommerce' );
+							return __( 'A human readable label for the setting group used in interfaces.', 'graphql-for-ecommerce' );
 						},
 					],
 					'description' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'A human readable description for the setting group used in interfaces.', 'wp-graphql-woocommerce' );
+							return __( 'A human readable description for the setting group used in interfaces.', 'graphql-for-ecommerce' );
 						},
 					],
 					'parentId'    => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'ID of parent grouping.', 'wp-graphql-woocommerce' );
+							return __( 'ID of parent grouping.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['parent_id'] ) ? $source['parent_id'] : null;
@@ -58,7 +58,7 @@ class WC_Setting_Group_Type {
 					'subGroups'   => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'IDs for settings sub groups.', 'wp-graphql-woocommerce' );
+							return __( 'IDs for settings sub groups.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['sub_groups'] ) ? $source['sub_groups'] : [];
@@ -67,7 +67,7 @@ class WC_Setting_Group_Type {
 					'settings'    => [
 						'type'        => [ 'list_of' => 'WCSetting' ],
 						'description' => static function () {
-							return __( 'The settings belonging to this group.', 'wp-graphql-woocommerce' );
+							return __( 'The settings belonging to this group.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$controller = new \WC_REST_Setting_Options_Controller();

--- a/includes/type/object/class-wc-setting-type.php
+++ b/includes/type/object/class-wc-setting-type.php
@@ -35,13 +35,13 @@ class WC_Setting_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A relative date value with a number and unit.', 'wp-graphql-woocommerce' );
+					return __( 'A relative date value with a number and unit.', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'number' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'The number of periods.', 'wp-graphql-woocommerce' );
+							return __( 'The number of periods.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$number = $source['number'] ?? '';
@@ -51,7 +51,7 @@ class WC_Setting_Type {
 					'unit'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'The period unit (days, weeks, months, years).', 'wp-graphql-woocommerce' );
+							return __( 'The period unit (days, weeks, months, years).', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -63,25 +63,25 @@ class WC_Setting_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'An image width value with dimensions and crop flag.', 'wp-graphql-woocommerce' );
+					return __( 'An image width value with dimensions and crop flag.', 'graphql-for-ecommerce' );
 				},
 				'fields'          => [
 					'width'  => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Image width in pixels.', 'wp-graphql-woocommerce' );
+							return __( 'Image width in pixels.', 'graphql-for-ecommerce' );
 						},
 					],
 					'height' => [
 						'type'        => 'Int',
 						'description' => static function () {
-							return __( 'Image height in pixels.', 'wp-graphql-woocommerce' );
+							return __( 'Image height in pixels.', 'graphql-for-ecommerce' );
 						},
 					],
 					'crop'   => [
 						'type'        => 'Boolean',
 						'description' => static function () {
-							return __( 'Whether to crop the image.', 'wp-graphql-woocommerce' );
+							return __( 'Whether to crop the image.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							return ! empty( $source['crop'] );
@@ -103,14 +103,14 @@ class WC_Setting_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A WC setting with a string value.', 'wp-graphql-woocommerce' );
+					return __( 'A WC setting with a string value.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => [ 'WCSetting' ],
 				'fields'          => [
 					'value'   => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Setting value.', 'wp-graphql-woocommerce' );
+							return __( 'Setting value.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$value = $source['value'] ?? null;
@@ -120,7 +120,7 @@ class WC_Setting_Type {
 					'default' => [
 						'type'        => 'String',
 						'description' => static function () {
-							return __( 'Default value for the setting.', 'wp-graphql-woocommerce' );
+							return __( 'Default value for the setting.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$value = $source['default'] ?? null;
@@ -136,14 +136,14 @@ class WC_Setting_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A WC setting with an array value.', 'wp-graphql-woocommerce' );
+					return __( 'A WC setting with an array value.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => [ 'WCSetting' ],
 				'fields'          => [
 					'value'   => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Setting value as a list of strings.', 'wp-graphql-woocommerce' );
+							return __( 'Setting value as a list of strings.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$value = $source['value'] ?? null;
@@ -153,7 +153,7 @@ class WC_Setting_Type {
 					'default' => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => static function () {
-							return __( 'Default value as a list of strings.', 'wp-graphql-woocommerce' );
+							return __( 'Default value as a list of strings.', 'graphql-for-ecommerce' );
 						},
 						'resolve'     => static function ( $source ) {
 							$value = $source['default'] ?? null;
@@ -169,20 +169,20 @@ class WC_Setting_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A WC setting with a relative date value.', 'wp-graphql-woocommerce' );
+					return __( 'A WC setting with a relative date value.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => [ 'WCSetting' ],
 				'fields'          => [
 					'value'   => [
 						'type'        => 'WCRelativeDate',
 						'description' => static function () {
-							return __( 'Setting value as a relative date.', 'wp-graphql-woocommerce' );
+							return __( 'Setting value as a relative date.', 'graphql-for-ecommerce' );
 						},
 					],
 					'default' => [
 						'type'        => 'WCRelativeDate',
 						'description' => static function () {
-							return __( 'Default value as a relative date.', 'wp-graphql-woocommerce' );
+							return __( 'Default value as a relative date.', 'graphql-for-ecommerce' );
 						},
 					],
 				],
@@ -194,20 +194,20 @@ class WC_Setting_Type {
 			[
 				'eagerlyLoadType' => true,
 				'description'     => static function () {
-					return __( 'A WC setting with an image width value.', 'wp-graphql-woocommerce' );
+					return __( 'A WC setting with an image width value.', 'graphql-for-ecommerce' );
 				},
 				'interfaces'      => [ 'WCSetting' ],
 				'fields'          => [
 					'value'   => [
 						'type'        => 'WCImageWidth',
 						'description' => static function () {
-							return __( 'Setting value as image dimensions.', 'wp-graphql-woocommerce' );
+							return __( 'Setting value as image dimensions.', 'graphql-for-ecommerce' );
 						},
 					],
 					'default' => [
 						'type'        => 'WCImageWidth',
 						'description' => static function () {
-							return __( 'Default value as image dimensions.', 'wp-graphql-woocommerce' );
+							return __( 'Default value as image dimensions.', 'graphql-for-ecommerce' );
 						},
 					],
 				],

--- a/includes/utils/class-protected-router.php
+++ b/includes/utils/class-protected-router.php
@@ -103,7 +103,7 @@ class Protected_Router {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Protected_Router class should not be cloned.', 'wp-graphql-woocommerce' ), esc_html( WPGRAPHQL_WOOCOMMERCE_VERSION ) );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Protected_Router class should not be cloned.', 'graphql-for-ecommerce' ), esc_html( WPGRAPHQL_WOOCOMMERCE_VERSION ) );
 	}
 
 	/**
@@ -113,7 +113,7 @@ class Protected_Router {
 	 */
 	public function __wakeup() {
 		// De-serializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the Protected_Router class is not allowed', 'wp-graphql-woocommerce' ), esc_html( WPGRAPHQL_WOOCOMMERCE_VERSION ) );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the Protected_Router class is not allowed', 'graphql-for-ecommerce' ), esc_html( WPGRAPHQL_WOOCOMMERCE_VERSION ) );
 	}
 
 	/**

--- a/includes/utils/class-ql-session-handler.php
+++ b/includes/utils/class-ql-session-handler.php
@@ -312,17 +312,17 @@ class QL_Session_Handler extends WC_Session_Handler {
 
 			// Check if token was successful decoded.
 			if ( ! $token ) {
-				throw new \Exception( __( 'Failed to decode session token', 'wp-graphql-woocommerce' ) );
+				throw new \Exception( __( 'Failed to decode session token', 'graphql-for-ecommerce' ) );
 			}
 
 			// The Token is decoded now validate the iss.
 			if ( empty( $token->iss ) || get_bloginfo( 'url' ) !== $token->iss ) {
-				throw new \Exception( __( 'The iss do not match with this server', 'wp-graphql-woocommerce' ) );
+				throw new \Exception( __( 'The iss do not match with this server', 'graphql-for-ecommerce' ) );
 			}
 
 			// Validate the customer id in the token.
 			if ( empty( $token->data ) || empty( $token->data->customer_id ) ) {
-				throw new \Exception( __( 'Customer ID not found in the token', 'wp-graphql-woocommerce' ) );
+				throw new \Exception( __( 'Customer ID not found in the token', 'graphql-for-ecommerce' ) );
 			}
 		} catch ( \Throwable $error ) {
 			return new \WP_Error( 'invalid_token', $error->getMessage() );
@@ -343,7 +343,7 @@ class QL_Session_Handler extends WC_Session_Handler {
 	protected function validate_cart_token( $cart_token ) {
 		// Validate Cart-Token using WooCommerce's JsonWebToken utility if available.
 		if ( ! $this->supports_store_api() ) {
-			return new \WP_Error( 'store_api_not_supported', __( 'Store API not available', 'wp-graphql-woocommerce' ) );
+			return new \WP_Error( 'store_api_not_supported', __( 'Store API not available', 'graphql-for-ecommerce' ) );
 		}
 
 		try {
@@ -354,7 +354,7 @@ class QL_Session_Handler extends WC_Session_Handler {
 			);
 
 			if ( ! $is_valid ) {
-				throw new \Exception( __( 'Invalid Cart-Token', 'wp-graphql-woocommerce' ) );
+				throw new \Exception( __( 'Invalid Cart-Token', 'graphql-for-ecommerce' ) );
 			}
 
 			// Decode the token to get the payload.

--- a/includes/utils/class-session-transaction-manager.php
+++ b/includes/utils/class-session-transaction-manager.php
@@ -228,7 +228,7 @@ class Session_Transaction_Manager {
 		// If lead transaction object invalid pop transaction and loop.
 		if ( ! is_array( $transaction_queue[0] ) ) {
 			$this->acquire_lock();
-			$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
+			$transaction_queue = get_transient( "graphql_woocommerce_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 			if ( ! empty( $transaction_queue ) ) {
 				array_shift( $transaction_queue );
 				$this->save_transaction_queue( $transaction_queue );
@@ -241,7 +241,7 @@ class Session_Transaction_Manager {
 		} elseif ( true === $this->did_transaction_expire( $transaction_queue ) ) {
 			// If transaction has expired, remove it from the queue array and continue loop.
 			$this->acquire_lock();
-			$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
+			$transaction_queue = get_transient( "graphql_woocommerce_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 			if ( ! empty( $transaction_queue ) ) {
 				array_shift( $transaction_queue );
 				$this->save_transaction_queue( $transaction_queue );
@@ -265,7 +265,7 @@ class Session_Transaction_Manager {
 		$this->acquire_lock();
 
 		// Get transaction queue.
-		$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
+		$transaction_queue = get_transient( "graphql_woocommerce_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 		if ( ! $transaction_queue ) {
 			$transaction_queue = [];
 		}
@@ -353,7 +353,7 @@ class Session_Transaction_Manager {
 		$this->acquire_lock();
 
 		// Get transaction queue.
-		$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
+		$transaction_queue = get_transient( "graphql_woocommerce_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 
 		if ( ! empty( $transaction_queue[0]['transaction_id'] ) && $this->transaction_id === $transaction_queue[0]['transaction_id'] ) {
 			// Remove Transaction ID and update queue.
@@ -378,12 +378,12 @@ class Session_Transaction_Manager {
 	public function save_transaction_queue( $queue = [] ) {
 		// If queue empty delete transient and bail.
 		if ( empty( $queue ) ) {
-			delete_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
+			delete_transient( "graphql_woocommerce_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 			return;
 		}
 
 		// Save transaction queue.
-		set_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}", $queue, 5 * MINUTE_IN_SECONDS );
+		set_transient( "graphql_woocommerce_session_transactions_queue_{$this->session_handler->get_customer_id()}", $queue, 5 * MINUTE_IN_SECONDS );
 	}
 
 	/**
@@ -394,7 +394,7 @@ class Session_Transaction_Manager {
 	public function set_timestamp() {
 		$this->acquire_lock();
 
-		$transaction_queue = get_transient( "woo_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
+		$transaction_queue = get_transient( "graphql_woocommerce_session_transactions_queue_{$this->session_handler->get_customer_id()}" );
 		if ( ! $transaction_queue ) {
 			$transaction_queue = [];
 		}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -79,7 +79,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- Value: replace the text domain used. -->
-			<property name="text_domain" type="array" value="wp-graphql-woocommerce"/>
+			<property name="text_domain" type="array" value="graphql-for-ecommerce"/>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WP.Capabilities">

--- a/tests/wpunit/ProductQueriesTest.php
+++ b/tests/wpunit/ProductQueriesTest.php
@@ -757,7 +757,7 @@ class ProductQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQ
 			$this->expectedField(
 				'product.addToCartDescription',
 				/* translators: %s: Group name */
-				sprintf( __( 'View products in the &ldquo;%s&rdquo; group', 'wp-graphql-woocommerce' ), 'Test Group' )
+				sprintf( __( 'View products in the &ldquo;%s&rdquo; group', 'graphql-for-ecommerce' ), 'Test Group' )
 			),
 		];
 

--- a/vendor-prefixed/firebase/php-jwt/src/JWK.php
+++ b/vendor-prefixed/firebase/php-jwt/src/JWK.php
@@ -37,6 +37,15 @@ class JWK
         // 'P-521' => '1.3.132.0.35', // Len: 132 (not supported)
     ];
 
+    // Known standard curves from the IANA JOSE registry which are not supported
+    private const KNOWN_UNSUPPORTED_EC_CURVES = [
+        'P-521',   // RFC 7518
+        'Ed25519', // RFC 8037
+        'Ed448',   // RFC 8037
+        'X25519',  // RFC 8037
+        'X448'     // RFC 8037
+    ];
+
     // For keys with "kty" equal to "OKP" (Octet Key Pair), the "crv" parameter must contain the key subtype.
     // This library supports the following subtypes:
     private const OKP_SUBTYPES = [
@@ -148,7 +157,10 @@ class JWK
                 }
 
                 if (!isset(self::EC_CURVES[$jwk['crv']])) {
-                    throw new DomainException('Unrecognised or unsupported EC curve');
+                    if (!\in_array($jwk['crv'], self::KNOWN_UNSUPPORTED_EC_CURVES)) {
+                        throw new DomainException('Unrecognised EC curve');
+                    }
+                    return null;
                 }
 
                 if (empty($jwk['x']) || empty($jwk['y'])) {

--- a/vendor-prefixed/firebase/php-jwt/src/JWT.php
+++ b/vendor-prefixed/firebase/php-jwt/src/JWT.php
@@ -70,7 +70,8 @@ class JWT
         'RS256' => ['openssl', 'SHA256'],
         'RS384' => ['openssl', 'SHA384'],
         'RS512' => ['openssl', 'SHA512'],
-        'EdDSA' => ['sodium_crypto', 'EdDSA'],
+        'PS256' => ['openssl', 'SHA256'],
+        'EdDSA' => ['sodium_crypto', 'EdDSA']
     ];
 
     /**
@@ -230,6 +231,15 @@ class JWT
         if ($keyId !== null) {
             $header['kid'] = $keyId;
         }
+        if (isset($payload['nbf']) && !\is_numeric($payload['nbf'])) {
+            throw new UnexpectedValueException('Payload nbf must be a number');
+        }
+        if (isset($payload['iat']) && !\is_numeric($payload['iat'])) {
+            throw new UnexpectedValueException('Payload iat must be a number');
+        }
+        if (isset($payload['exp']) && !\is_numeric($payload['exp'])) {
+            throw new UnexpectedValueException('Payload exp must be a number');
+        }
         $segments = [];
         $segments[] = static::urlsafeB64Encode((string) static::jsonEncode($header));
         $segments[] = static::urlsafeB64Encode((string) static::jsonEncode($payload));
@@ -247,7 +257,7 @@ class JWT
      * @param string $msg  The message to sign
      * @param string|OpenSSLAsymmetricKey|OpenSSLCertificate  $key  The secret key.
      * @param string $alg  Supported algorithms are 'EdDSA', 'ES384', 'ES256', 'ES256K', 'HS256',
-     *                    'HS384', 'HS512', 'RS256', 'RS384', and 'RS512'
+     *                    'HS384', 'HS512', 'RS256', 'RS384', 'PS256' and 'RS512'
      *
      * @return string An encrypted message
      *
@@ -270,6 +280,9 @@ class JWT
                 self::validateHmacKeyLength($key, $algorithm);
                 return \hash_hmac($algorithm, $msg, $key, true);
             case 'openssl':
+                if ($alg === 'PS256') {
+                    return self::signPS256($key, $msg);
+                }
                 $signature = '';
                 if (!$key = openssl_pkey_get_private($key)) {
                     throw new DomainException('OpenSSL unable to validate key');
@@ -326,6 +339,9 @@ class JWT
         list($function, $algorithm) = static::$supported_algs[$alg];
         switch ($function) {
             case 'openssl':
+                if ($alg === 'PS256') {
+                    return self::verifyPS256($keyMaterial, $msg, $signature);
+                }
                 if (!$key = openssl_pkey_get_public($keyMaterial)) {
                     throw new DomainException('OpenSSL unable to validate key');
                 }
@@ -747,5 +763,77 @@ class JWT
             throw new DomainException('Key cannot be empty string');
         }
         return $key;
+    }
+
+    /**
+     * Signs a message with a PS256 algorithm
+     *
+     * @param string|OpenSSLAsymmetricKey|OpenSSLCertificate $key
+     * @param string $message
+     * @throws DomainException Provided key is invalid
+     */
+    private static function signPS256(
+        #[\SensitiveParameter] string|OpenSSLAsymmetricKey|OpenSSLCertificate $key,
+        string $message
+    ): string {
+        if (!class_exists('\phpseclib3\Crypt\RSA')) {
+            throw new DomainException('phpseclib/phpseclib is required for PS256 support');
+        }
+
+        if ($key instanceof OpenSSLCertificate) {
+            throw new DomainException('Cannot sign with an X.509 certificate. A private key is required.');
+        }
+
+        if ($key instanceof OpenSSLAsymmetricKey) {
+            if (!openssl_pkey_export($key, $pem)) {
+                throw new DomainException('OpenSSL unable to export the AsymmetricKey');
+            }
+            $key = $pem;
+        }
+
+        /** @var \phpseclib3\Crypt\RSA\PrivateKey $rsa */
+        $rsa = \phpseclib3\Crypt\PublicKeyLoader::load($key);
+
+        return $rsa->withPadding(\phpseclib3\Crypt\RSA::SIGNATURE_PSS)
+            ->withHash('sha256')
+            ->sign($message);
+    }
+
+    /**
+     * Validates a PS256 algorithm signature.
+     *
+     * @param string|OpenSSLAsymmetricKey|OpenSSLCertificate $key
+     * @param string $message
+     * @param string $signature
+     * @throws DomainException Provided key is invalid
+     */
+    private static function verifyPS256(
+        #[\SensitiveParameter] string|OpenSSLAsymmetricKey|OpenSSLCertificate $key,
+        string $message,
+        string $signature
+    ): bool {
+        if (!class_exists('\phpseclib3\Crypt\RSA')) {
+            throw new DomainException('phpseclib/phpseclib is required for PS256 support');
+        }
+
+        if ($key instanceof OpenSSLAsymmetricKey) {
+            $details = openssl_pkey_get_details($key);
+            if (!$details || !isset($details['key'])) {
+                throw new DomainException('OpenSSL unable to extract public key');
+            }
+            $key = $details['key'];
+        } elseif ($key instanceof OpenSSLCertificate) {
+            if (!openssl_x509_export($key, $pem)) {
+                throw new DomainException('OpenSSL unable to export certificate');
+            }
+            $key = $pem;
+        }
+
+        /** @var \phpseclib3\Crypt\RSA\PublicKey $rsa */
+        $rsa = \phpseclib3\Crypt\PublicKeyLoader::load($key);
+
+        return $rsa->withPadding(\phpseclib3\Crypt\RSA::SIGNATURE_PSS)
+            ->withHash('sha256')
+            ->verify($message, $signature);
     }
 }

--- a/wp-graphql-woocommerce.php
+++ b/wp-graphql-woocommerce.php
@@ -12,6 +12,7 @@
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Requires at least: 6.3
  * Requires PHP: 8.1
+ * Requires Plugins: woocommerce
  * WC requires at least: 9.0.0
  * WC tested up to: 10.4.3
  * WPGraphQL requires at least: 2.0.0

--- a/wp-graphql-woocommerce.php
+++ b/wp-graphql-woocommerce.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Plugin Name: WPGraphQL for eCommerce (WooGraphQL)
+ * Plugin Name: GraphQL for eCommerce
  * Plugin URI: https://github.com/wp-graphql/wp-graphql-woocommerce
  * Description: Adds WooCommerce functionality to WPGraphQL schema.
  * Version: 1.0.2
  * Author: kidunot89
  * Author URI: https://axistaylor.com
- * Text Domain: wp-graphql-woocommerce
+ * Text Domain: graphql-for-ecommerce
  * Domain Path: /languages
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -147,7 +147,7 @@ function init() {
 						<?php
 							printf(
 								/* translators: dependency not ready error message */
-								esc_html__( '%1$s must be active for "WPGraphQL for WooCommerce (WooGraphQL)" to work', 'wp-graphql-woocommerce' ),
+								esc_html__( '%1$s must be active for "GraphQL for eCommerce" to work', 'graphql-for-ecommerce' ),
 								esc_html( $dep )
 							);
 						?>


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Make sure you are requesting to pull request from a **topic/feature/bugfix/devops branch** (right side). Don't pull request from your master!
- [x] Have you ensured/updated that CLI tests to extend coverage to any new logic.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Addresses the issues raised in the WordPress.org Plugin Directory review.

**Trademark / naming (the gating issue).** The directory display name/slug began with the `WPGraphQL` trademark (and `WooGraphQL` is a portmanteau of the WooCommerce mark), which can imply official affiliation.
- Display name (plugin header + `README.txt` title) → **GraphQL for eCommerce**.
- Slug / text domain → **graphql-for-ecommerce** (header, all i18n string literals across the plugin, and the PHPCS `WordPress.WP.I18n` `text_domain` config).
- User-facing notices/errors that named the old plugin were updated.
- `WooGraphQL` is kept only as the project's informal nickname (repo/docs/community), not in the directory's official name/slug. Internal file names and GitHub URLs are unchanged.

**Prefix data storage.** The session transaction queue transient used the generic `woo_` word; it now uses the plugin's `graphql_woocommerce_` namespace. (Audited the rest — `define()`s, options, and namespaced classes were already distinct.)

**Plugin headers / packaging.**
- Added `Requires Plugins: woocommerce`.
- `README.txt` "Tested up to" → `7.0`.
- Ship `composer.json` in the distributed plugin (removed it, and `composer.lock`, from the `composer archive` excludes).

Items reviewed and left as-is (compliant): the only `admin_notices` is a `current_user_can`-gated dependency-missing error (not an upgrade nag, Guideline 11), and there is no unprotected request handling — the one pre-auth `$_GET` download endpoint validates an HMAC token (a nonce doesn't apply to unauthenticated download links).

Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
`composer lint` and `composer stan` are clean. Full wpunit suite green after the rename:

```
vendor/bin/codecept run wpunit
Tests: 304, Assertions: 833, Skipped: 2
```

Any other comments?
-------------------
The WordPress.org slug reservation (`graphql-for-ecommerce`) still needs to be requested by replying to the review email — that part is on the WordPress.org side and is not a code change.