### PR TITLE
fix: resolve product variation type when the node is a base Post model

### DIFF
--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -396,9 +396,22 @@ class Post_Types {
 	public static function resolve_product_variation_type( $value ) {
 		$type_registry  = \WPGraphQL::get_type_registry();
 		$possible_types = WooGraphQL::get_enabled_product_variation_types();
-		$product_type   = $value->get_type();
 
-		if ( isset( $possible_types[ $product_type ] ) ) {
+		// Normally $value is a Product_Variation model. In some setups the
+		// variation node is loaded through the generic post loader (e.g. a cart
+		// item's variation under Polylang, which doesn't manage the
+		// product_variation post-type) and arrives as a base
+		// \WPGraphQL\Model\Post with no get_type(). Fall back to resolving the
+		// variation's product type from its ID.
+		if ( is_callable( [ $value, 'get_type' ] ) ) {
+			$product_type = $value->get_type();
+		} else {
+			$variation_id = $value->databaseId ?? ( $value->ID ?? 0 );
+			$product      = $variation_id ? wc_get_product( $variation_id ) : false;
+			$product_type = $product ? $product->get_type() : null;
+		}
+
+		if ( $product_type && isset( $possible_types[ $product_type ] ) ) {
 			return $type_registry->get_type( $possible_types[ $product_type ] );
 		}
 
@@ -406,7 +419,7 @@ class Post_Types {
 			sprintf(
 			/* translators: %s: Product type */
 				__( 'The "%s" product variation type is not supported by the core WPGraphQL for WooCommerce (WooGraphQL) schema.', 'wp-graphql-woocommerce' ),
-				$value->type
+				$product_type ?? ''
 			)
 		);
 	}

--- a/includes/type/interface/class-product-with-pricing.php
+++ b/includes/type/interface/class-product-with-pricing.php
@@ -69,7 +69,6 @@ class Product_With_Pricing {
                         // @codingStandardsIgnoreLine.
                         return $source->priceRaw;
 					} else {
-						graphql_debug( $source->price );
 						// @codingStandardsIgnoreLine.
 						return $source->price;
 					}

--- a/tests/wpunit/CartQueriesTest.php
+++ b/tests/wpunit/CartQueriesTest.php
@@ -183,6 +183,62 @@ class CartQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLTe
 		$this->assertQuerySuccessful( $response, $this->getExpectedCartItemData( 'cartItem', $key ) );
 	}
 
+	// Resolves a cart item's variation when its node loads as a base
+	// \WPGraphQL\Model\Post (no get_type()) instead of a Product_Variation —
+	// the case on sites where the WC model upgrade doesn't run for the
+	// product_variation post type (e.g. Polylang). Without the fallback in
+	// Post_Types::resolve_product_variation_type() this query fatals.
+	public function testCartItemVariationResolvesWhenLoadedAsPostModel() {
+		$cart       = \WC()->cart;
+		$variations = $this->factory->product_variation->createSome();
+		$key        = $cart->add_to_cart(
+			$variations['product'],
+			1,
+			$variations['variations'][0],
+			[ 'attribute_pa_color' => 'red' ]
+		);
+
+		// Drop the WC model upgrade so the variation node arrives as a base Post.
+		remove_filter(
+			'graphql_dataloader_pre_get_model',
+			[ '\WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader', 'inject_post_loader_models' ],
+			10
+		);
+
+		$query = '
+			query ($key: ID!) {
+				cartItem(key: $key) {
+					variation {
+						node {
+							__typename
+							... on SimpleProductVariation {
+								databaseId
+							}
+						}
+					}
+				}
+			}
+		';
+
+		$response = $this->graphql( [ 'query' => $query, 'variables' => [ 'key' => $key ] ] );
+
+		// Restore the filter before asserting so its removal can't leak into other tests.
+		add_filter(
+			'graphql_dataloader_pre_get_model',
+			[ '\WPGraphQL\WooCommerce\Data\Loader\WC_CPT_Loader', 'inject_post_loader_models' ],
+			10,
+			3
+		);
+
+		$this->assertQuerySuccessful(
+			$response,
+			[
+				$this->expectedField( 'cartItem.variation.node.__typename', 'SimpleProductVariation' ),
+				$this->expectedField( 'cartItem.variation.node.databaseId', $variations['variations'][0] ),
+			]
+		);
+	}
+
 	public function testCartItemConnection() {
 		$keys = $this->factory->cart->add(
 			[

--- a/tests/wpunit/CoreInterfaceQueriesTest.php
+++ b/tests/wpunit/CoreInterfaceQueriesTest.php
@@ -72,6 +72,12 @@ class CoreInterfaceQueriesTest extends \Codeception\TestCase\WPTestCase {
 		// Create order and order note to be queried.
 		$order_id = $this->orders->create();
 		$order    = \wc_get_order( $order_id );
+
+		// Adding a customer note triggers the Customer Note email, which on newer
+		// WooCommerce logs an extra "Email sent" order note. Disable it so the
+		// comment count stays deterministic.
+		add_filter( 'woocommerce_email_enabled_customer_note', '__return_false' );
+
 		$order->add_order_note( 'testnote' );
 		$order->add_order_note( 'testcustomernote', 1, true );
 

--- a/tests/wpunit/OrderQueriesTest.php
+++ b/tests/wpunit/OrderQueriesTest.php
@@ -439,6 +439,11 @@ class OrderQueriesTest extends \Tests\WPGraphQL\WooCommerce\TestCase\WooGraphQLT
 		$order_id = $this->factory->order->createNew();
 		$order = wc_get_order( $order_id );
 
+		// Adding a customer note triggers the Customer Note email, which on newer
+		// WooCommerce logs an extra "Email sent" order note. Disable it so the
+		// order's notes are exactly the ones added below.
+		add_filter( 'woocommerce_email_enabled_customer_note', '__return_false' );
+
 		// Add some order notes
 		$note1_id = $order->add_order_note( 'Test order note 1', false );
 		$note2_id = $order->add_order_note( 'Test customer note 2', true );


### PR DESCRIPTION
## Summary

`Post_Types::resolve_product_variation_type()` assumes `$value` is a `Product_Variation` model and calls `$value->get_type()`. When a variation node is loaded through the generic post loader instead — e.g. a cart item's `variation.node` on a site running Polylang, which doesn't manage the `product_variation` post-type — `$value` arrives as a base `\WPGraphQL\Model\Post` with no `get_type()`, and the resolver fatals (surfacing downstream as "Callback returned incorrect type; expected Promise").

This adds a fallback: when `get_type()` isn't callable, resolve the variation's product type from its ID via `wc_get_product()`. The error message also reports the resolved `$product_type` instead of the now-possibly-absent `$value->type`.

Also removes a stray `graphql_debug()` left in the `ProductWithPricing` price resolver.

## Test plan

- Query a cart whose items have variations on a Polylang-enabled store (`cart.contents.nodes[].variation.node`) — previously fataled, now resolves the correct `ProductVariation` type.
- Query a variation through the normal `Product_Variation` model path — unchanged (still uses `get_type()`).
- Query a variation of an unsupported product type — still throws the "not supported" `UserError` (now with the resolved type name).